### PR TITLE
[ACI-2869] Fix duplicate blob uploads

### DIFF
--- a/internal/xcode/upload_multi.go
+++ b/internal/xcode/upload_multi.go
@@ -69,6 +69,7 @@ func UploadCacheFilesToBuildCache(ctx context.Context, dd FileGroupInfo, kvClien
 	for _, file := range dd.Files {
 		mutex.Lock()
 		_, ok := missingBlobs[file.Hash]
+		delete(missingBlobs, file.Hash) // Remove the blob from the list of missing blobs as it's being uploaded
 		mutex.Unlock()
 		if !ok {
 			continue
@@ -82,10 +83,6 @@ func UploadCacheFilesToBuildCache(ctx context.Context, dd FileGroupInfo, kvClien
 			defer func() { <-semaphore }() // Release a slot in the semaphore
 
 			uploadCacheFileToBuildCache(ctx, kvClient, file, &mutex, &stats, logger)
-
-			mutex.Lock()
-			delete(missingBlobs, file.Hash)
-			mutex.Unlock()
 		}(file)
 	}
 


### PR DESCRIPTION
- delete is a noop if key doesn't exist
- we can delete the blob in advance as the `uploadCacheFileToBuildCache` will run eventually and that will either download the blob or it will be skipped with an error after the retries