### PR TITLE
[ACI-3782] Make plugin prefetching optional

### DIFF
--- a/cmd/enable_for_gradle.go
+++ b/cmd/enable_for_gradle.go
@@ -57,7 +57,7 @@ If the "# [start/end] generated-by-bitrise-build-cache" block is already present
 		}
 
 		if err := getPlugins(cmd.Context(), logger, os.Getenv); err != nil {
-			return fmt.Errorf("failed to fetch plugins: %w", err)
+			logger.TWarnf("failed to prefetch plugins: %w", err)
 		}
 
 		//


### PR DESCRIPTION
Some workflows work with dummy tokens and even in live pipelines we might not want to fail on a safety net step.