### PR TITLE
fix(benchmark): mirror gradle phase to legacy env var and file

### DIFF
--- a/internal/config/common/benchmark.go
+++ b/internal/config/common/benchmark.go
@@ -25,6 +25,14 @@ const (
 	BuildToolGradle = "gradle"
 	BuildToolXcode  = "xcode"
 	BuildToolBazel  = "bazel"
+
+	// LegacyBenchmarkPhaseEnvVar is the pre-per-build-tool env var name. Older
+	// external readers (notably gradle-analytics plugin versions < 2.6.1) still
+	// look up this name, so the gradle activation path mirrors its phase here
+	// for back-compat. New code should use BenchmarkPhaseEnvVar instead.
+	LegacyBenchmarkPhaseEnvVar = "BITRISE_BUILD_CACHE_BENCHMARK_PHASE"
+
+	legacyBenchmarkPhaseFileName = "benchmark-phase.json"
 )
 
 type benchmarkResponse struct {
@@ -132,12 +140,23 @@ func BenchmarkPhaseEnvVar(buildTool string) string {
 
 // BenchmarkPhaseFilePath returns the path to the benchmark phase file for a build tool.
 func BenchmarkPhaseFilePath(buildTool string) (string, error) {
+	return benchmarkPhaseDirJoin("benchmark-phase-" + buildTool + ".json")
+}
+
+// LegacyBenchmarkPhaseFilePath returns the pre-per-build-tool file path. Kept
+// as a fallback for older external readers; mirrored from the gradle activation
+// path for back-compat.
+func LegacyBenchmarkPhaseFilePath() (string, error) {
+	return benchmarkPhaseDirJoin(legacyBenchmarkPhaseFileName)
+}
+
+func benchmarkPhaseDirJoin(name string) (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("get home directory: %w", err)
 	}
 
-	return filepath.Join(homeDir, ".local", "state", "xcelerate", "benchmark", "benchmark-phase-"+buildTool+".json"), nil
+	return filepath.Join(homeDir, ".local", "state", "xcelerate", "benchmark", name), nil
 }
 
 // WriteBenchmarkPhaseFile writes the benchmark phase to a JSON file for the given build tool.
@@ -149,6 +168,23 @@ func WriteBenchmarkPhaseFile(buildTool, phase string, logger log.Logger) {
 		return
 	}
 
+	writeBenchmarkPhaseFileTo(filePath, phase, logger)
+}
+
+// WriteLegacyBenchmarkPhaseFile writes the benchmark phase to the pre-per-build-tool
+// file path so older external readers still find it.
+func WriteLegacyBenchmarkPhaseFile(phase string, logger log.Logger) {
+	filePath, err := LegacyBenchmarkPhaseFilePath()
+	if err != nil {
+		logger.Debugf("Failed to get legacy benchmark phase file path: %v", err)
+
+		return
+	}
+
+	writeBenchmarkPhaseFileTo(filePath, phase, logger)
+}
+
+func writeBenchmarkPhaseFileTo(filePath, phase string, logger log.Logger) {
 	dir := filepath.Dir(filePath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		logger.Debugf("Failed to create benchmark phase dir: %v", err)

--- a/internal/config/common/benchmark_test.go
+++ b/internal/config/common/benchmark_test.go
@@ -296,3 +296,41 @@ func TestBenchmarkPhaseEnvVar(t *testing.T) {
 	assert.Equal(t, "BITRISE_BUILD_CACHE_BENCHMARK_PHASE_XCODE", BenchmarkPhaseEnvVar(BuildToolXcode))
 	assert.Equal(t, "BITRISE_BUILD_CACHE_BENCHMARK_PHASE_BAZEL", BenchmarkPhaseEnvVar(BuildToolBazel))
 }
+
+func TestLegacyBenchmarkPhaseEnvVar(t *testing.T) {
+	assert.Equal(t, "BITRISE_BUILD_CACHE_BENCHMARK_PHASE", LegacyBenchmarkPhaseEnvVar)
+}
+
+func TestWriteLegacyBenchmarkPhaseFile(t *testing.T) {
+	logger := log.NewLogger()
+
+	t.Run("creates legacy-named file", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		WriteLegacyBenchmarkPhaseFile("baseline", logger)
+
+		filePath := filepath.Join(home, ".local", "state", "xcelerate", "benchmark", "benchmark-phase.json")
+		assert.FileExists(t, filePath)
+
+		data, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+
+		var result BenchmarkPhaseFile
+		require.NoError(t, json.Unmarshal(data, &result))
+		assert.Equal(t, "baseline", result.Phase)
+	})
+
+	t.Run("legacy and per-tool files coexist", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		WriteBenchmarkPhaseFile(BuildToolGradle, "warmup", logger)
+		WriteLegacyBenchmarkPhaseFile("warmup", logger)
+
+		legacyPath := filepath.Join(home, ".local", "state", "xcelerate", "benchmark", "benchmark-phase.json")
+		gradlePath := filepath.Join(home, ".local", "state", "xcelerate", "benchmark", "benchmark-phase-gradle.json")
+		assert.FileExists(t, legacyPath)
+		assert.FileExists(t, gradlePath)
+	})
+}

--- a/internal/config/gradle/benchmark.go
+++ b/internal/config/gradle/benchmark.go
@@ -14,8 +14,11 @@ type EnvExporter interface {
 
 // ApplyBenchmarkPhase queries the benchmark phase and overrides gradle params accordingly.
 // Baseline phase disables cache and enables analytics only. Warmup phase logs a warning.
-// The phase is exported as BITRISE_BUILD_CACHE_BENCHMARK_PHASE env var
-// and written to ~/.local/state/xcelerate/benchmark/benchmark-phase.json as fallback.
+// The phase is exported as the per-build-tool BITRISE_BUILD_CACHE_BENCHMARK_PHASE_GRADLE
+// env var and written to ~/.local/state/xcelerate/benchmark/benchmark-phase-gradle.json.
+// For back-compat with older gradle-analytics plugins (< 2.6.1) that still read the
+// pre-split BITRISE_BUILD_CACHE_BENCHMARK_PHASE env var and benchmark-phase.json file,
+// the gradle phase is mirrored to those legacy names too.
 func ApplyBenchmarkPhase(
 	params *ActivateGradleParams,
 	logger log.Logger,
@@ -41,6 +44,12 @@ func ApplyBenchmarkPhase(
 	exporter.Export(envVar, phase)
 	exporter.ExportToShellRC("Bitrise Benchmark Phase", "export "+envVar+"="+phase)
 	common.WriteBenchmarkPhaseFile(common.BuildToolGradle, phase, logger)
+
+	// Back-compat: pre-2.6.1 gradle-analytics plugins read the legacy env var
+	// and file name. Mirror the gradle phase so older plugin versions still
+	// tag their invocations correctly.
+	exporter.Export(common.LegacyBenchmarkPhaseEnvVar, phase)
+	common.WriteLegacyBenchmarkPhaseFile(phase, logger)
 
 	switch phase {
 	case common.BenchmarkPhaseBaseline:

--- a/internal/config/gradle/benchmark_test.go
+++ b/internal/config/gradle/benchmark_test.go
@@ -19,6 +19,18 @@ type noopExporter struct{}
 func (n *noopExporter) Export(_, _ string)          {}
 func (n *noopExporter) ExportToShellRC(_, _ string) {}
 
+type recordingExporter struct {
+	exports map[string]string
+}
+
+func (r *recordingExporter) Export(key, value string) {
+	if r.exports == nil {
+		r.exports = map[string]string{}
+	}
+	r.exports[key] = value
+}
+func (r *recordingExporter) ExportToShellRC(_, _ string) {}
+
 func Test_ApplyBenchmarkPhase(t *testing.T) {
 	prep := func() log.Logger {
 		mockLogger := &mocks.Logger{}
@@ -107,6 +119,45 @@ func Test_ApplyBenchmarkPhase(t *testing.T) {
 
 		assert.True(t, params.Cache.Enabled)
 		assert.False(t, params.Analytics.Enabled)
+	})
+
+	t.Run("exports both per-tool and legacy env vars for back-compat", func(t *testing.T) {
+		logger := prep()
+		params := ActivateGradleParams{
+			Cache: CacheParams{Enabled: true},
+		}
+
+		mockProvider := &commonmocks.BenchmarkPhaseProviderMock{
+			GetBenchmarkPhaseFunc: func(_ string, _ common.CacheConfigMetadata) (string, error) {
+				return common.BenchmarkPhaseWarmup, nil
+			},
+		}
+
+		exporter := &recordingExporter{}
+		ApplyBenchmarkPhase(&params, logger, mockProvider, common.CacheConfigMetadata{}, exporter)
+
+		assert.Equal(t, common.BenchmarkPhaseWarmup, exporter.exports[common.BenchmarkPhaseEnvVar(common.BuildToolGradle)])
+		assert.Equal(t, common.BenchmarkPhaseWarmup, exporter.exports[common.LegacyBenchmarkPhaseEnvVar],
+			"legacy env var must be mirrored for older gradle-analytics plugins")
+	})
+
+	t.Run("does not export legacy env var when phase is empty", func(t *testing.T) {
+		logger := prep()
+		params := ActivateGradleParams{
+			Cache: CacheParams{Enabled: true},
+		}
+
+		mockProvider := &commonmocks.BenchmarkPhaseProviderMock{
+			GetBenchmarkPhaseFunc: func(_ string, _ common.CacheConfigMetadata) (string, error) {
+				return "", nil
+			},
+		}
+
+		exporter := &recordingExporter{}
+		ApplyBenchmarkPhase(&params, logger, mockProvider, common.CacheConfigMetadata{}, exporter)
+
+		_, hasLegacy := exporter.exports[common.LegacyBenchmarkPhaseEnvVar]
+		assert.False(t, hasLegacy)
 	})
 
 	t.Run("error falls back to original params", func(t *testing.T) {

--- a/internal/config/xcelerate/benchmark.go
+++ b/internal/config/xcelerate/benchmark.go
@@ -14,8 +14,12 @@ type EnvExporter interface {
 
 // ApplyBenchmarkPhase queries the benchmark phase and overrides xcode params accordingly.
 // Baseline phase disables cache. Warmup phase logs a warning.
-// The phase is exported as BITRISE_BUILD_CACHE_BENCHMARK_PHASE env var
-// and written to ~/.local/state/xcelerate/benchmark/benchmark-phase.json as fallback.
+// The phase is exported as the per-build-tool BITRISE_BUILD_CACHE_BENCHMARK_PHASE_XCODE
+// env var and written to ~/.local/state/xcelerate/benchmark/benchmark-phase-xcode.json.
+// The legacy BITRISE_BUILD_CACHE_BENCHMARK_PHASE env var is intentionally NOT mirrored
+// here — only the gradle activation path writes it, to avoid clobbering the gradle
+// phase in mixed (e.g. React Native) activations where the legacy reader is the
+// gradle plugin.
 func ApplyBenchmarkPhase(
 	params *Params,
 	logger log.Logger,


### PR DESCRIPTION
## Summary

- Mirror the gradle benchmark phase to the pre-split `BITRISE_BUILD_CACHE_BENCHMARK_PHASE` env var and `~/.local/state/xcelerate/benchmark/benchmark-phase.json` file alongside the new per-build-tool names, so external readers that have not yet migrated still find the value.
- Only the gradle activation path mirrors the legacy slot; xcode intentionally does not, to avoid clobbering gradle's phase in mixed activations (e.g. React Native).

## Why

Resolves [ACI-4865](https://bitrise.atlassian.net/browse/ACI-4865). Customer builds were stuck at `baseline` even after 5–6 successful builds because pre-2.6.1 `gradle-analytics` plugin versions still read the legacy env var name. After PR #280 split benchmark phase storage per build tool, the legacy name was no longer written, so older plugins reported gradle invocations with no phase tag. The server's `/invocations/gradle/command_benchmark_status` endpoint never observed any baseline activity and progression never advanced.

## What changed

- `internal/config/common/benchmark.go` — adds `LegacyBenchmarkPhaseEnvVar`, `LegacyBenchmarkPhaseFilePath()`, and `WriteLegacyBenchmarkPhaseFile()`. Existing per-build-tool helpers refactored to share a small writer helper.
- `internal/config/gradle/benchmark.go` — also exports the legacy env var and writes the legacy file when applying the gradle phase.
- `internal/config/xcelerate/benchmark.go` — doc-comment update only; clarifies the xcode path does not write the legacy slot.

## Out of scope

- Shell-RC block name collision when both gradle and xcode activations run — split into a separate PR.

## Test plan

- [x] `go test -tags unit -race ./internal/config/...` passes
- [x] `make lint` clean
- [ ] On a Bitrise CI workflow with a pre-2.6.1 gradle-analytics plugin, verify after activation that `envman print | grep BITRISE_BUILD_CACHE_BENCHMARK_PHASE` shows both `..._GRADLE` and the bare legacy key, and that `~/.local/state/xcelerate/benchmark/benchmark-phase.json` exists with the gradle phase.
- [ ] On the same workflow run the build, then confirm the gradle plugin's reported invocation in gradle-analytics carries `benchmarkPhase=baseline` (or whatever is current).
- [ ] After 5–6 such builds, confirm the `command_benchmark_status` endpoint progresses past `baseline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4865]: https://bitrise.atlassian.net/browse/ACI-4865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ