### PR TITLE
fix(benchmark): use per-build-tool shell-rc block name

### DIFF
--- a/internal/config/gradle/benchmark.go
+++ b/internal/config/gradle/benchmark.go
@@ -39,7 +39,9 @@ func ApplyBenchmarkPhase(
 	envVar := common.BenchmarkPhaseEnvVar(common.BuildToolGradle)
 	logger.Infof("(i) Benchmark phase: %s", phase)
 	exporter.Export(envVar, phase)
-	exporter.ExportToShellRC("Bitrise Benchmark Phase", "export "+envVar+"="+phase)
+	// Block name is per-build-tool so xcode's call doesn't overwrite gradle's
+	// block (or vice versa) in mixed activations like React Native.
+	exporter.ExportToShellRC("Bitrise Benchmark Phase Gradle", "export "+envVar+"="+phase)
 	common.WriteBenchmarkPhaseFile(common.BuildToolGradle, phase, logger)
 
 	switch phase {

--- a/internal/config/gradle/benchmark_test.go
+++ b/internal/config/gradle/benchmark_test.go
@@ -19,6 +19,18 @@ type noopExporter struct{}
 func (n *noopExporter) Export(_, _ string)          {}
 func (n *noopExporter) ExportToShellRC(_, _ string) {}
 
+type recordingShellRCExporter struct {
+	blocks map[string]string
+}
+
+func (r *recordingShellRCExporter) Export(_, _ string) {}
+func (r *recordingShellRCExporter) ExportToShellRC(blockName, content string) {
+	if r.blocks == nil {
+		r.blocks = map[string]string{}
+	}
+	r.blocks[blockName] = content
+}
+
 func Test_ApplyBenchmarkPhase(t *testing.T) {
 	prep := func() log.Logger {
 		mockLogger := &mocks.Logger{}
@@ -107,6 +119,25 @@ func Test_ApplyBenchmarkPhase(t *testing.T) {
 
 		assert.True(t, params.Cache.Enabled)
 		assert.False(t, params.Analytics.Enabled)
+	})
+
+	t.Run("uses gradle-specific shell-rc block name", func(t *testing.T) {
+		logger := prep()
+		params := ActivateGradleParams{Cache: CacheParams{Enabled: true}}
+
+		mockProvider := &commonmocks.BenchmarkPhaseProviderMock{
+			GetBenchmarkPhaseFunc: func(_ string, _ common.CacheConfigMetadata) (string, error) {
+				return common.BenchmarkPhaseWarmup, nil
+			},
+		}
+
+		exporter := &recordingShellRCExporter{}
+		ApplyBenchmarkPhase(&params, logger, mockProvider, common.CacheConfigMetadata{}, exporter)
+
+		_, hasGradleBlock := exporter.blocks["Bitrise Benchmark Phase Gradle"]
+		assert.True(t, hasGradleBlock, "expected gradle-specific block name so xcode activation doesn't clobber it")
+		_, hasGenericBlock := exporter.blocks["Bitrise Benchmark Phase"]
+		assert.False(t, hasGenericBlock, "generic block name reintroduces the cross-tool clobber")
 	})
 
 	t.Run("error falls back to original params", func(t *testing.T) {

--- a/internal/config/xcelerate/benchmark.go
+++ b/internal/config/xcelerate/benchmark.go
@@ -39,7 +39,9 @@ func ApplyBenchmarkPhase(
 	envVar := common.BenchmarkPhaseEnvVar(common.BuildToolXcode)
 	logger.Infof("(i) Benchmark phase: %s", phase)
 	exporter.Export(envVar, phase)
-	exporter.ExportToShellRC("Bitrise Benchmark Phase", "export "+envVar+"="+phase)
+	// Block name is per-build-tool so gradle's call doesn't overwrite xcode's
+	// block (or vice versa) in mixed activations like React Native.
+	exporter.ExportToShellRC("Bitrise Benchmark Phase Xcode", "export "+envVar+"="+phase)
 	common.WriteBenchmarkPhaseFile(common.BuildToolXcode, phase, logger)
 
 	switch phase {

--- a/internal/config/xcelerate/benchmark_test.go
+++ b/internal/config/xcelerate/benchmark_test.go
@@ -18,6 +18,18 @@ type noopExporter struct{}
 func (n *noopExporter) Export(_, _ string)          {}
 func (n *noopExporter) ExportToShellRC(_, _ string) {}
 
+type recordingShellRCExporter struct {
+	blocks map[string]string
+}
+
+func (r *recordingShellRCExporter) Export(_, _ string) {}
+func (r *recordingShellRCExporter) ExportToShellRC(blockName, content string) {
+	if r.blocks == nil {
+		r.blocks = map[string]string{}
+	}
+	r.blocks[blockName] = content
+}
+
 func TestApplyBenchmarkPhase(t *testing.T) {
 	t.Run("baseline phase disables cache", func(t *testing.T) {
 		params := xcelerate.Params{
@@ -71,6 +83,24 @@ func TestApplyBenchmarkPhase(t *testing.T) {
 		xcelerate.ApplyBenchmarkPhase(&params, mockLogger, mockProvider, common.CacheConfigMetadata{}, &noopExporter{})
 
 		assert.True(t, params.BuildCacheEnabled)
+	})
+
+	t.Run("uses xcode-specific shell-rc block name", func(t *testing.T) {
+		params := xcelerate.Params{BuildCacheEnabled: true}
+
+		mockProvider := &commonmocks.BenchmarkPhaseProviderMock{
+			GetBenchmarkPhaseFunc: func(_ string, _ common.CacheConfigMetadata) (string, error) {
+				return common.BenchmarkPhaseWarmup, nil
+			},
+		}
+
+		exporter := &recordingShellRCExporter{}
+		xcelerate.ApplyBenchmarkPhase(&params, mockLogger, mockProvider, common.CacheConfigMetadata{}, exporter)
+
+		_, hasXcodeBlock := exporter.blocks["Bitrise Benchmark Phase Xcode"]
+		assert.True(t, hasXcodeBlock, "expected xcode-specific block name so gradle activation doesn't clobber it")
+		_, hasGenericBlock := exporter.blocks["Bitrise Benchmark Phase"]
+		assert.False(t, hasGenericBlock, "generic block name reintroduces the cross-tool clobber")
 	})
 
 	t.Run("error falls back to original params", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Use `"Bitrise Benchmark Phase Gradle"` and `"Bitrise Benchmark Phase Xcode"` as the shell-rc block names instead of a shared `"Bitrise Benchmark Phase"` block, so the two activations no longer overwrite each other in `~/.bashrc` / `~/.zshrc`.

## Why

Resolves part of [ACI-4865](https://bitrise.atlassian.net/browse/ACI-4865). `stringmerge.ChangeContentInBlock` replaces a block in place. When React Native activation runs gradle then xcode (`pkg/reactnative/activator.go:95-109`), xcode's `ExportToShellRC("Bitrise Benchmark Phase", ...)` overwrote gradle's export of the same block name, so shells started from those rc files only saw one of the two `BITRISE_BUILD_CACHE_BENCHMARK_PHASE_*` env vars.

envman and `GITHUB_ENV` keep the keys separately, so this never affected Bitrise CI itself — but it broke local-dev shells and any non-Bitrise CI environment without `GITHUB_ENV`.

## What changed

- `internal/config/gradle/benchmark.go` — block name `"Bitrise Benchmark Phase Gradle"`.
- `internal/config/xcelerate/benchmark.go` — block name `"Bitrise Benchmark Phase Xcode"`.
- Tests on both sides assert the per-build-tool block name and that the old generic name is no longer used.

## Test plan

- [x] `go test -tags unit -race ./internal/config/...` passes
- [x] `make lint` clean
- [ ] After running `activate react-native` locally on a clean shell, check that `~/.zshrc` contains both `# [start] Bitrise Benchmark Phase Gradle` and `# [start] Bitrise Benchmark Phase Xcode` blocks with their respective env vars.
- [ ] Re-running activation overwrites the block content in place (no duplicates), one block per tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4865]: https://bitrise.atlassian.net/browse/ACI-4865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ