### PR TITLE
fix: Don't fail when CLI is the main binary with (devel) version

### DIFF
--- a/internal/dependencies/cli.go
+++ b/internal/dependencies/cli.go
@@ -49,8 +49,10 @@ func cliVersion() (string, error) {
 		return "", fmt.Errorf("failed to read build info")
 	}
 
-	// When the CLI is the main module (built directly), use Main.Version.
-	if info.Main.Path == cliModulePath && info.Main.Version != "(devel)" && info.Main.Version != "" {
+	if info.Main.Path == cliModulePath {
+		// We ARE the CLI binary. Use the embedded version if available,
+		// otherwise return "" — the caller will see IsInstalled() == true
+		// and skip installation.
 		return strings.TrimPrefix(info.Main.Version, "v"), nil
 	}
 


### PR DESCRIPTION
## Summary

When the CLI binary runs `activate react-native`, `cliVersion()` fails because `debug.ReadBuildInfo().Main.Version` is `(devel)` for binaries built by GoReleaser (which uses `go build`, not `go install module@version`).

Since `Main.Path` matches `cliModulePath`, we know we ARE the CLI binary — there's nothing to install. Return the version as-is and let `EnsureAll` skip via `IsInstalled()` (the binary is already on PATH).

**Error before fix:**
```
Error: activate react-native: install dependencies: determine CLI tool: determine CLI version: module github.com/bitrise-io/bitrise-build-cache-cli/v2 not found in build info (main=github.com/bitrise-io/bitrise-build-cache-cli/v2, version=(devel))
```

## Test plan

- [x] `make check` passes
- [ ] CI E2E workflows pass
- [ ] RN step E2E: `activate react-native` succeeds with CLI binary from GitHub releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)