### PR TITLE
chore: auto-update activate-react-native-features step on CLI release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -26,6 +26,7 @@ A release can be triggered by:
 | Gradle step (unified CI) | `48fa8fbee698622c` | `bitrise-steplib/bitrise-step-activate-gradle-remote-cache` |
 | Xcode step (unified CI) | `48fa8fbee698622c` | `bitrise-steplib/bitrise-step-activate-build-cache-for-xcode` |
 | Gradle features step (unified CI) | `48fa8fbee698622c` | `bitrise-steplib/bitrise-step-activate-gradle-features` |
+| React Native features step (unified CI) | `48fa8fbee698622c` | `bitrise-steplib/bitrise-step-activate-react-native-features` |
 | Steplib | — | `bitrise-io/bitrise-steplib` |
 
 ## Steps
@@ -72,11 +73,12 @@ Create a GitHub release in `bitrise-build-cache-cli`.
 
 ### 7. Wait for step auto-update PRs
 
-The CLI release triggers auto-update PRs in **three** step repos (all use unified CI app `48fa8fbee698622c`). The PR title will be "feat: Release new CLI". Monitor CI on all three, then approve and merge:
+The CLI release triggers auto-update PRs in **four** step repos (all use unified CI app `48fa8fbee698622c`). The PR title will be "feat: Release new CLI". Monitor CI on all four, then approve and merge:
 
 1. **Gradle step:** `bitrise-steplib/bitrise-step-activate-gradle-remote-cache`
 2. **Xcode step:** `bitrise-steplib/bitrise-step-activate-build-cache-for-xcode`
 3. **Gradle features step:** `bitrise-steplib/bitrise-step-activate-gradle-features` (experimental, no release needed)
+4. **React Native features step:** `bitrise-steplib/bitrise-step-activate-react-native-features` (experimental, no release needed)
 
 ```bash
 # For each step repo:
@@ -101,10 +103,10 @@ After the step releases, PRs appear in `bitrise-io/bitrise-steplib` for each rel
 
 ```bash
 gh pr review --approve --repo bitrise-io/bitrise-steplib <PR_NUMBER>
-gh pr merge --merge --auto --repo bitrise-io/bitrise-steplib <PR_NUMBER>
+gh pr merge --squash --auto --repo bitrise-io/bitrise-steplib <PR_NUMBER>
 ```
 
-Always wait for CI to pass — never bypass branch protection.
+Always wait for CI to pass — never bypass branch protection. The steplib repo requires squash merges (merge commits are blocked).
 
 ## Flaky E2E tests — cache hit rate
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -132,6 +132,10 @@ workflows:
         envs:
         - STEP_NAME: bitrise-step-activate-build-cache-for-xcode
         - UPDATE_SCRIPT_PATH: ../scripts/update_activate_build_cache_for_xcode.sh
+    - bundle::update-step:
+        envs:
+        - STEP_NAME: bitrise-step-activate-react-native-features
+        - UPDATE_SCRIPT_PATH: ../scripts/update_activate_react_native_features.sh
     - slack@4:
         inputs:
           - channel: "#team-advanced-ci-alerts-website"
@@ -1038,6 +1042,10 @@ workflows:
           envs:
             - STEP_NAME: bitrise-step-activate-build-cache-for-xcode
             - UPDATE_SCRIPT_PATH: ../scripts/update_activate_build_cache_for_xcode.sh
+      - bundle::update-step:
+          envs:
+            - STEP_NAME: bitrise-step-activate-react-native-features
+            - UPDATE_SCRIPT_PATH: ../scripts/update_activate_react_native_features.sh
 
 step_bundles:
   generate_gradle_verification_reference:

--- a/scripts/update_activate_react_native_features.sh
+++ b/scripts/update_activate_react_native_features.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -ex
+
+FILE_TO_UPDATE="step/cli.go"
+
+# bitrise-step-activate-react-native-features keeps the CLI version as a Go
+# constant in step/cli.go (downloaded from GitHub releases at runtime, no
+# vendored Go module). The constant carries the bare semver — strip the
+# leading "v" from BITRISE_GIT_TAG.
+NEW_VERSION="${BITRISE_GIT_TAG#v}"
+
+SED_IN_PLACE_COMMAND=(-i)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  SED_IN_PLACE_COMMAND=(-i "")
+fi
+
+sed -E "${SED_IN_PLACE_COMMAND[@]}" "s/cliVersion[[:space:]]+=[[:space:]]+\"[0-9]+\.[0-9]+\.[0-9]+\"/cliVersion    = \"$NEW_VERSION\"/" "$FILE_TO_UPDATE"


### PR DESCRIPTION
## Summary

Found during the v2.3.0 release flow: the `bitrise-step-activate-react-native-features` step (added to steplib recently) is not wired into the CLI's release workflow, so each CLI release silently skipped it. The step has to be bumped manually.

This PR plugs it in:

- `bitrise.yml`: add a `bundle::update-step` entry for `bitrise-step-activate-react-native-features` to both the live `release` workflow and the dry-run helper, mirroring the existing 3 step entries.
- `scripts/update_activate_react_native_features.sh` (new): sed-bumps the `cliVersion` constant in `step/cli.go` (the step downloads the CLI binary from GitHub releases at runtime, no vendored Go module).
- `.claude/skills/release/SKILL.md`:
  - Document the 4th step repo alongside the existing three.
  - Step 9: `--merge` → `--squash` (steplib blocks merge commits — hit this during v2.3.0).

## Test plan

- [x] Dry-run sed locally: `cliVersion = "2.2.2"` → `cliVersion = "2.3.0"` from `BITRISE_GIT_TAG=v2.3.0`
- [ ] Validate by triggering the next CLI release and confirming a PR appears in `bitrise-step-activate-react-native-features` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)