### PR TITLE
fix: fail RN wrapper invocation when any child invocation failed

### DIFF
--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -378,6 +378,7 @@ func (c *XcodebuildRunner) writeChildStatsLedger(parentID string, inv analytics.
 		Hits:               hits,
 		Total:              total,
 		BenchmarkPhase:     c.Metadata.BenchmarkPhase,
+		Failed:             !inv.Success,
 	}
 
 	if err := childstats.NewWriter().Write(entry); err != nil {

--- a/pkg/ccache/storage_helper.go
+++ b/pkg/ccache/storage_helper.go
@@ -289,6 +289,7 @@ func (h *StorageHelper) writeChildStatsLedger(invocationID, parentID string, sta
 		Hits:               int64(stats.CacheHit),
 		Total:              total,
 		BenchmarkPhase:     os.Getenv(configcommon.BenchmarkPhaseEnvVar("ccache")),
+		Failed:             !stats.Success(),
 	}
 
 	if err := childstats.NewWriter().Write(entry); err != nil {

--- a/pkg/common/childstats/childstats.go
+++ b/pkg/common/childstats/childstats.go
@@ -50,15 +50,19 @@ const (
 
 // Entry is a single child invocation's ledger record.
 type Entry struct {
-	ChildInvocationID  string    `json:"child_invocation_id"`
-	ParentInvocationID string    `json:"parent_invocation_id"`
-	BuildTool          string    `json:"build_tool"`
-	HitRate            float32   `json:"hit_rate"`
-	Hits               int64     `json:"hits,omitempty"`
-	Total              int64     `json:"total,omitempty"`
-	BenchmarkPhase     string    `json:"benchmark_phase,omitempty"`
-	WrittenAt          time.Time `json:"written_at"`
-	SchemaVersion      int       `json:"schema_version"`
+	ChildInvocationID  string  `json:"child_invocation_id"`
+	ParentInvocationID string  `json:"parent_invocation_id"`
+	BuildTool          string  `json:"build_tool"`
+	HitRate            float32 `json:"hit_rate"`
+	Hits               int64   `json:"hits,omitempty"`
+	Total              int64   `json:"total,omitempty"`
+	BenchmarkPhase     string  `json:"benchmark_phase,omitempty"`
+	// Failed indicates the child invocation reported a failure. Default is
+	// false (no failure) for legacy entries that don't carry the field —
+	// writers that can detect failure must set this explicitly.
+	Failed        bool      `json:"failed,omitempty"`
+	WrittenAt     time.Time `json:"written_at"`
+	SchemaVersion int       `json:"schema_version"`
 }
 
 // LedgerDir returns the directory for a parent invocation's child entries.
@@ -185,6 +189,12 @@ type Summary struct {
 	// SkippedCount is the number of entries excluded (malformed only).
 	SkippedCount int
 
+	// FailedCount is the number of entries that reported Failed=true. Used
+	// by parent wrappers to fail the wrapper invocation when any child
+	// failed (e.g. an xcodebuild child errored even though the parent script
+	// kept running).
+	FailedCount int
+
 	// ByTool breaks down the stats per build tool (gradle, ccache, xcode, ...).
 	ByTool map[string]ToolSummary
 }
@@ -265,6 +275,10 @@ func (a *Aggregator) Compute() (Summary, error) {
 		summary.ChildCount++
 		summary.TotalHits += entry.Hits
 		summary.TotalCount += entry.Total
+
+		if entry.Failed {
+			summary.FailedCount++
+		}
 
 		byToolSums[entry.BuildTool] += entry.HitRate
 		byToolCounts[entry.BuildTool]++

--- a/pkg/common/childstats/childstats_test.go
+++ b/pkg/common/childstats/childstats_test.go
@@ -252,3 +252,32 @@ func TestAggregator_Cleanup_RemovesDir(t *testing.T) {
 	// Cleanup on a missing dir is a no-op, not an error.
 	require.NoError(t, agg.Cleanup())
 }
+
+func TestAggregator_Compute_CountsFailedEntries(t *testing.T) {
+	setHome(t)
+
+	w := NewWriter()
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "ok", BuildTool: "gradle", HitRate: 0.5}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "fail-1", BuildTool: "xcode", HitRate: 0.3, Failed: true}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "fail-2", BuildTool: "ccache", HitRate: 0, Failed: true}))
+
+	summary, err := NewAggregator("p").Compute()
+	require.NoError(t, err)
+	assert.Equal(t, 3, summary.ChildCount)
+	assert.Equal(t, 2, summary.FailedCount)
+}
+
+func TestAggregator_Compute_LegacyEntriesDefaultToNotFailed(t *testing.T) {
+	setHome(t)
+
+	// Simulate a legacy entry written by a writer that did not know about Failed.
+	dir := LedgerDir("p")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	legacy := `{"child_invocation_id":"old","parent_invocation_id":"p","build_tool":"gradle","hit_rate":0.5,"schema_version":1}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "old"+EntryFileSuffix), []byte(legacy), 0o600))
+
+	summary, err := NewAggregator("p").Compute()
+	require.NoError(t, err)
+	assert.Equal(t, 1, summary.ChildCount)
+	assert.Equal(t, 0, summary.FailedCount, "missing 'failed' field must default to not-failed")
+}

--- a/pkg/reactnative/post_run_deps.go
+++ b/pkg/reactnative/post_run_deps.go
@@ -98,6 +98,19 @@ func (d *postRunDeps) run(ctx context.Context, wrapperInvocationID string, args 
 				summary.BaselineCount, summary.ChildCount,
 			)
 		}
+
+		if summary.FailedCount > 0 {
+			d.logger.TWarnf(
+				"%d of %d child invocations reported a failure — marking the wrapper run as failed.",
+				summary.FailedCount, summary.ChildCount,
+			)
+		}
+	}
+
+	wrapperSuccess := execErr == nil && summary.FailedCount == 0
+	wrapperErr := execErr
+	if wrapperErr == nil && summary.FailedCount > 0 {
+		wrapperErr = fmt.Errorf("%d of %d child invocations failed", summary.FailedCount, summary.ChildCount)
 	}
 
 	inv := multiplatform.NewInvocation(multiplatform.InvocationRunStats{
@@ -106,8 +119,8 @@ func (d *postRunDeps) run(ctx context.Context, wrapperInvocationID string, args 
 		Duration:       duration,
 		Command:        command,
 		FullCommand:    fullCommand,
-		Success:        execErr == nil,
-		Error:          execErr,
+		Success:        wrapperSuccess,
+		Error:          wrapperErr,
 		BuildTool:      "react-native",
 		Wrapper:        "bitrise-build-cache-cli react-native",
 		HitRate:        summary.MeanHitRate,


### PR DESCRIPTION
## Summary

The react-native run wrapper invocation was reporting `Success=true` even when a child (xcodebuild, ccache) clearly failed — because the wrapper's Success was tied only to the wrapped exec's exit code. Scripts often swallow child failures and continue, so the wrapper-level signal was lying.

- `childstats.Entry`: add `failed` bool (omitempty). Legacy entries without the field decode to `false` (counted as not-failed), preserving prior behaviour.
- `childstats.Aggregator`: counts `Failed=true` entries into new `Summary.FailedCount`.
- xcodebuild wrapper: writes `Failed = !inv.Success`.
- ccache storage helper: writes `Failed = !stats.Success()` (uses the stats-error helper from #286).
- `pkg/reactnative/post_run_deps`: combines exec error with `summary.FailedCount` when setting `Success`/`Error` on the wrapper invocation; warn-logs the count.

## Test plan

- [x] `go test -tags unit -race ./...` — green
- [x] `make lint` — green
- [x] New unit tests cover FailedCount aggregation and the legacy-no-field default
- [ ] Manual e2e: trigger an RN run where xcodebuild fails but the wrapping script continues. Verify the RN wrapper invocation reports Success=false + Error="N of N child invocations failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)