### PR TITLE
feat(ccache): parse stats from ccache -v -v -s text output

### DIFF
--- a/docs/ccache.md
+++ b/docs/ccache.md
@@ -167,4 +167,6 @@ func NewCcacheInvocation(invocationID, parentInvocationID string, invocationDate
 func (c *Client) PutCcacheInvocation(inv CcacheInvocation) error
 ```
 
+`ParseCcacheStats` parses the text output of `ccache -v -v -s`. It is line-by-line: indent depth (2 spaces = 1 level) builds a section path like `"Cacheable calls / Hits / Direct"`, which is dispatched to the matching `CcacheStats` field. `CacheHitRate` and `TotalCalls` are derived after parsing. Always returns `nil` error.
+
 `CcacheStats.HasActivity()` returns true when `DirectCacheHit + PreprocessedCacheHit + CacheMiss > 0`. Used by `StorageHelper.CollectAndSendStats` to gate analytics.

--- a/internal/ccache/analytics/invocations.go
+++ b/internal/ccache/analytics/invocations.go
@@ -1,18 +1,74 @@
 package analytics
 
 import (
-	"encoding/json"
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 )
 
-// ParseCcacheStats parses the JSON output of `ccache --print-stats --format=json`.
-// CacheHitRate is computed from direct and preprocessed hits over total attempts.
+// ParseCcacheStats parses the text output of `ccache -v -v -s`.
+// CacheHitRate and TotalCalls are derived fields computed after parsing.
+// Always returns nil — unrecognised lines are silently ignored.
 func ParseCcacheStats(data []byte) (CcacheStats, error) {
 	var stats CcacheStats
-	if err := json.Unmarshal(data, &stats); err != nil {
-		return CcacheStats{}, fmt.Errorf("parse ccache stats JSON: %w", err)
+	lines := strings.Split(string(data), "\n")
+
+	// sectionParents[level] = section name at that indent level (2 spaces = 1 level).
+	const maxDepth = 6
+	sectionParents := make([]string, maxDepth)
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		indent := countLeadingSpaces(line)
+		level := indent / 2
+		if level >= maxDepth {
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+		key, rest, ok := strings.Cut(trimmed, ":")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		rest = strings.TrimSpace(rest)
+
+		// Clear deeper levels (stale from a previous branch at this depth).
+		for i := range maxDepth - level - 1 {
+			sectionParents[level+1+i] = ""
+		}
+		sectionParents[level] = key
+
+		// Build full path from ancestor sections + current key.
+		parts := make([]string, 0, level+1)
+		for i := range level {
+			if sectionParents[i] != "" {
+				parts = append(parts, sectionParents[i])
+			}
+		}
+		parts = append(parts, key)
+		fullKey := strings.Join(parts, " / ")
+
+		nums := extractNumbers(rest)
+		first := 0.0
+		second := 0.0
+		if len(nums) > 0 {
+			first = nums[0]
+		}
+		if len(nums) > 1 {
+			second = nums[1]
+		}
+
+		applyStatField(&stats, fullKey, first, second)
 	}
+
+	// Derived fields.
+	stats.TotalCalls = stats.CacheableCalls + stats.UncacheableCalls
 
 	total := stats.DirectCacheHit + stats.PreprocessedCacheHit + stats.CacheMiss
 	if total > 0 {
@@ -43,4 +99,147 @@ func (c *Client) PutCcacheInvocation(inv CcacheInvocation) error {
 	}
 
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Private
+// ---------------------------------------------------------------------------
+
+//nolint:gochecknoglobals
+var numberRe = regexp.MustCompile(`\d+(?:\.\d+)?`)
+
+func countLeadingSpaces(s string) int {
+	n := 0
+	for _, ch := range s {
+		if ch != ' ' {
+			break
+		}
+		n++
+	}
+
+	return n
+}
+
+func extractNumbers(s string) []float64 {
+	matches := numberRe.FindAllString(s, -1)
+	result := make([]float64, 0, len(matches))
+	for _, m := range matches {
+		f, err := strconv.ParseFloat(m, 64)
+		if err == nil {
+			result = append(result, f)
+		}
+	}
+
+	return result
+}
+
+// applyStatField maps a parsed (section / key) path to the corresponding CcacheStats field.
+// Unrecognised paths are silently ignored — the field stays at zero.
+func applyStatField(s *CcacheStats, key string, first, second float64) { //nolint:gocognit,gocyclo
+	switch key {
+	// ── Cacheable calls ──────────────────────────────────────────────────────
+	case "Cacheable calls":
+		s.CacheableCalls = int(first)
+	case "Cacheable calls / Hits / Direct":
+		s.DirectCacheHit = int(first)
+	case "Cacheable calls / Hits / Preprocessed":
+		s.PreprocessedCacheHit = int(first)
+	case "Cacheable calls / Misses":
+		s.CacheMiss = int(first)
+
+	// ── Uncacheable calls ────────────────────────────────────────────────────
+	case "Uncacheable calls":
+		s.UncacheableCalls = int(first)
+	case "Uncacheable calls / Called for linking":
+		s.CalledForLink = int(first)
+	case "Uncacheable calls / Called for preprocessing":
+		s.CalledForPreprocessing = int(first)
+	case "Uncacheable calls / Autoconf compile/link":
+		s.AutoconfTest = int(first)
+	case "Uncacheable calls / Bad compiler arguments":
+		s.BadCompilerArguments = int(first)
+	case "Uncacheable calls / Ccache disabled":
+		s.Disabled = int(first)
+	case "Uncacheable calls / Compilation failed":
+		s.CompileFailed = int(first)
+	case "Uncacheable calls / Compiler output file missing":
+		s.CompilerProducedNoOutput = int(first)
+	case "Uncacheable calls / Compiler produced empty output":
+		s.CompilerProducedEmptyOutput = int(first)
+	case "Uncacheable calls / Compiler produced stdout":
+		s.CompilerProducedStdout = int(first)
+	case "Uncacheable calls / Could not use modules":
+		s.CouldNotUseModules = int(first)
+	case "Uncacheable calls / Could not use precompiled header":
+		s.CouldNotUsePrecompiledHeader = int(first)
+	case "Uncacheable calls / Forced recache":
+		s.Recache = int(first)
+	case "Uncacheable calls / Multiple source files":
+		s.MultipleSourceFiles = int(first)
+	case "Uncacheable calls / No input file":
+		s.NoInputFile = int(first)
+	case "Uncacheable calls / Output to stdout":
+		s.OutputToStdout = int(first)
+	case "Uncacheable calls / Preprocessing failed":
+		s.PreprocessorError = int(first)
+	case "Uncacheable calls / Unsupported code directive":
+		s.UnsupportedCodeDirective = int(first)
+	case "Uncacheable calls / Unsupported compiler option":
+		s.UnsupportedCompilerOption = int(first)
+	case "Uncacheable calls / Unsupported environment variable":
+		s.UnsupportedEnvironmentVariable = int(first)
+	case "Uncacheable calls / Unsupported source encoding":
+		s.UnsupportedSourceEncoding = int(first)
+	case "Uncacheable calls / Unsupported source language":
+		s.UnsupportedSourceLanguage = int(first)
+
+	// ── Errors ───────────────────────────────────────────────────────────────
+	case "Errors / Compiler check failed":
+		s.CompilerCheckFailed = int(first)
+	case "Errors / Could not find compiler":
+		s.CouldNotFindCompiler = int(first)
+	case "Errors / Could not read or parse input file":
+		s.BadInputFile = int(first)
+	case "Errors / Could not write to output file":
+		s.BadOutputFile = int(first)
+	case "Errors / Error hashing extra file":
+		s.ErrorHashingExtraFile = int(first)
+	case "Errors / Input file modified during compilation":
+		s.ModifiedInputFile = int(first)
+	case "Errors / Internal error":
+		s.InternalError = int(first)
+	case "Errors / Missing cache file":
+		s.MissingCacheFile = int(first)
+
+	// ── Local storage ────────────────────────────────────────────────────────
+	case "Local storage / Cache size (GiB)":
+		s.CacheSizeGiB = first
+		s.MaxCacheSizeGiB = second
+	case "Local storage / Files":
+		s.FilesInCache = int(first)
+	case "Local storage / Cleanups":
+		s.CleanupsPerformed = int(first)
+	case "Local storage / Hits":
+		s.LocalStorageHit = int(first)
+	case "Local storage / Misses":
+		s.LocalStorageMiss = int(first)
+	case "Local storage / Reads":
+		s.LocalStorageReads = int(first)
+	case "Local storage / Writes":
+		s.LocalStorageWrite = int(first)
+
+	// ── Remote storage ───────────────────────────────────────────────────────
+	case "Remote storage / Hits":
+		s.RemoteStorageHit = int(first)
+	case "Remote storage / Misses":
+		s.RemoteStorageMiss = int(first)
+	case "Remote storage / Reads":
+		s.RemoteStorageReads = int(first)
+	case "Remote storage / Writes":
+		s.RemoteStorageWrite = int(first)
+	case "Remote storage / Errors":
+		s.RemoteStorageError = int(first)
+	case "Remote storage / Timeouts":
+		s.RemoteStorageTimeout = int(first)
+	}
 }

--- a/internal/ccache/analytics/invocations.go
+++ b/internal/ccache/analytics/invocations.go
@@ -8,55 +8,40 @@ import (
 	"time"
 )
 
+//nolint:gochecknoglobals
+var (
+	configLineRe = regexp.MustCompile(`^\(([^)]+)\)\s+(\S+)\s*=\s*(.*)$`)
+)
+
 // ParseCcacheStats parses the text output of `ccache -v -v -s`.
 // CacheHitRate and TotalCalls are derived fields computed after parsing.
 // Always returns nil — unrecognised lines are silently ignored.
 func ParseCcacheStats(data []byte) (CcacheStats, error) {
 	var stats CcacheStats
-	lines := strings.Split(string(data), "\n")
+	var path []string
 
-	// sectionParents[level] = section name at that indent level (2 spaces = 1 level).
-	const maxDepth = 6
-	sectionParents := make([]string, maxDepth)
-
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" {
+	for _, line := range strings.Split(string(data), "\n") {
+		m := statsLineRe.FindStringSubmatch(line)
+		if m == nil {
 			continue
 		}
 
-		indent := countLeadingSpaces(line)
-		level := indent / 2
-		if level >= maxDepth {
-			continue
+		level := len(m[1]) / 2
+		key := m[2]
+		rest := m[3]
+
+		if level > len(path) {
+			continue // skip malformed indent jumps
 		}
 
-		trimmed := strings.TrimSpace(line)
-		key, rest, ok := strings.Cut(trimmed, ":")
-		if !ok {
-			continue
-		}
-		key = strings.TrimSpace(key)
-		rest = strings.TrimSpace(rest)
-
-		// Clear deeper levels (stale from a previous branch at this depth).
-		for i := range maxDepth - level - 1 {
-			sectionParents[level+1+i] = ""
-		}
-		sectionParents[level] = key
-
-		// Build full path from ancestor sections + current key.
-		parts := make([]string, 0, level+1)
-		for i := range level {
-			if sectionParents[i] != "" {
-				parts = append(parts, sectionParents[i])
-			}
-		}
-		parts = append(parts, key)
-		fullKey := strings.Join(parts, " / ")
+		// Truncate to parent depth, then append current key.
+		// e.g. at level 2 under ["Cacheable calls", "Hits"] → append "Direct"
+		// At level 1 after ["Cacheable calls", "Hits", "Direct"] → truncate to ["Cacheable calls"], append "Misses"
+		path = append(path[:level], key)
+		fullKey := strings.Join(path, " / ")
 
 		nums := extractNumbers(rest)
-		first := 0.0
-		second := 0.0
+		var first, second float64
 		if len(nums) > 0 {
 			first = nums[0]
 		}
@@ -69,13 +54,45 @@ func ParseCcacheStats(data []byte) (CcacheStats, error) {
 
 	// Derived fields.
 	stats.TotalCalls = stats.CacheableCalls + stats.UncacheableCalls
+	stats.CacheHit = stats.DirectCacheHit + stats.PreprocessedCacheHit
 
-	total := stats.DirectCacheHit + stats.PreprocessedCacheHit + stats.CacheMiss
-	if total > 0 {
-		stats.CacheHitRate = float64(stats.DirectCacheHit+stats.PreprocessedCacheHit) / float64(total)
+	if stats.CacheHit > 0 {
+		stats.DirectCacheHitPercentage = float64(stats.DirectCacheHit) / float64(stats.CacheHit)
+		stats.PreprocessedCacheHitPercentage = float64(stats.PreprocessedCacheHit) / float64(stats.CacheHit)
+	}
+
+	if stats.CacheableCalls > 0 {
+		cacheable := float64(stats.CacheableCalls)
+		stats.CacheHitRate = float64(stats.CacheHit) / cacheable
+		stats.CacheMissRate = float64(stats.CacheMiss) / cacheable
+		stats.RemoteStorageHitPercentage = float64(stats.RemoteStorageHit) / cacheable
+		stats.RemoteStorageMissPercentage = float64(stats.RemoteStorageMiss) / cacheable
+		stats.RemoteStorageErrorPercentage = float64(stats.RemoteStorageError) / cacheable
+		stats.RemoteStorageTimeoutPercentage = float64(stats.RemoteStorageTimeout) / cacheable
 	}
 
 	return stats, nil
+}
+
+// ParseCcacheConfig parses the text output of `ccache --show-config` into a slice of CcacheConfigEntry.
+// Each line has the form: (source) key = value
+// Blank and malformed lines are silently ignored.
+func ParseCcacheConfig(data []byte) []CcacheConfigEntry {
+	lines := strings.Split(string(data), "\n")
+	entries := make([]CcacheConfigEntry, 0, len(lines))
+	for _, line := range lines {
+		m := configLineRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		entries = append(entries, CcacheConfigEntry{
+			Source: strings.TrimSpace(m[1]),
+			Key:    strings.TrimSpace(m[2]),
+			Value:  strings.TrimSpace(m[3]),
+		})
+	}
+
+	return entries
 }
 
 // NewCcacheInvocation assembles a CcacheInvocation from a ccache stats snapshot and transfer byte counts.
@@ -106,19 +123,12 @@ func (c *Client) PutCcacheInvocation(inv CcacheInvocation) error {
 // ---------------------------------------------------------------------------
 
 //nolint:gochecknoglobals
-var numberRe = regexp.MustCompile(`\d+(?:\.\d+)?`)
-
-func countLeadingSpaces(s string) int {
-	n := 0
-	for _, ch := range s {
-		if ch != ' ' {
-			break
-		}
-		n++
-	}
-
-	return n
-}
+var (
+	// statsLineRe captures: (indent)(key): (rest)
+	// Non-greedy key matches up to the first colon.
+	statsLineRe = regexp.MustCompile(`^( *)(.*?): *(.*)$`)
+	numberRe    = regexp.MustCompile(`\d+(?:\.\d+)?`)
+)
 
 func extractNumbers(s string) []float64 {
 	matches := numberRe.FindAllString(s, -1)

--- a/internal/ccache/analytics/invocations_test.go
+++ b/internal/ccache/analytics/invocations_test.go
@@ -66,6 +66,64 @@ Remote storage:
   Timeouts:                                  0
 `
 
+const sampleConfigOutput = `(default) absolute_paths_in_stderr = false
+(default) base_dir =
+(default) cache_dir = /Users/user/Library/Caches/ccache
+(default) compiler_check = mtime
+(/Users/user/Library/Preferences/ccache/ccache.conf) hash_dir = false
+(/Users/user/Library/Preferences/ccache/ccache.conf) max_size = 10.0 GiB
+(/Users/user/Library/Preferences/ccache/ccache.conf) remote_only = true
+(/Users/user/Library/Preferences/ccache/ccache.conf) remote_storage = crsh:/var/folders/tmp/ccache-ipc.sock
+`
+
+func Test_ParseCcacheConfig(t *testing.T) {
+	t.Run("parses default source entries", func(t *testing.T) {
+		entries := ParseCcacheConfig([]byte(sampleConfigOutput))
+
+		assert.Contains(t, entries, CcacheConfigEntry{Key: "absolute_paths_in_stderr", Value: "false", Source: "default"})
+		assert.Contains(t, entries, CcacheConfigEntry{Key: "compiler_check", Value: "mtime", Source: "default"})
+	})
+
+	t.Run("parses file source entries", func(t *testing.T) {
+		entries := ParseCcacheConfig([]byte(sampleConfigOutput))
+
+		assert.Contains(t, entries, CcacheConfigEntry{
+			Key:    "max_size",
+			Value:  "10.0 GiB",
+			Source: "/Users/user/Library/Preferences/ccache/ccache.conf",
+		})
+		assert.Contains(t, entries, CcacheConfigEntry{
+			Key:    "remote_storage",
+			Value:  "crsh:/var/folders/tmp/ccache-ipc.sock",
+			Source: "/Users/user/Library/Preferences/ccache/ccache.conf",
+		})
+	})
+
+	t.Run("empty value trimmed to empty string", func(t *testing.T) {
+		entries := ParseCcacheConfig([]byte(sampleConfigOutput))
+
+		assert.Contains(t, entries, CcacheConfigEntry{Key: "base_dir", Value: "", Source: "default"})
+	})
+
+	t.Run("returns all entries", func(t *testing.T) {
+		entries := ParseCcacheConfig([]byte(sampleConfigOutput))
+
+		assert.Len(t, entries, 8)
+	})
+
+	t.Run("malformed lines silently ignored", func(t *testing.T) {
+		entries := ParseCcacheConfig([]byte("not a valid line\nalso bad\n"))
+
+		assert.Empty(t, entries)
+	})
+
+	t.Run("empty input returns empty slice", func(t *testing.T) {
+		entries := ParseCcacheConfig([]byte(""))
+
+		assert.Empty(t, entries)
+	})
+}
+
 func Test_ParseCcacheStats(t *testing.T) {
 	t.Run("parses cacheable call counts", func(t *testing.T) {
 		stats, err := ParseCcacheStats([]byte(sampleStatsOutput))

--- a/internal/ccache/analytics/invocations_test.go
+++ b/internal/ccache/analytics/invocations_test.go
@@ -6,74 +6,161 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
+// sampleStatsOutput is representative `ccache -v -v -s` text output.
+const sampleStatsOutput = `Cache directory:                          /home/user/.cache/ccache
+Config file:                              /home/user/.config/ccache/ccache.conf
+Stats updated:                            Mon Apr 14 10:00:00 2025
+Stats zeroed:                             Mon Apr 14 09:00:00 2025
+Cacheable calls:                            18
+  Hits:                                      5 / 18  (27.78 %)
+    Direct:                                  3
+    Preprocessed:                            2
+  Misses:                                   13
+Uncacheable calls:                           2
+  Autoconf compile/link:                     0
+  Bad compiler arguments:                    0
+  Called for linking:                        2
+  Called for preprocessing:                  0
+  Ccache disabled:                           0
+  Compilation failed:                        0
+  Compiler output file missing:              0
+  Compiler produced empty output:            0
+  Compiler produced stdout:                  0
+  Could not use modules:                     0
+  Could not use precompiled header:          0
+  Forced recache:                            0
+  Multiple source files:                     0
+  No input file:                             0
+  Output to stdout:                          0
+  Preprocessing failed:                      0
+  Unsupported code directive:                0
+  Unsupported compiler option:               0
+  Unsupported environment variable:          0
+  Unsupported source encoding:               0
+  Unsupported source language:               0
+Errors:                                      0
+  Compiler check failed:                     0
+  Could not find compiler:                   0
+  Could not read or parse input file:        0
+  Could not write to output file:            0
+  Error hashing extra file:                  0
+  Input file modified during compilation:    0
+  Internal error:                            0
+  Missing cache file:                        0
+Local storage:
+  Cache size (GiB):                        0.4 / 10.0 ( 3.85%)
+  Files:                                  4520
+  Cleanups:                                  0
+  Hits:                                      5
+  Misses:                                   13
+  Reads:                                    18
+  Writes:                                   13
+Remote storage:
+  Hits:                                      3
+  Misses:                                   10
+  Reads:                                    13
+  Writes:                                    3
+  Errors:                                    1
+  Timeouts:                                  0
+`
+
 func Test_ParseCcacheStats(t *testing.T) {
-	t.Run("parses flat JSON from ccache output", func(t *testing.T) {
-		data := []byte(`{
-			"direct_cache_hit": 3,
-			"preprocessed_cache_hit": 1,
-			"cache_miss": 2
-		}`)
+	t.Run("parses cacheable call counts", func(t *testing.T) {
+		stats, err := ParseCcacheStats([]byte(sampleStatsOutput))
 
-		stats, err := ParseCcacheStats(data)
-
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 3, stats.DirectCacheHit)
-		assert.Equal(t, 1, stats.PreprocessedCacheHit)
-		assert.Equal(t, 2, stats.CacheMiss)
+		assert.Equal(t, 2, stats.PreprocessedCacheHit)
+		assert.Equal(t, 13, stats.CacheMiss)
+		assert.Equal(t, 18, stats.CacheableCalls)
 	})
 
-	t.Run("computes cache hit rate from hits and misses", func(t *testing.T) {
-		// 3 direct + 1 preprocessed = 4 hits out of 6 total → 0.666...
-		data := []byte(`{"direct_cache_hit": 3, "preprocessed_cache_hit": 1, "cache_miss": 2}`)
+	t.Run("parses uncacheable call counts", func(t *testing.T) {
+		stats, err := ParseCcacheStats([]byte(sampleStatsOutput))
 
-		stats, err := ParseCcacheStats(data)
-
-		require.NoError(t, err)
-		assert.InDelta(t, 4.0/6.0, stats.CacheHitRate, 1e-9)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, stats.UncacheableCalls)
+		assert.Equal(t, 2, stats.CalledForLink)
+		assert.Equal(t, 0, stats.CalledForPreprocessing)
 	})
 
-	t.Run("hit rate is zero when there are no attempts", func(t *testing.T) {
-		data := []byte(`{"direct_cache_hit": 0, "preprocessed_cache_hit": 0, "cache_miss": 0}`)
+	t.Run("derives total calls", func(t *testing.T) {
+		stats, err := ParseCcacheStats([]byte(sampleStatsOutput))
 
-		stats, err := ParseCcacheStats(data)
+		assert.NoError(t, err)
+		assert.Equal(t, 20, stats.TotalCalls) // 18 cacheable + 2 uncacheable
+	})
 
-		require.NoError(t, err)
+	t.Run("computes cache hit rate", func(t *testing.T) {
+		// 3 direct + 2 preprocessed = 5 hits out of 18 total cacheable calls → 5/18
+		stats, err := ParseCcacheStats([]byte(sampleStatsOutput))
+
+		assert.NoError(t, err)
+		assert.InDelta(t, 5.0/18.0, stats.CacheHitRate, 1e-9)
+	})
+
+	t.Run("parses local storage fields", func(t *testing.T) {
+		stats, err := ParseCcacheStats([]byte(sampleStatsOutput))
+
+		assert.NoError(t, err)
+		assert.InDelta(t, 0.4, stats.CacheSizeGiB, 1e-9)
+		assert.InDelta(t, 10.0, stats.MaxCacheSizeGiB, 1e-9)
+		assert.Equal(t, 4520, stats.FilesInCache)
+		assert.Equal(t, 0, stats.CleanupsPerformed)
+		assert.Equal(t, 5, stats.LocalStorageHit)
+		assert.Equal(t, 13, stats.LocalStorageMiss)
+		assert.Equal(t, 18, stats.LocalStorageReads)
+		assert.Equal(t, 13, stats.LocalStorageWrite)
+	})
+
+	t.Run("parses remote storage fields", func(t *testing.T) {
+		stats, err := ParseCcacheStats([]byte(sampleStatsOutput))
+
+		assert.NoError(t, err)
+		assert.Equal(t, 3, stats.RemoteStorageHit)
+		assert.Equal(t, 10, stats.RemoteStorageMiss)
+		assert.Equal(t, 13, stats.RemoteStorageReads)
+		assert.Equal(t, 3, stats.RemoteStorageWrite)
+		assert.Equal(t, 1, stats.RemoteStorageError)
+		assert.Equal(t, 0, stats.RemoteStorageTimeout)
+	})
+
+	t.Run("hit rate is zero when no cacheable calls", func(t *testing.T) {
+		stats, err := ParseCcacheStats([]byte(`Cacheable calls:                             0
+  Hits:                                      0
+    Direct:                                  0
+    Preprocessed:                            0
+  Misses:                                    0
+`))
+
+		assert.NoError(t, err)
 		assert.Equal(t, 0.0, stats.CacheHitRate)
 	})
 
-	t.Run("hit rate is 1.0 when all attempts are hits", func(t *testing.T) {
-		data := []byte(`{"direct_cache_hit": 5, "preprocessed_cache_hit": 0, "cache_miss": 0}`)
+	t.Run("hit rate is 1.0 when all calls are direct hits", func(t *testing.T) {
+		stats, err := ParseCcacheStats([]byte(`Cacheable calls:                             5
+  Hits:                                      5 / 5  (100.00 %)
+    Direct:                                  5
+    Preprocessed:                            0
+  Misses:                                    0
+`))
 
-		stats, err := ParseCcacheStats(data)
-
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 1.0, stats.CacheHitRate)
 	})
 
-	t.Run("hit rate is 0.0 when all attempts are misses", func(t *testing.T) {
-		data := []byte(`{"direct_cache_hit": 0, "preprocessed_cache_hit": 0, "cache_miss": 10}`)
+	t.Run("returns no error on empty input", func(t *testing.T) {
+		stats, err := ParseCcacheStats([]byte(""))
 
-		stats, err := ParseCcacheStats(data)
-
-		require.NoError(t, err)
-		assert.Equal(t, 0.0, stats.CacheHitRate)
+		assert.NoError(t, err)
+		assert.Equal(t, CcacheStats{}, stats)
 	})
 
-	t.Run("unknown fields are ignored", func(t *testing.T) {
-		data := []byte(`{"direct_cache_hit": 1, "cache_miss": 1, "future_field": 99}`)
+	t.Run("unknown lines are silently ignored", func(t *testing.T) {
+		_, err := ParseCcacheStats([]byte("Future field: 99\n"))
 
-		stats, err := ParseCcacheStats(data)
-
-		require.NoError(t, err)
-		assert.Equal(t, 1, stats.DirectCacheHit)
-	})
-
-	t.Run("returns error on malformed JSON", func(t *testing.T) {
-		_, err := ParseCcacheStats([]byte(`not json`))
-
-		assert.Error(t, err)
+		assert.NoError(t, err)
 	})
 }

--- a/internal/ccache/analytics/types.go
+++ b/internal/ccache/analytics/types.go
@@ -2,40 +2,35 @@ package analytics
 
 import "time"
 
-// CcacheStats holds all statistics parsed from `ccache --print-stats --format=json`.
-// JSON tags match ccache's output keys directly.
+// CcacheStats holds statistics parsed from `ccache -v -v -s`.
 // CacheHitRate is the only computed field (not emitted by ccache).
 type CcacheStats struct {
 	// Cache outcomes
-	DirectCacheHit        int     `json:"direct_cache_hit"`
-	PreprocessedCacheHit  int     `json:"preprocessed_cache_hit"`
-	CacheMiss             int     `json:"cache_miss"`
-	CacheHitRate          float64 `json:"cache_hit_rate"`
-	DirectCacheMiss       int     `json:"direct_cache_miss"`
-	PreprocessedCacheMiss int     `json:"preprocessed_cache_miss"`
-
-	// Storage
-	FilesInCache         int   `json:"files_in_cache"`
-	CacheSizeKibibyte    int64 `json:"cache_size_kibibyte"`
-	MaxCacheSizeKibibyte int64 `json:"max_cache_size_kibibyte"`
-	MaxFilesInCache      int   `json:"max_files_in_cache"`
-	CleanupsPerformed    int   `json:"cleanups_performed"`
-
-	// Remote storage
-	RemoteStorageHit      int `json:"remote_storage_hit"`
-	RemoteStorageMiss     int `json:"remote_storage_miss"`
-	RemoteStorageError    int `json:"remote_storage_error"`
-	RemoteStorageTimeout  int `json:"remote_storage_timeout"`
-	RemoteStorageWrite    int `json:"remote_storage_write"`
-	RemoteStorageReadHit  int `json:"remote_storage_read_hit"`
-	RemoteStorageReadMiss int `json:"remote_storage_read_miss"`
+	DirectCacheHit       int     `json:"direct_cache_hit"`
+	PreprocessedCacheHit int     `json:"preprocessed_cache_hit"`
+	CacheMiss            int     `json:"cache_miss"`
+	CacheHitRate         float64 `json:"cache_hit_rate"`
+	CacheableCalls       int     `json:"cacheable_calls"`
+	TotalCalls           int     `json:"total_calls"`
+	UncacheableCalls     int     `json:"uncacheable_calls"`
 
 	// Local storage
-	LocalStorageHit      int `json:"local_storage_hit"`
-	LocalStorageMiss     int `json:"local_storage_miss"`
-	LocalStorageReadHit  int `json:"local_storage_read_hit"`
-	LocalStorageReadMiss int `json:"local_storage_read_miss"`
-	LocalStorageWrite    int `json:"local_storage_write"`
+	FilesInCache      int     `json:"files_in_cache"`
+	CacheSizeGiB      float64 `json:"cache_size_gib"`
+	MaxCacheSizeGiB   float64 `json:"max_cache_size_gib"`
+	CleanupsPerformed int     `json:"cleanups_performed"`
+	LocalStorageHit   int     `json:"local_storage_hit"`
+	LocalStorageMiss  int     `json:"local_storage_miss"`
+	LocalStorageReads int     `json:"local_storage_reads"`
+	LocalStorageWrite int     `json:"local_storage_write"`
+
+	// Remote storage
+	RemoteStorageHit     int `json:"remote_storage_hit"`
+	RemoteStorageMiss    int `json:"remote_storage_miss"`
+	RemoteStorageError   int `json:"remote_storage_error"`
+	RemoteStorageTimeout int `json:"remote_storage_timeout"`
+	RemoteStorageWrite   int `json:"remote_storage_write"`
+	RemoteStorageReads   int `json:"remote_storage_reads"`
 
 	// Compiler errors and unsupported inputs
 	CompileFailed                int `json:"compile_failed"`
@@ -47,6 +42,9 @@ type CcacheStats struct {
 	CouldNotFindCompiler         int `json:"could_not_find_compiler"`
 	CouldNotUseModules           int `json:"could_not_use_modules"`
 	CouldNotUsePrecompiledHeader int `json:"could_not_use_precompiled_header"`
+	BadInputFile                 int `json:"bad_input_file"`
+	BadOutputFile                int `json:"bad_output_file"`
+	ModifiedInputFile            int `json:"modified_input_file"`
 
 	// Skipped / non-compilations
 	CalledForLink                  int `json:"called_for_link"`
@@ -60,19 +58,14 @@ type CcacheStats struct {
 	NoInputFile                    int `json:"no_input_file"`
 	OutputToStdout                 int `json:"output_to_stdout"`
 	BadCompilerArguments           int `json:"bad_compiler_arguments"`
-	BadInputFile                   int `json:"bad_input_file"`
-	BadOutputFile                  int `json:"bad_output_file"`
 	AutoconfTest                   int `json:"autoconf_test"`
-	ModifiedInputFile              int `json:"modified_input_file"`
+	Recache                        int `json:"recache"`
+	Disabled                       int `json:"disabled"`
 
-	// Misc
-	Recache               int   `json:"recache"`
-	Disabled              int   `json:"disabled"`
-	InternalError         int   `json:"internal_error"`
-	ErrorHashingExtraFile int   `json:"error_hashing_extra_file"`
-	MissingCacheFile      int   `json:"missing_cache_file"`
-	StatsUpdatedTimestamp int64 `json:"stats_updated_timestamp"`
-	StatsZeroedTimestamp  int64 `json:"stats_zeroed_timestamp"`
+	// Misc errors
+	InternalError         int `json:"internal_error"`
+	ErrorHashingExtraFile int `json:"error_hashing_extra_file"`
+	MissingCacheFile      int `json:"missing_cache_file"`
 }
 
 // HasActivity returns true if ccache processed any compilations (hits or misses).

--- a/internal/ccache/analytics/types.go
+++ b/internal/ccache/analytics/types.go
@@ -5,14 +5,32 @@ import "time"
 // CcacheStats holds statistics parsed from `ccache -v -v -s`.
 // CacheHitRate is the only computed field (not emitted by ccache).
 type CcacheStats struct {
-	// Cache outcomes
-	DirectCacheHit       int     `json:"direct_cache_hit"`
-	PreprocessedCacheHit int     `json:"preprocessed_cache_hit"`
-	CacheMiss            int     `json:"cache_miss"`
-	CacheHitRate         float64 `json:"cache_hit_rate"`
-	CacheableCalls       int     `json:"cacheable_calls"`
-	TotalCalls           int     `json:"total_calls"`
-	UncacheableCalls     int     `json:"uncacheable_calls"`
+	// Diagnostic main                              // UI usage
+	TotalCalls       int `json:"total_calls"`       // `Total calls`
+	CacheableCalls   int `json:"cacheable_calls"`   // `Cacheable calls` - Used as the denominator in `Cache hits & misses` -> `Cache hits`, `Cache misses` and `Remote storage` -> `Hits`, `Misses`, `Errors`, `Timeouts`
+	UncacheableCalls int `json:"uncacheable_calls"` // `UncacheableCalls`
+
+	// Cache hits & misses
+	CacheHit                       int     `json:"cache_hit"`                         // `Cache hits & misses` -> `Cache hits` - Used as the denominator in `Cache hits & misses` -> `Direct hits` and `Preprocessed hits`
+	CacheHitRate                   float64 `json:"cache_hit_rate"`                    // `Cache hits & misses` -> `Cache hits` percentage
+	DirectCacheHit                 int     `json:"direct_cache_hit"`                  // `Cache hits & misses` -> `Direct hits`
+	DirectCacheHitPercentage       float64 `json:"direct_cache_hit_percentage"`       // `Cache hits & misses` -> `Direct hits` percentage
+	PreprocessedCacheHit           int     `json:"preprocessed_cache_hit"`            // `Cache hits & misses` -> `Preprocessed hits`
+	PreprocessedCacheHitPercentage float64 `json:"preprocessed_cache_hit_percentage"` // `Cache hits & misses` -> `Preprocessed hits` percentage
+	CacheMiss                      int     `json:"cache_miss"`                        // `Cache hits & misses` -> `Cache misses`
+	CacheMissRate                  float64 `json:"cache_miss_rate"`                   // `Cache hits & misses` -> `Cache misses` percentage
+
+	// Remote storage
+	RemoteStorageHit               int     `json:"remote_storage_hit"`                // `Remote storage` -> `Hits`
+	RemoteStorageHitPercentage     float64 `json:"remote_storage_hit_percentage"`     // `Remote storage` -> `Hits` percentage
+	RemoteStorageMiss              int     `json:"remote_storage_miss"`               // `Remote storage` -> `Misses`
+	RemoteStorageMissPercentage    float64 `json:"remote_storage_miss_percentage"`    // `Remote storage` -> `Misses` percentage
+	RemoteStorageError             int     `json:"remote_storage_error"`              // `Remote storage` -> `Errors`
+	RemoteStorageErrorPercentage   float64 `json:"remote_storage_error_percentage"`   // `Remote storage` -> `Errors` percentage
+	RemoteStorageTimeout           int     `json:"remote_storage_timeout"`            // `Remote storage` -> `Timeouts`
+	RemoteStorageTimeoutPercentage float64 `json:"remote_storage_timeout_percentage"` // `Remote storage` -> `Timeouts` percentage
+	RemoteStorageWrite             int     `json:"remote_storage_write"`
+	RemoteStorageReads             int     `json:"remote_storage_reads"`
 
 	// Local storage
 	FilesInCache      int     `json:"files_in_cache"`
@@ -23,14 +41,6 @@ type CcacheStats struct {
 	LocalStorageMiss  int     `json:"local_storage_miss"`
 	LocalStorageReads int     `json:"local_storage_reads"`
 	LocalStorageWrite int     `json:"local_storage_write"`
-
-	// Remote storage
-	RemoteStorageHit     int `json:"remote_storage_hit"`
-	RemoteStorageMiss    int `json:"remote_storage_miss"`
-	RemoteStorageError   int `json:"remote_storage_error"`
-	RemoteStorageTimeout int `json:"remote_storage_timeout"`
-	RemoteStorageWrite   int `json:"remote_storage_write"`
-	RemoteStorageReads   int `json:"remote_storage_reads"`
 
 	// Compiler errors and unsupported inputs
 	CompileFailed                int `json:"compile_failed"`
@@ -66,11 +76,21 @@ type CcacheStats struct {
 	InternalError         int `json:"internal_error"`
 	ErrorHashingExtraFile int `json:"error_hashing_extra_file"`
 	MissingCacheFile      int `json:"missing_cache_file"`
+
+	Config []CcacheConfigEntry `json:"config"`
 }
 
 // HasActivity returns true if ccache processed any compilations (hits or misses).
 func (s CcacheStats) HasActivity() bool {
-	return s.DirectCacheHit+s.PreprocessedCacheHit+s.CacheMiss > 0
+	return s.CacheableCalls+s.UncacheableCalls > 0
+}
+
+// CcacheConfigEntry is a single configuration key-value pair from `ccache --show-config`,
+// annotated with its source (e.g. "default" or the path of the config file that set it).
+type CcacheConfigEntry struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Source string `json:"source"`
 }
 
 // CcacheInvocation is the analytics payload for ccache statistics captured during a run.

--- a/pkg/ccache/storage_helper.go
+++ b/pkg/ccache/storage_helper.go
@@ -225,6 +225,12 @@ func (h *StorageHelper) CollectAndSendStats(ctx context.Context, invocationIDOve
 		stats = s
 	}
 
+	if c, err := h.parseCcacheConfig(ctx); err != nil {
+		h.logger.TWarnf("Failed to parse ccache config: %v", err)
+	} else {
+		stats.Config = c
+	}
+
 	h.sessionMu.RLock()
 	dl, ul := h.downloaded, h.uploaded
 	invocationID := h.invocationID
@@ -415,6 +421,20 @@ func (h *StorageHelper) parseCcacheStats(ctx context.Context) (ccacheanalytics.C
 	}
 
 	return stats, nil
+}
+
+func (h *StorageHelper) parseCcacheConfig(ctx context.Context) ([]ccacheanalytics.CcacheConfigEntry, error) {
+	ccachePath, err := exec.LookPath("ccache")
+	if err != nil {
+		return nil, fmt.Errorf("ccache binary not found: %w", err)
+	}
+
+	configData, err := exec.CommandContext(ctx, ccachePath, "--show-config").Output() //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("run ccache --show-config: %w", err)
+	}
+
+	return ccacheanalytics.ParseCcacheConfig(configData), nil
 }
 
 func (h *StorageHelper) zeroCcacheStats(ctx context.Context, logger log.Logger) {

--- a/pkg/ccache/storage_helper.go
+++ b/pkg/ccache/storage_helper.go
@@ -404,9 +404,9 @@ func (h *StorageHelper) parseCcacheStats(ctx context.Context) (ccacheanalytics.C
 		return ccacheanalytics.CcacheStats{}, fmt.Errorf("ccache binary not found: %w", err)
 	}
 
-	statsData, err := exec.CommandContext(ctx, ccachePath, "--print-stats", "--format=json").Output() //nolint:gosec
+	statsData, err := exec.CommandContext(ctx, ccachePath, "-v", "-v", "-s").Output() //nolint:gosec
 	if err != nil {
-		return ccacheanalytics.CcacheStats{}, fmt.Errorf("run ccache --print-stats: %w", err)
+		return ccacheanalytics.CcacheStats{}, fmt.Errorf("run ccache -v -v -s: %w", err)
 	}
 
 	stats, err := ccacheanalytics.ParseCcacheStats(statsData)


### PR DESCRIPTION
## Summary

- Replaces `ccache --print-stats --format=json` with `ccache -v -v -s` text output parsing
- Parser walks lines by indent depth (2 spaces = 1 level), building a section path (e.g. `"Cacheable calls / Hits / Direct"`) dispatched to the matching `CcacheStats` field
- Cache size now reported in GiB directly from the output; `CacheHitRate` and `TotalCalls` are derived post-parse
- Drops fields absent from the text output (`DirectCacheMiss`, `PreprocessedCacheMiss`, `CacheSizeKibibyte`, `StatsUpdatedTimestamp`, etc.) — backend accepts sparse payloads

## Test plan

- [ ] `make check` passes (lint + unit tests)
- [ ] `internal/ccache/analytics` tests cover: cacheable/uncacheable counts, local/remote storage fields, hit rate computation, GiB cache size parsing, empty input, unknown lines ignored