### PR TITLE
fix: Suppress verbose build logs in duckduck e2e workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -935,7 +935,7 @@ workflows:
         inputs:
         - content: |-
             set -exo pipefail
-            (./gradlew debug --info --stacktrace 2>&1) | tee "$BITRISE_DEPLOY_DIR/logs.txt"
+            ./gradlew debug --info --stacktrace > "$BITRISE_DEPLOY_DIR/logs.txt" 2>&1
     - script:
         title: Assert downloads from MavenCentral mirror
         inputs:


### PR DESCRIPTION
## Summary
- Replace `tee` with file-only redirect in the `e2e-mavencentral-mirror-duckduck` workflow's "Build and capture logs" step
- The `--info` flag on the Gradle build produces very large output that overwhelmed our services when printed to stdout via `tee`
- Logs are still captured to `$BITRISE_DEPLOY_DIR/logs.txt` for the assertion steps that follow

## Test plan
- [ ] Verify `e2e-mavencentral-mirror-duckduck` workflow still passes (assertions read from the log file, not stdout)
- [ ] Confirm build log output is no longer printed to the Bitrise step log

🤖 Generated with [Claude Code](https://claude.com/claude-code)