### PR TITLE
fix: Strip leading -- separator in react-native run

### DIFF
--- a/pkg/reactnative/runner.go
+++ b/pkg/reactnative/runner.go
@@ -55,6 +55,11 @@ func (r *Runner) Run(args []string, invocationID string, environ []string) error
 
 	fmt.Fprintf(os.Stderr, "React Native invocation ID: %s\n", invocationID)
 
+	// Strip leading "--" separator (cobra passes it through with DisableFlagParsing)
+	if len(args) > 0 && args[0] == "--" {
+		args = args[1:]
+	}
+
 	if len(args) == 0 {
 		return fmt.Errorf("missing arguments")
 	}


### PR DESCRIPTION
## Summary

- Strip leading `--` from args in `react-native run` command
- With `DisableFlagParsing: true`, cobra passes `--` through as a regular argument
- Without this fix, `react-native run -- yarn build:ios` would try to execute `"--"` as the command

Now both forms work:
```
bitrise-build-cache-cli react-native run yarn build:ios
bitrise-build-cache-cli react-native run -- yarn build:ios
```

## Test plan

- [x] Existing `TestRunner_Run` tests pass
- [ ] Manual: `bitrise-build-cache-cli react-native run -- echo hello`

🤖 Generated with [Claude Code](https://claude.com/claude-code)