### PR TITLE
Note about CLI configuring the env it's running in.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The CLI requires the following environment variables to be set for authenticatio
 
 Note: the easiest way to get these parameters and do a Bitrise Build Cache setup is by going to [bitrise.io/build-cache](https://app.bitrise.io/build-cache), clicking `Add new connection` on the page and follow the guide there. It'll automatically generate and show the information you need for the setup.
 
+Important: the `bitrise-build-cache` CLI configures the environment it's running in. If you're running commands in Docker containers you have to run the CLI in the same container in which you run Gradle/Bazel commands in.
+
 
 ## What does the CLI do on a high level?
 


### PR DESCRIPTION
Especially important if the user is using Docker containers to run Bazel/Gradle commands in. The CLI has to run in the same environment, in the same docker container as the gradle/bazel commands.