### PR TITLE
fix: Export install directory to PATH after dependency install

### DIFF
--- a/internal/dependencies/cli.go
+++ b/internal/dependencies/cli.go
@@ -18,7 +18,8 @@ import (
 const (
 	cliBinaryName = "bitrise-build-cache"
 	cliModulePath = "github.com/bitrise-io/bitrise-build-cache-cli"
-	installDir    = "/usr/local/bin"
+	// InstallDir is the directory where dependency binaries (CLI, ccache) are installed.
+	InstallDir = "/usr/local/bin"
 )
 
 // CLITool returns a Tool that installs the bitrise-build-cache binary
@@ -79,7 +80,7 @@ func installFromGitHubRelease(ctx context.Context, logger log.Logger, url, binar
 	}
 	defer resp.Close()
 
-	destPath := filepath.Join(installDir, binaryName)
+	destPath := filepath.Join(InstallDir, binaryName)
 	if err := extractBinaryFromTarGz(resp, binaryName, destPath); err != nil {
 		return fmt.Errorf("extract binary: %w", err)
 	}

--- a/pkg/reactnative/activator.go
+++ b/pkg/reactnative/activator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -17,6 +18,7 @@ import (
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/internal/config/xcelerate"
 	"github.com/bitrise-io/bitrise-build-cache-cli/internal/dependencies"
+	"github.com/bitrise-io/bitrise-build-cache-cli/internal/envexport"
 	"github.com/bitrise-io/bitrise-build-cache-cli/internal/utils"
 	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/pkg/ccache"
 )
@@ -52,6 +54,8 @@ func (a *Activator) Activate(ctx context.Context) error {
 	if err := installDeps(ctx, logger, a.Params.Cpp); err != nil {
 		return fmt.Errorf("install dependencies: %w", err)
 	}
+
+	exportInstallDirToPath(logger)
 
 	if a.Params.Gradle {
 		logger.TInfof("Activating Gradle build cache...")
@@ -95,6 +99,22 @@ func (a *Activator) Activate(ctx context.Context) error {
 // ---------------------------------------------------------------------------
 // Private — sub-system activation
 // ---------------------------------------------------------------------------
+
+func exportInstallDirToPath(logger log.Logger) {
+	dir := dependencies.InstallDir
+	envs := utils.AllEnvs()
+
+	currentPath := envs["PATH"]
+	if strings.Contains(currentPath, dir) {
+		return
+	}
+
+	newPath := dir + ":" + currentPath
+	exporter := envexport.New(envs, logger)
+	exporter.Export("PATH", newPath)
+
+	logger.TInfof("Added %s to PATH", dir)
+}
 
 func installDeps(ctx context.Context, logger log.Logger, doCpp bool) error {
 	var tools []dependencies.Tool


### PR DESCRIPTION
## Summary

- After `installDeps` downloads CLI and ccache binaries to `/usr/local/bin`, export that directory to PATH
- Uses `envexport.Export` which sets `os.Setenv`, `envman add`, and writes to `GITHUB_ENV`
- Skips if the directory is already on PATH
- Export `dependencies.InstallDir` constant so `pkg/reactnative` can reference it

This ensures subsequent workflow steps (e.g. `react-native run`) can find `bitrise-build-cache` and `ccache` without full paths.

## Test plan

- [ ] `make check` passes
- [ ] E2E: verify `which bitrise-build-cache` succeeds in a step after activation

🤖 Generated with [Claude Code](https://claude.com/claude-code)