### PR TITLE
chore(ACI-4859): work in delayed RN/ccache CLI review feedback

### DIFF
--- a/cmd/common/register_invocation.go
+++ b/cmd/common/register_invocation.go
@@ -39,7 +39,8 @@ var registerInvocationCmd = &cobra.Command{
 func init() {
 	registerInvocationCmd.Flags().StringVar(&registerInvocationID, "invocation-id", "", "Invocation ID to register (required)")
 	_ = registerInvocationCmd.MarkFlagRequired("invocation-id")
-	registerInvocationCmd.Flags().StringVar(&registerInvocationBuildTool, "build-tool", "multiplatform", "Build tool label for the invocation")
+	registerInvocationCmd.Flags().StringVar(&registerInvocationBuildTool, "build-tool", "", "Build tool label for the invocation (required, e.g. gradle, ccache, reactnative)")
+	_ = registerInvocationCmd.MarkFlagRequired("build-tool")
 
 	RootCmd.AddCommand(registerInvocationCmd)
 }

--- a/cmd/xcode/restoreXcodeDerivedDataFiles.go
+++ b/cmd/xcode/restoreXcodeDerivedDataFiles.go
@@ -82,7 +82,7 @@ var restoreXcodeDerivedDataFilesCmd = &cobra.Command{
 
 			op.DurationMilliseconds = int(time.Since(op.StartedAt).Milliseconds())
 
-			xaClient, clientErr := xa.NewClient(consts.AnalyticsServiceEndpoint, authConfig.AuthToken, logger)
+			xaClient, clientErr := xa.NewClient(consts.XcodeAnalyticsServiceEndpoint, authConfig.AuthToken, logger)
 			if clientErr != nil {
 				return fmt.Errorf("failed to create Xcode Analytics Service client: %w", clientErr)
 			}

--- a/cmd/xcode/saveXcodeDerivedDataFiles.go
+++ b/cmd/xcode/saveXcodeDerivedDataFiles.go
@@ -82,7 +82,7 @@ var saveXcodeDerivedDataFilesCmd = &cobra.Command{
 
 			op.DurationMilliseconds = int(time.Since(op.StartedAt).Milliseconds())
 
-			xaClient, clientErr := xa.NewClient(consts.AnalyticsServiceEndpoint, authConfig.AuthToken, logger)
+			xaClient, clientErr := xa.NewClient(consts.XcodeAnalyticsServiceEndpoint, authConfig.AuthToken, logger)
 			if clientErr != nil {
 				return fmt.Errorf("failed to create Xcode Analytics Service client: %w", clientErr)
 			}

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -390,7 +390,7 @@ func (c *XcodebuildRunner) resolveInvocationAPI() (invocationSaver, error) {
 		return c.invocationAPI, nil
 	}
 
-	client, err := analytics.NewClient(consts.AnalyticsServiceEndpoint, c.Config.AuthConfig.TokenInGradleFormat(), c.Logger)
+	client, err := analytics.NewClient(consts.XcodeAnalyticsServiceEndpoint, c.Config.AuthConfig.TokenInGradleFormat(), c.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("create analytics client: %w", err)
 	}

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,103 @@
+# Analytics: Invocation Registration
+
+## Overview
+
+A build run that uses Bitrise Build Cache is reported to the analytics backend as an **invocation**. When several tools cooperate inside a single build, each is its own invocation and the relationships between them are reported as **invocation relations** (parent → child).
+
+Two CLI subcommands act as the public, build-tool-agnostic registration surface — used both by other parts of the CLI (xcode, ccache, react-native wrappers) and by external callers (the bitrise-io/gradle-plugins repo). They live on the root command, not under `ccache` or any tool-specific namespace.
+
+| Command | Flags | What it does |
+|---------|-------|-------------|
+| `register-invocation` | `--invocation-id` (req), `--build-tool` (req — e.g. `gradle`, `ccache`, `reactnative`, `xcode`) | Registers a single invocation with the analytics backend. |
+| `register-child-invocation` | `--parent-id` (req), `--child-id` (req), `--build-tool` (default `ccache`) | Registers a parent → child relation between two invocation IDs. |
+
+Both commands read auth credentials from the multiplatform analytics config (`~/.bitrise/analytics/multiplatform/config.json`), written by `activate react-native`, `activate c++`, or `activate xcode`. This is the single canonical on-disk source of auth credentials — neither the ccache config nor the xcelerate config persists auth.
+
+The backend endpoint used by both commands is `consts.MultiplatformAnalyticsServiceEndpoint` (`https://multiplatform-analytics.services.bitrise.io`).
+
+---
+
+## Conceptual model
+
+```
+Wrapper (react-native run, gradle build, xcodebuild wrapper, ...)
+   │
+   │  register-invocation  →  parent invocation
+   │
+   ├── register-child-invocation  →  parent → gradle child relation
+   ├── register-child-invocation  →  parent → ccache child relation
+   └── register-child-invocation  →  parent → xcode child relation
+```
+
+`BITRISE_INVOCATION_ID` is the contract carrying the parent ID across processes. A wrapper sets it; child tools read it. If empty, the tool is the top-level invocation and registers itself only.
+
+---
+
+## Use cases
+
+### CLI-internal callers
+
+**`react-native run` (cmd/reactnative + pkg/reactnative).** The wrapper invocation is created inside `react-native run`: it reads `BITRISE_INVOCATION_ID` from the environment, falls back to a fresh UUID if empty, and exports the resolved value back into the child environment. After the build completes, `postRunDeps.run` calls `multiplatform.Client.PutInvocation` directly (Go API, not the CLI subcommand) and then `helper.CollectAndSendStats` registers the parent → ccache child relation. See `docs/reactnative.md` for the full data flow.
+
+**Xcode wrapper (`cmd/xcode/xcodebuild.go`).** When `BITRISE_INVOCATION_ID` is set, `XcodebuildRunner.saveInvocationAndRelation` calls `sendRelation(parentID)` which `PUT`s an `InvocationRelation` to the multiplatform service marking the xcode invocation as a child of the wrapper.
+
+**ccache storage helper (`pkg/ccache/storage_helper.go`).** `StorageHelper.CollectAndSendStats` queries the running storage helper for the (parent, child) pair via IPC `0xB2`, and — when there was activity — calls `InvocationRegistry.RegisterRelation` (which is the same code path the `register-child-invocation` CLI subcommand uses) to register the parent → ccache relation.
+
+### External callers (bitrise-io/gradle-plugins)
+
+**Orchestrator mode — `BitriseCCachePlugin.close()`** (`cache/src/main/kotlin/io/bitrise/gradle/cache/BitriseCCachePlugin.kt`). When Gradle itself is the orchestrator (no wrapper above it), the plugin registers both the parent and the gradle child at the end of the build:
+
+```kotlin
+runCli("register-invocation",       "--invocation-id=$parentId", "--build-tool=gradle")
+runCli("register-child-invocation", "--parent-id=$parentId", "--child-id=$gradleId", "--build-tool=gradle")
+```
+
+`parentId` and `gradleId` here come from build-time parameters. The `register-invocation` call is the gradle plugin's only path for creating a top-level invocation — when a wrapper is present (next case), this call is skipped.
+
+**Wrapper-present mode — `BitriseBuildCacheService.close()`** (`cache/src/main/kotlin/io/bitrise/gradle/cache/BitriseBuildCacheService.kt`). When Gradle runs underneath a wrapper (e.g. `react-native run`, a Bitrise step), the wrapper has already created the parent invocation; the plugin only registers the parent → gradle relation by reading the parent ID from `BITRISE_INVOCATION_ID`:
+
+```kotlin
+val parentId = System.getenv("BITRISE_INVOCATION_ID")?.takeIf { it.isNotBlank() }
+parentId?.let {
+    ProcessBuilder(
+        "bitrise-build-cache",
+        "register-child-invocation",
+        "--parent-id=$it",
+        "--child-id=$invocationId",
+        "--build-tool=gradle",
+    )...
+}
+```
+
+If `BITRISE_INVOCATION_ID` is unset the plugin does nothing — there is no parent to relate to. The Gradle invocation is still reported via the gradle-analytics service through its own channel; only the relation is gated on the env var.
+
+### Generic external callers
+
+Any tool that is invoked under `BITRISE_INVOCATION_ID` and wants to show up as a child in the analytics UI can shell out:
+
+```bash
+bitrise-build-cache register-child-invocation \
+  --parent-id="$BITRISE_INVOCATION_ID" \
+  --child-id="$MY_INVOCATION_ID" \
+  --build-tool=mytool
+```
+
+Prerequisite: `~/.bitrise/analytics/multiplatform/config.json` must exist (auth source). It is created by any of the `activate` subcommands (`activate react-native`, `activate c++`, `activate xcode`).
+
+---
+
+## Programmatic API (Go)
+
+The same backend calls are exposed as a Go API at `pkg/common`:
+
+```go
+type InvocationRegistry struct { ... }
+
+func NewInvocationRegistry(params InvocationRegistryParams) (*InvocationRegistry, error)
+func (inv *InvocationRegistry) RegisterMultiplatformInvocation(ctx context.Context, params RegisterInvocationParams) error
+func (inv *InvocationRegistry) RegisterRelation(ctx context.Context, params RegisterRelationParams) error
+```
+
+`NewInvocationRegistry` reads the multiplatform analytics config from disk (auth + debug-logging flag). Pass `Envs` to override the metadata source.
+
+This is the path used by every CLI-internal caller. The two cobra commands are thin wrappers around it; external callers can either invoke the CLI or import `pkg/common` directly.

--- a/docs/ccache.md
+++ b/docs/ccache.md
@@ -27,14 +27,7 @@ ccache integration enables C++ build caching via a local IPC proxy server. The p
 
 ## Top-level analytics commands
 
-These commands are build-tool-agnostic and registered on the root command (not under `ccache`). Used by Kotlin/Gradle code to register invocation relationships from outside the CLI wrapper.
-
-| Command | Flags | What it does |
-|---------|-------|-------------|
-| `register-invocation` | `--invocation-id` (req), `--build-tool` (default: "multiplatform") | Registers invocation with analytics backend |
-| `register-child-invocation` | `--parent-id` (req), `--child-id` (req), `--build-tool` (default: "ccache") | Registers parent→child relation in analytics |
-
-Both commands read auth credentials from the multiplatform analytics config (`~/.bitrise/analytics/multiplatform/config.json`), written by `activate react-native` or `activate c++`.
+`register-invocation` and `register-child-invocation` are build-tool-agnostic commands shared with other tools (xcode, react-native, the gradle plugin). They are documented in `docs/analytics.md` along with the CLI-internal and gradle-plugin use cases.
 
 ---
 
@@ -169,4 +162,4 @@ func (c *Client) PutCcacheInvocation(inv CcacheInvocation) error
 
 `ParseCcacheStats` parses the text output of `ccache -v -v -s`. It is line-by-line: indent depth (2 spaces = 1 level) builds a section path like `"Cacheable calls / Hits / Direct"`, which is dispatched to the matching `CcacheStats` field. `CacheHitRate` and `TotalCalls` are derived after parsing. Always returns `nil` error.
 
-`CcacheStats.HasActivity()` returns true when `DirectCacheHit + PreprocessedCacheHit + CacheMiss > 0`. Used by `StorageHelper.CollectAndSendStats` to gate analytics.
+`CcacheStats.HasActivity()` returns true when `CacheableCalls + UncacheableCalls > 0`. Used by `StorageHelper.CollectAndSendStats` to gate analytics.

--- a/docs/reactnative.md
+++ b/docs/reactnative.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-React Native support wraps build/run commands with pre/post hooks that activate multi-platform build caching (Gradle, Xcode, C++/ccache) and report analytics. The C++ side is tightly coupled to the ccache storage helper — see `docs/ccache.md` for the ccache internals.
+React Native support wraps build/run commands with pre/post hooks that activate multi-platform build caching (Gradle, Xcode, C++/ccache) and report analytics. The C++ side is tightly coupled to the ccache storage helper — see `docs/ccache.md` for the ccache internals. Invocation registration (parent → child relations) is documented in `docs/analytics.md`.
 
 **Layers:**
 - `cmd/reactnative/` — cobra commands
@@ -70,14 +70,15 @@ func (r *Runner) Run(ctx context.Context, args []string, wrapperInvocationID str
 ```
 
 **Run flow:**
-1. Strip leading `"--"` from args (cobra `DisableFlagParsing` artifact)
-2. If ccache socket available:
+1. Resolve `wrapperInvocationID`: caller (the `react-native run` cobra command) reads `BITRISE_INVOCATION_ID` from the environment and passes it in. If it is empty, `Run` generates a fresh UUID. Either way the resolved value is the React Native invocation ID for this run — there is no pre-existing parent ID; the wrapper invocation is created here.
+2. Strip leading `"--"` from args (cobra `DisableFlagParsing` artifact)
+3. If ccache socket available:
    - Start storage helper if not already listening; await ready
    - Health check
    - `socket.SetInvocationID(wrapperInvocationID, <new UUID>)` — links RN invocation to a fresh ccache session; resets byte counters on the server
    - `ccache -z` — zero local ccache stats
-3. Execute command with `BITRISE_INVOCATION_ID=wrapperInvocationID` injected into environ
-4. Post-run: `postRunDeps.run(ctx, wrapperInvocationID, args, duration, execErr)`
+4. Execute the command with `BITRISE_INVOCATION_ID=wrapperInvocationID` exported into the child environment, so any subprocess (e.g. xcodebuild, ccache) treats this RN run as its parent.
+5. Post-run: `postRunDeps.run(ctx, wrapperInvocationID, args, duration, execErr)`
 
 ---
 
@@ -101,12 +102,12 @@ Implemented by `internal/ccache.Socket` in production. This interface talks to t
 
 **postRunDeps** handles all analytics after command execution. Created by `newPostRunDeps(logger, osProxy, decoderFactory)` which reads the multiplatform analytics config and creates a `ccacheanalytics.Client`.
 
-The analytics client receives its own `clientLogger` created with `log.WithDebugLog(config.DebugLogging)`. This is separate from the runner's logger — `HTTP PUT:` debug lines appear when `activate react-native --debug` was used, without relying on cobra's `IsDebugLogMode` (which cobra never sets for `DisableFlagParsing` commands).
+The analytics client uses the runner's logger directly. The runner constructs its default logger with `WithDebugLog(config.DebugLogging)` (read from the multiplatform config), so `HTTP PUT:` debug lines appear when `activate react-native --debug` was used. Cobra's `IsDebugLogMode` is bypassed because cobra never sets it for `DisableFlagParsing` commands.
 
 **postRunDeps.run call sequence:**
 
 ```
-wrapperInvocationID = injected BITRISE_INVOCATION_ID (RN parent)
+wrapperInvocationID = the RN invocation ID created in `react-native run` (and exported as BITRISE_INVOCATION_ID for children)
 
 1. sendInvocation — reports React Native invocation (duration, command, success/error)
    → if this fails, returns early (ccache stats skipped)
@@ -129,16 +130,21 @@ helper.CollectAndSendStats(ctx, "", "")
 ## Full Analytics Data Flow
 
 ```
-Bitrise build
-└── BITRISE_INVOCATION_ID = <parent>
+Bitrise build / shell
     │
     └── react-native run [args]
+        │   wrapperInvocationID is created here:
+        │     • if BITRISE_INVOCATION_ID is set in the environment, use it
+        │     • otherwise generate a fresh UUID
+        │   The resolved ID is exported to child processes as BITRISE_INVOCATION_ID
+        │   so xcodebuild, ccache, etc. treat this RN run as their parent.
         │
-        ├── [pre-run] socket.SetInvocationID(parent, <new UUID>)
+        ├── [pre-run] socket.SetInvocationID(wrapperInvocationID, <new UUID>)
         │       → IPC 0xB1 → server resets session byte counters, assigns ccache child ID
         │       → ccache -z (zeros local ccache stats)
         │
-        ├── [exec] command runs, C++ files compiled via ccache
+        ├── [exec] command runs with BITRISE_INVOCATION_ID=wrapperInvocationID
+        │       → C++ files compiled via ccache
         │       → ccache GET/PUT requests proxy through storage helper
         │       → session byte counters accumulate
         │

--- a/internal/config/ccache/config.go
+++ b/internal/config/ccache/config.go
@@ -163,7 +163,10 @@ func ReadConfig(osProxy utils.OsProxy, decoderFactory utils.DecoderFactory) (Con
 
 	// Auth credentials live in the multiplatform analytics config. Populate the
 	// in-memory AuthConfig from there so callers can keep using config.AuthConfig.
-	if mpCfg, mpErr := multiplatformconfig.ReadConfig(osProxy, decoderFactory); mpErr == nil {
+	// Guard against an empty/decoded-but-unauthenticated multiplatform config —
+	// matches the xcelerate fallback so we don't silently wipe credentials when
+	// the file exists but carries no token.
+	if mpCfg, mpErr := multiplatformconfig.ReadConfig(osProxy, decoderFactory); mpErr == nil && mpCfg.AuthConfig.AuthToken != "" {
 		config.AuthConfig = mpCfg.AuthConfig
 	}
 

--- a/internal/config/ccache/config.go
+++ b/internal/config/ccache/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
@@ -38,15 +39,19 @@ type Params struct {
 }
 
 type Config struct {
-	LogFile            string                 `json:"logFile,omitempty"`
-	ErrLogFile         string                 `json:"errLogFile,omitempty"`
-	IPCEndpoint        string                 `json:"ipcEndpoint,omitempty"`
-	IdleTimeout        time.Duration          `json:"idleTimeout,omitempty"`
-	PushEnabled        bool                   `json:"pushEnabled"`
-	Enabled            bool                   `json:"enabled"`
-	DebugLogging       bool                   `json:"debugLogging,omitempty"`
-	BuildCacheEndpoint string                 `json:"buildCacheEndpoint,omitempty"`
-	AuthConfig         common.CacheAuthConfig `json:"authConfig,omitempty"`
+	LogFile            string        `json:"logFile,omitempty"`
+	ErrLogFile         string        `json:"errLogFile,omitempty"`
+	IPCEndpoint        string        `json:"ipcEndpoint,omitempty"`
+	IdleTimeout        time.Duration `json:"idleTimeout,omitempty"`
+	PushEnabled        bool          `json:"pushEnabled"`
+	Enabled            bool          `json:"enabled"`
+	DebugLogging       bool          `json:"debugLogging,omitempty"`
+	BuildCacheEndpoint string        `json:"buildCacheEndpoint,omitempty"`
+
+	// AuthConfig is populated at runtime from the multiplatform analytics
+	// config (single canonical source for auth credentials on disk). Not
+	// persisted in the ccache config JSON.
+	AuthConfig common.CacheAuthConfig `json:"-"`
 }
 
 func DirPath(osProxy utils.OsProxy) string {
@@ -154,6 +159,12 @@ func ReadConfig(osProxy utils.OsProxy, decoderFactory utils.DecoderFactory) (Con
 	var config Config
 	if err := dec.Decode(&config); err != nil {
 		return Config{}, fmt.Errorf(ErrFmtDecodeConfigFile, configFilePath, err)
+	}
+
+	// Auth credentials live in the multiplatform analytics config. Populate the
+	// in-memory AuthConfig from there so callers can keep using config.AuthConfig.
+	if mpCfg, mpErr := multiplatformconfig.ReadConfig(osProxy, decoderFactory); mpErr == nil {
+		config.AuthConfig = mpCfg.AuthConfig
 	}
 
 	return config, nil

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/shirou/gopsutil/v4/process"
 
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/envexport"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
@@ -81,6 +82,17 @@ func Activate(
 
 	if err := config.Save(logger, osProxy, encoderFactory); err != nil {
 		return fmt.Errorf(ErrFmtCreateXcodeConfig, err)
+	}
+
+	// Auth credentials are persisted only in the multiplatform analytics config
+	// (single source of truth on disk). The xcelerate config carries auth in-memory
+	// at runtime via ReadConfig, but never to JSON.
+	mpCfg := multiplatformconfig.Config{
+		AuthConfig:   config.AuthConfig,
+		DebugLogging: config.DebugLogging,
+	}
+	if err := mpCfg.Save(osProxy, encoderFactory); err != nil {
+		return fmt.Errorf("failed to save multiplatform analytics config: %w", err)
 	}
 
 	if err := copyCLIToXcelerateBinDir(ctx, osProxy, logger); err != nil {

--- a/internal/config/xcelerate/config.go
+++ b/internal/config/xcelerate/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
@@ -42,23 +43,28 @@ type Params struct {
 // the BITRISE_BUILD_CACHE_BENCHMARK_PHASE env var and written to
 // ~/.local/state/xcelerate/benchmark/benchmark-phase.json during activation.
 type Config struct {
-	ProxyVersion           string                 `json:"proxyVersion"`
-	ProxySocketPath        string                 `json:"proxySocketPath"`
-	CLIVersion             string                 `json:"cliVersion"`
-	WrapperVersion         string                 `json:"wrapperVersion"`
-	OriginalXcodebuildPath string                 `json:"originalXcodebuildPath"`
-	OriginalXcrunPath      string                 `json:"originalXcrunPath"`
-	BuildCacheEnabled      bool                   `json:"buildCacheEnabled"`
-	BuildCacheSkipFlags    bool                   `json:"buildCacheSkipFlags"`
-	BuildCacheEndpoint     string                 `json:"buildCacheEndpoint"`
-	PushEnabled            bool                   `json:"pushEnabled"`
-	DebugLogging           bool                   `json:"debugLogging,omitempty"`
-	Silent                 bool                   `json:"silent,omitempty"`
-	XcodebuildTimestamps   bool                   `json:"xcodebuildTimestamps,omitempty"`
-	AuthConfig             common.CacheAuthConfig `json:"authConfig,omitempty"`
-	ExternalAppID          string                 `json:"externalAppId,omitempty"`
-	ExternalBuildID        string                 `json:"externalBuildId,omitempty"`
-	ExternalWorkflowName   string                 `json:"externalWorkflowName,omitempty"`
+	ProxyVersion           string `json:"proxyVersion"`
+	ProxySocketPath        string `json:"proxySocketPath"`
+	CLIVersion             string `json:"cliVersion"`
+	WrapperVersion         string `json:"wrapperVersion"`
+	OriginalXcodebuildPath string `json:"originalXcodebuildPath"`
+	OriginalXcrunPath      string `json:"originalXcrunPath"`
+	BuildCacheEnabled      bool   `json:"buildCacheEnabled"`
+	BuildCacheSkipFlags    bool   `json:"buildCacheSkipFlags"`
+	BuildCacheEndpoint     string `json:"buildCacheEndpoint"`
+	PushEnabled            bool   `json:"pushEnabled"`
+	DebugLogging           bool   `json:"debugLogging,omitempty"`
+	Silent                 bool   `json:"silent,omitempty"`
+	XcodebuildTimestamps   bool   `json:"xcodebuildTimestamps,omitempty"`
+	// AuthConfig is sourced from the multiplatform analytics config at runtime
+	// (single canonical source for auth credentials on disk). The JSON tag is
+	// preserved for read-side backwards compatibility with older xcelerate
+	// configs that still have `authConfig` on disk from a previous CLI version;
+	// Save zeroes it before writing and `omitzero` keeps it out of the file.
+	AuthConfig           common.CacheAuthConfig `json:"authConfig,omitzero"`
+	ExternalAppID        string                 `json:"externalAppId,omitempty"`
+	ExternalBuildID      string                 `json:"externalBuildId,omitempty"`
+	ExternalWorkflowName string                 `json:"externalWorkflowName,omitempty"`
 }
 
 func ReadConfig(osProxy utils.OsProxy, decoderFactory utils.DecoderFactory) (Config, error) {
@@ -74,6 +80,14 @@ func ReadConfig(osProxy utils.OsProxy, decoderFactory utils.DecoderFactory) (Con
 	var config Config
 	if err := dec.Decode(&config); err != nil {
 		return Config{}, fmt.Errorf("decode xcelerate config file (%s): %w", configFilePath, err)
+	}
+
+	// Auth credentials live in the multiplatform analytics config. Prefer that
+	// source so callers can keep using config.AuthConfig; fall back to whatever
+	// the legacy xcelerate config (decoded above) carried, for users upgrading
+	// from a CLI version that still persisted auth in the xcelerate config.
+	if mpCfg, mpErr := multiplatformconfig.ReadConfig(osProxy, decoderFactory); mpErr == nil && mpCfg.AuthConfig.AuthToken != "" {
+		config.AuthConfig = mpCfg.AuthConfig
 	}
 
 	return config, nil
@@ -244,6 +258,12 @@ func (config Config) Save(logger log.Logger, os utils.OsProxy, encoderFactory ut
 		return fmt.Errorf(ErrFmtCreateConfigFile, err)
 	}
 	defer f.Close()
+
+	// Auth credentials live in the multiplatform analytics config now. Strip
+	// them before writing the xcelerate config so we don't persist a second
+	// copy on disk. Older configs that still carry `authConfig` on disk are
+	// tolerated on read (see ReadConfig).
+	config.AuthConfig = common.CacheAuthConfig{}
 
 	enc := encoderFactory.Encoder(f)
 	enc.SetIndent("", "  ")

--- a/internal/config/xcelerate/config_test.go
+++ b/internal/config/xcelerate/config_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	commonmocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/mocks"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils/mocks"
@@ -175,6 +176,75 @@ func TestConfig_Save(t *testing.T) {
 
 		// then
 		assert.EqualError(t, err, fmt.Errorf(xcelerate.ErrFmtEncodeConfigFile, encodingError).Error())
+	})
+}
+
+// TestConfig_AuthBackwardsCompat covers the upgrade path from CLI versions
+// that persisted authConfig in the xcelerate config file. New CLI must:
+//   - Save: not write authConfig into the xcelerate config (it lives in the
+//     multiplatform config now).
+//   - ReadConfig: still pick up authConfig from a legacy xcelerate config file
+//     when no multiplatform config exists yet.
+func TestConfig_AuthBackwardsCompat(t *testing.T) {
+	t.Run("Save strips authConfig from disk", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		osProxy := utils.DefaultOsProxy{}
+
+		cfg := xcelerate.Config{
+			ProxyVersion:           "1.0.0",
+			OriginalXcodebuildPath: "/usr/bin/xcodebuild",
+			AuthConfig:             common.CacheAuthConfig{AuthToken: "secret", WorkspaceID: "ws"},
+		}
+
+		require.NoError(t, cfg.Save(mockLogger, osProxy, utils.DefaultEncoderFactory{}))
+
+		raw, err := os.ReadFile(xcelerate.PathFor(osProxy, "config.json"))
+		require.NoError(t, err)
+		assert.NotContains(t, string(raw), "authConfig", "auth must not be persisted in xcelerate config")
+		assert.NotContains(t, string(raw), "secret")
+	})
+
+	t.Run("ReadConfig falls back to legacy authConfig when multiplatform missing", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		osProxy := utils.DefaultOsProxy{}
+
+		dir := xcelerate.DirPath(osProxy)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		legacy := `{"proxyVersion":"1.0.0","authConfig":{"AuthToken":"legacy-token","WorkspaceID":"legacy-ws"}}`
+		require.NoError(t, os.WriteFile(xcelerate.PathFor(osProxy, "config.json"), []byte(legacy), 0o600))
+
+		cfg, err := xcelerate.ReadConfig(osProxy, utils.DefaultDecoderFactory{})
+		require.NoError(t, err)
+		assert.Equal(t, "legacy-token", cfg.AuthConfig.AuthToken)
+		assert.Equal(t, "legacy-ws", cfg.AuthConfig.WorkspaceID)
+	})
+
+	t.Run("ReadConfig prefers multiplatform config when present", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		osProxy := utils.DefaultOsProxy{}
+
+		// Legacy xcelerate config carries old auth.
+		dir := xcelerate.DirPath(osProxy)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		legacy := `{"proxyVersion":"1.0.0","authConfig":{"AuthToken":"legacy-token","WorkspaceID":"legacy-ws"}}`
+		require.NoError(t, os.WriteFile(xcelerate.PathFor(osProxy, "config.json"), []byte(legacy), 0o600))
+
+		// New multiplatform config carries current auth.
+		mp := multiplatformconfig.Config{
+			AuthConfig: common.CacheAuthConfig{AuthToken: "current-token", WorkspaceID: "current-ws"},
+		}
+		require.NoError(t, mp.Save(osProxy, utils.DefaultEncoderFactory{}))
+
+		cfg, err := xcelerate.ReadConfig(osProxy, utils.DefaultDecoderFactory{})
+		require.NoError(t, err)
+		assert.Equal(t, "current-token", cfg.AuthConfig.AuthToken)
+		assert.Equal(t, "current-ws", cfg.AuthConfig.WorkspaceID)
 	})
 }
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -10,7 +10,7 @@ const (
 	// More info: https://github.com/bitrise-io/build-prebooting-deployments/blob/production/preboot-reconciler/startup_script_extension_macos_bitvirt.sh#L72
 	BitriseAccelerate = "grpcs://bitrise-accelerate.services.bitrise.io"
 
-	AnalyticsServiceEndpoint              = "https://xcode-analytics.services.bitrise.io"
+	XcodeAnalyticsServiceEndpoint         = "https://xcode-analytics.services.bitrise.io"
 	MultiplatformAnalyticsServiceEndpoint = "https://multiplatform-analytics.services.bitrise.io"
 
 	BitriseWebsiteBaseURL = "https://app.bitrise.io"

--- a/pkg/ccache/activator.go
+++ b/pkg/ccache/activator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
@@ -109,6 +110,17 @@ func (a *Activator) Activate(ctx context.Context) error {
 
 	if err := config.Save(a.logger, a.osProxy, a.encoderFactory); err != nil {
 		return fmt.Errorf("failed to save ccache config: %w", err)
+	}
+
+	// Auth credentials are persisted only in the multiplatform analytics config
+	// (single source of truth on disk). The ccache config carries auth in-memory
+	// at runtime via ReadConfig, but never to JSON.
+	mpCfg := multiplatformconfig.Config{
+		AuthConfig:   config.AuthConfig,
+		DebugLogging: a.debugLogging,
+	}
+	if err := mpCfg.Save(a.osProxy, a.encoderFactory); err != nil {
+		return fmt.Errorf("failed to save multiplatform analytics config: %w", err)
 	}
 
 	baseDir := a.baseDirOverride

--- a/pkg/ccache/storage_helper.go
+++ b/pkg/ccache/storage_helper.go
@@ -96,9 +96,7 @@ func NewStorageHelper(params StorageHelperParams) (*StorageHelper, error) {
 	config.DebugLogging = config.DebugLogging || params.DebugLogging
 
 	registry, err := pkgcommon.NewInvocationRegistry(pkgcommon.InvocationRegistryParams{
-		Envs:         params.Envs,
-		AuthConfig:   &config.AuthConfig,
-		DebugLogging: config.DebugLogging,
+		Envs: params.Envs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create invocation registry: %w", err)

--- a/pkg/common/invocation_registry.go
+++ b/pkg/common/invocation_registry.go
@@ -25,13 +25,6 @@ type InvocationRegistryParams struct {
 	// Envs is the set of environment variables used for metadata.
 	// If nil, the current process environment is used.
 	Envs map[string]string
-
-	// AuthConfig, when non-nil, is used directly and skips reading the
-	// multiplatform config file. Callers that already have credentials
-	// loaded (e.g. StorageHelper) should set this to avoid a redundant
-	// file read and to work when no multiplatform config file exists.
-	AuthConfig   *configcommon.CacheAuthConfig
-	DebugLogging bool
 }
 
 // RegisterInvocationParams configures the RegisterMultiplatformInvocation operation.
@@ -73,25 +66,16 @@ type InvocationRegistry struct {
 }
 
 // NewInvocationRegistry returns an InvocationRegistry ready to register invocations
-// and relations. If params.AuthConfig is non-nil it is used directly; otherwise the
-// multiplatform analytics config file is read from disk.
+// and relations. Auth credentials and the debug-logging flag are read from the
+// multiplatform analytics config file on disk (single canonical source).
 func NewInvocationRegistry(params InvocationRegistryParams) (*InvocationRegistry, error) {
 	if params.Envs == nil {
 		params.Envs = utils.AllEnvs()
 	}
 
-	var config multiplatformconfig.Config
-	if params.AuthConfig != nil {
-		config = multiplatformconfig.Config{
-			AuthConfig:   *params.AuthConfig,
-			DebugLogging: params.DebugLogging,
-		}
-	} else {
-		var err error
-		config, err = multiplatformconfig.ReadConfig(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
-		if err != nil {
-			return nil, fmt.Errorf("read multiplatform config: %w", err)
-		}
+	config, err := multiplatformconfig.ReadConfig(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
+	if err != nil {
+		return nil, fmt.Errorf("read multiplatform config: %w", err)
 	}
 
 	return &InvocationRegistry{

--- a/pkg/reactnative/post_run_deps.go
+++ b/pkg/reactnative/post_run_deps.go
@@ -39,13 +39,7 @@ func newPostRunDeps(logger log.Logger, osProxy utils.OsProxy, decoderFactory uti
 		return nil
 	}
 
-	// Use a debug-enabled logger for the analytics client if activation was done
-	// with --debug. The runner's logger (passed in) is NOT modified — we create
-	// a separate client logger so HTTP PUT lines appear in the output when debug
-	// mode was requested at activation time.
-	clientLogger := log.NewLogger(log.WithDebugLog(config.DebugLogging))
-
-	client, err := ccacheanalytics.NewClient(consts.MultiplatformAnalyticsServiceEndpoint, config.AuthConfig.TokenInGradleFormat(), clientLogger)
+	client, err := ccacheanalytics.NewClient(consts.MultiplatformAnalyticsServiceEndpoint, config.AuthConfig.TokenInGradleFormat(), logger)
 	if err != nil {
 		logger.TWarnf("Failed to create analytics client for post-run hook: %v", err)
 

--- a/pkg/reactnative/runner.go
+++ b/pkg/reactnative/runner.go
@@ -11,6 +11,7 @@ import (
 
 	ccacheipc "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache"
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
@@ -59,11 +60,6 @@ type Runner struct {
 
 // NewRunner creates a Runner with production pre-run and post-run hooks.
 func NewRunner(params RunnerParams) *Runner {
-	logger := params.Logger
-	if logger == nil {
-		logger = log.NewLogger()
-	}
-
 	osProxy := params.OsProxy
 	if osProxy == nil {
 		osProxy = utils.DefaultOsProxy{}
@@ -72,6 +68,19 @@ func NewRunner(params RunnerParams) *Runner {
 	decoderFactory := params.DecoderFactory
 	if decoderFactory == nil {
 		decoderFactory = utils.DefaultDecoderFactory{}
+	}
+
+	logger := params.Logger
+	if logger == nil {
+		// Honour DebugLogging from the multiplatform analytics config so
+		// `activate react-native --debug` propagates to the runner and to any
+		// component (e.g. the analytics client) that uses this logger.
+		debug := false
+		if cfg, err := multiplatformconfig.ReadConfig(osProxy, decoderFactory); err == nil {
+			debug = cfg.DebugLogging
+		}
+
+		logger = log.NewLogger(log.WithDebugLog(debug))
 	}
 
 	var ccacheConfig *ccacheconfig.Config


### PR DESCRIPTION
## Summary

Addresses [ACI-4859](https://bitrise.atlassian.net/browse/ACI-4859) — postponed review comments from PRs #272 and #274.

- Fix `HasActivity()` doc in `docs/ccache.md`.
- Rename `consts.AnalyticsServiceEndpoint` → `XcodeAnalyticsServiceEndpoint`.
- `register-invocation`: `--build-tool` is now required (was a misleading `multiplatform` default).
- `pkg/reactnative` runner: default logger reads `DebugLogging` from multiplatform config; `postRunDeps` reuses it instead of creating a separate `clientLogger`.
- **Single canonical on-disk auth source:**
  - `activate cpp` and `activate xcode` now also write the multiplatform analytics config.
  - `ccache.Config.AuthConfig` is no longer persisted to JSON (read from multiplatform).
  - `xcelerate.Config.AuthConfig` keeps the JSON tag (`omitzero`) for read-side backwards compatibility with already-deployed xcelerate configs; `Save` strips it; `ReadConfig` prefers multiplatform and falls back to legacy auth on disk if missing.
  - `pkg/common/InvocationRegistryParams` drops `AuthConfig` + `DebugLogging` override fields. `StorageHelper` updated.
- `docs/reactnative.md`: clarify that `wrapperInvocationID` is created inside `react-native run` (not pre-existing in env) and exported to children as `BITRISE_INVOCATION_ID`.
- New `docs/analytics.md`: documents `register-invocation` / `register-child-invocation`, single auth source, CLI-internal callers, and gradle-plugin callers (orchestrator + wrapper modes). Cross-linked from `ccache.md` and `reactnative.md`.

## Backwards compatibility

- xcelerate config: existing `~/.bitrise-xcelerate/config.json` files with `authConfig` still load (read-side fallback). After the next activation the field is dropped from the file.
- ccache config: not yet released — no compat shim needed.

## Test plan

- [x] `go test -tags unit -race ./...` — green
- [x] `make lint` — green
- [x] New unit tests cover xcelerate auth backwards-compat (3 cases: save strips, legacy fallback, multiplatform takes priority)
- [ ] Manual e2e: run `activate xcode` over an old config that has `authConfig` on disk, confirm xcodebuild wrapper still authenticates and the new file no longer carries `authConfig`
- [ ] Manual e2e: run `activate c++` from a clean machine, confirm `~/.bitrise/analytics/multiplatform/config.json` is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4859]: https://bitrise.atlassian.net/browse/ACI-4859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ