### PR TITLE
feat: add gradle mirror for repo.maven.apache.org/maven2 with pluginManagement support

### DIFF
--- a/cmd/gradle/activate_gradle_mirrors.go
+++ b/cmd/gradle/activate_gradle_mirrors.go
@@ -27,26 +27,28 @@ const (
 
 // RepoMirror describes a single repository that can be mirrored.
 type RepoMirror struct {
-	FlagName    string // cobra flag name, e.g. "mavencentral"
-	TemplateID  string // unique suffix for Kotlin variable names, e.g. "Central"
-	URLSegment  string // last path segment in the mirror URL, e.g. "central"
-	GradleMatch string // Kotlin predicate body (using `r` as the repo) that decides whether the repo should be mirrored
+	FlagName                string // cobra flag name, e.g. "mavencentral"
+	TemplateID              string // unique suffix for Kotlin variable names, e.g. "Central"
+	URLSegment              string // last path segment in the mirror URL, e.g. "central"
+	GradleMatch             string // Kotlin predicate body (using `r` as the repo) that decides whether the repo should be mirrored
+	ApplyToPluginManagement bool   // also apply this mirror to pluginManagement.repositories
 }
 
 // KnownMirrors is the registry of supported mirrors.
 var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
 	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: "r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME)"},
 	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
-	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getName().equals("https://repo.maven.apache.org/maven2")`},
+	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`, ApplyToPluginManagement: true},
 }
 
 //go:embed asset/gradle-mirrors.init.gradle.kts.gotemplate
 var gradleMirrorsInitTemplate string
 
 type mirrorTemplateEntry struct {
-	ID          string // unique suffix for Kotlin variable names (e.g. "Central", "Google")
-	GradleMatch string
-	MirrorURL   string
+	ID                      string // unique suffix for Kotlin variable names (e.g. "Central", "Google")
+	GradleMatch             string
+	MirrorURL               string
+	ApplyToPluginManagement bool
 }
 
 type gradleMirrorsTemplateData struct {
@@ -158,9 +160,10 @@ func ActivateGradleMirrorsFn(
 	for _, m := range mirrors {
 		url := fmt.Sprintf(gradleMirrorURLPattern, region, m.URLSegment)
 		entries = append(entries, mirrorTemplateEntry{
-			ID:          m.TemplateID,
-			GradleMatch: m.GradleMatch,
-			MirrorURL:   url,
+			ID:                      m.TemplateID,
+			GradleMatch:             m.GradleMatch,
+			MirrorURL:               url,
+			ApplyToPluginManagement: m.ApplyToPluginManagement,
 		})
 		logger.Debugf("Mirror %s: region=%s, URL=%s", m.FlagName, region, url)
 	}

--- a/cmd/gradle/activate_gradle_mirrors.go
+++ b/cmd/gradle/activate_gradle_mirrors.go
@@ -37,7 +37,7 @@ type RepoMirror struct {
 var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
 	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: "r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME)"},
 	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
-	{FlagName: "mavencentral-apache", TemplateID: "CentralApache", URLSegment: "central-apache", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`},
+	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`},
 }
 
 //go:embed asset/gradle-mirrors.init.gradle.kts.gotemplate

--- a/cmd/gradle/activate_gradle_mirrors.go
+++ b/cmd/gradle/activate_gradle_mirrors.go
@@ -30,13 +30,14 @@ type RepoMirror struct {
 	FlagName    string // cobra flag name, e.g. "mavencentral"
 	TemplateID  string // unique suffix for Kotlin variable names, e.g. "Central"
 	URLSegment  string // last path segment in the mirror URL, e.g. "central"
-	GradleMatch string // Kotlin expression used in the init script to match the repo
+	GradleMatch string // Kotlin predicate body (using `r` as the repo) that decides whether the repo should be mirrored
 }
 
 // KnownMirrors is the registry of supported mirrors.
 var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
-	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: "ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME"},
-	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `"Google"`},
+	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: "r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME)"},
+	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
+	{FlagName: "mavencentral-apache", TemplateID: "CentralApache", URLSegment: "central-apache", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`},
 }
 
 //go:embed asset/gradle-mirrors.init.gradle.kts.gotemplate

--- a/cmd/gradle/activate_gradle_mirrors.go
+++ b/cmd/gradle/activate_gradle_mirrors.go
@@ -35,10 +35,12 @@ type RepoMirror struct {
 }
 
 // KnownMirrors is the registry of supported mirrors.
+// Order matters: entries are applied in the listed order, so URL-based predicates
+// (e.g. apache-central) must run before name-based ones that overwrite the URL.
 var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
+	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`, ApplyToPluginManagement: true},
 	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: "r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME)"},
 	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
-	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`, ApplyToPluginManagement: true},
 }
 
 //go:embed asset/gradle-mirrors.init.gradle.kts.gotemplate

--- a/cmd/gradle/activate_gradle_mirrors.go
+++ b/cmd/gradle/activate_gradle_mirrors.go
@@ -37,7 +37,7 @@ type RepoMirror struct {
 var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
 	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: "r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME)"},
 	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
-	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: "r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME)"},
+	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getName().equals("https://repo.maven.apache.org/maven2")`},
 }
 
 //go:embed asset/gradle-mirrors.init.gradle.kts.gotemplate

--- a/cmd/gradle/activate_gradle_mirrors.go
+++ b/cmd/gradle/activate_gradle_mirrors.go
@@ -37,7 +37,7 @@ type RepoMirror struct {
 var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
 	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: "r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME)"},
 	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
-	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`},
+	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: "r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME)"},
 }
 
 //go:embed asset/gradle-mirrors.init.gradle.kts.gotemplate

--- a/cmd/gradle/activate_gradle_mirrors_test.go
+++ b/cmd/gradle/activate_gradle_mirrors_test.go
@@ -16,8 +16,18 @@ import (
 func TestActivateGradleMirrorsFn(t *testing.T) {
 	initFileName := "bitrise-gradle-mirrors.init.gradle.kts"
 	allMirrors := gradle.KnownMirrors
-	centralOnly := []gradle.RepoMirror{gradle.KnownMirrors[0]}
-	googleOnly := []gradle.RepoMirror{gradle.KnownMirrors[1]}
+	mirrorByFlag := func(flag string) gradle.RepoMirror {
+		for _, m := range gradle.KnownMirrors {
+			if m.FlagName == flag {
+				return m
+			}
+		}
+		t.Fatalf("mirror with flag %q not found", flag)
+
+		return gradle.RepoMirror{}
+	}
+	centralOnly := []gradle.RepoMirror{mirrorByFlag("mavencentral")}
+	googleOnly := []gradle.RepoMirror{mirrorByFlag("google")}
 
 	tests := []struct {
 		name             string

--- a/cmd/gradle/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/cmd/gradle/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -5,7 +5,7 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
     override fun apply(gradle: Gradle) {
         {{- range .Mirrors }}
         val canBeMirrored{{ .ID }}: Spec<MavenArtifactRepository> =
-            Spec { r -> r.getName().equals({{ .GradleMatch }}) }
+            Spec { r -> {{ .GradleMatch }} }
 
         val useMirror{{ .ID }}: Action<MavenArtifactRepository> = Action {
             val mirrorUrl: String = "{{ .MirrorURL }}"

--- a/cmd/gradle/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/cmd/gradle/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -2,22 +2,13 @@
 apply<InternalRepositoryPlugin>()
 
 class InternalRepositoryPlugin : Plugin<Gradle> {
-    private val logPrefix = "[bitrise-mirrors]"
-
     override fun apply(gradle: Gradle) {
-        println("$logPrefix init script applied")
-
         {{- range .Mirrors }}
         val canBeMirrored{{ .ID }}: Spec<MavenArtifactRepository> =
-            Spec { r ->
-                val matched = {{ .GradleMatch }}
-                println("$logPrefix [{{ .ID }}] check repo name='${r.getName()}' url='${r.getUrl()}' -> matched=$matched")
-                matched
-            }
+            Spec { r -> {{ .GradleMatch }} }
 
         val useMirror{{ .ID }}: Action<MavenArtifactRepository> = Action {
             val mirrorUrl: String = "{{ .MirrorURL }}"
-            println("$logPrefix [{{ .ID }}] rewriting repo name='${getName()}' from '${getUrl()}' to '$mirrorUrl'")
             setUrl(mirrorUrl)
         }
         {{- end }}
@@ -36,33 +27,27 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
             {{- end }}{{ end }}
         }
         gradle.beforeSettings(Action {
-            println("$logPrefix beforeSettings fired")
             configureMirror.execute(getBuildscript().getRepositories())
             // pluginManagement.repositories is empty here, so adding the mirror first
             // makes plugin resolution try it before any repos declared in settings.gradle.
             // Only mirrors flagged ApplyToPluginManagement run here — google's mirror URL is incompatible with Gradle's plugin portal.
             val pmRepos = getPluginManagement().getRepositories()
-            println("$logPrefix beforeSettings: pluginManagement.repositories size before prepend=${pmRepos.size}")
             {{- range .Mirrors }}{{ if .ApplyToPluginManagement }}
             pmRepos.maven {
                 setName("BitriseMirror{{ .ID }}")
                 setUrl("{{ .MirrorURL }}")
             }
-            println("$logPrefix beforeSettings: prepended BitriseMirror{{ .ID }} -> {{ .MirrorURL }}")
             {{- end }}{{ end }}
             configurePluginManagementMirror.execute(pmRepos)
         })
         // Remove the settingsEvaluated part if you are using Gradle <6.8
         gradle.settingsEvaluated(Action {
-            println("$logPrefix settingsEvaluated fired")
             configureMirror.execute(getDependencyResolutionManagement().getRepositories())
         })
         gradle.beforeProject(Action {
-            println("$logPrefix beforeProject fired for project='${getName()}'")
             configureMirror.execute(getBuildscript().getRepositories())
         })
         gradle.afterProject(Action {
-            println("$logPrefix afterProject fired for project='${getName()}'")
             configureMirror.execute(getRepositories())
         })
     }

--- a/cmd/gradle/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/cmd/gradle/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -19,10 +19,17 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                 .configureEach(useMirror{{ .ID }})
             {{- end }}
         }
+        val configurePluginManagementMirror: Action<RepositoryHandler> = Action {
+            {{- range .Mirrors }}{{ if .ApplyToPluginManagement }}
+            withType(MavenArtifactRepository::class.java)
+                .matching(canBeMirrored{{ .ID }})
+                .configureEach(useMirror{{ .ID }})
+            {{- end }}{{ end }}
+        }
         gradle.beforeSettings(Action {
             configureMirror.execute(getBuildscript().getRepositories())
-            // Note: PluginManagement repositories are not configurable because google's mirror URL is not compatible with Gradle's plugin portal
-            //configureMirror.execute(getPluginManagement().getRepositories())
+            // Only mirrors flagged ApplyToPluginManagement run here — google's mirror URL is incompatible with Gradle's plugin portal.
+            configurePluginManagementMirror.execute(getPluginManagement().getRepositories())
         })
         // Remove the settingsEvaluated part if you are using Gradle <6.8
         gradle.settingsEvaluated(Action {

--- a/cmd/gradle/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/cmd/gradle/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -2,13 +2,22 @@
 apply<InternalRepositoryPlugin>()
 
 class InternalRepositoryPlugin : Plugin<Gradle> {
+    private val logPrefix = "[bitrise-mirrors]"
+
     override fun apply(gradle: Gradle) {
+        println("$logPrefix init script applied")
+
         {{- range .Mirrors }}
         val canBeMirrored{{ .ID }}: Spec<MavenArtifactRepository> =
-            Spec { r -> {{ .GradleMatch }} }
+            Spec { r ->
+                val matched = {{ .GradleMatch }}
+                println("$logPrefix [{{ .ID }}] check repo name='${r.getName()}' url='${r.getUrl()}' -> matched=$matched")
+                matched
+            }
 
         val useMirror{{ .ID }}: Action<MavenArtifactRepository> = Action {
             val mirrorUrl: String = "{{ .MirrorURL }}"
+            println("$logPrefix [{{ .ID }}] rewriting repo name='${getName()}' from '${getUrl()}' to '$mirrorUrl'")
             setUrl(mirrorUrl)
         }
         {{- end }}
@@ -27,27 +36,33 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
             {{- end }}{{ end }}
         }
         gradle.beforeSettings(Action {
+            println("$logPrefix beforeSettings fired")
             configureMirror.execute(getBuildscript().getRepositories())
             // pluginManagement.repositories is empty here, so adding the mirror first
             // makes plugin resolution try it before any repos declared in settings.gradle.
             // Only mirrors flagged ApplyToPluginManagement run here — google's mirror URL is incompatible with Gradle's plugin portal.
             val pmRepos = getPluginManagement().getRepositories()
+            println("$logPrefix beforeSettings: pluginManagement.repositories size before prepend=${pmRepos.size}")
             {{- range .Mirrors }}{{ if .ApplyToPluginManagement }}
             pmRepos.maven {
                 setName("BitriseMirror{{ .ID }}")
                 setUrl("{{ .MirrorURL }}")
             }
+            println("$logPrefix beforeSettings: prepended BitriseMirror{{ .ID }} -> {{ .MirrorURL }}")
             {{- end }}{{ end }}
             configurePluginManagementMirror.execute(pmRepos)
         })
         // Remove the settingsEvaluated part if you are using Gradle <6.8
         gradle.settingsEvaluated(Action {
+            println("$logPrefix settingsEvaluated fired")
             configureMirror.execute(getDependencyResolutionManagement().getRepositories())
         })
         gradle.beforeProject(Action {
+            println("$logPrefix beforeProject fired for project='${getName()}'")
             configureMirror.execute(getBuildscript().getRepositories())
         })
         gradle.afterProject(Action {
+            println("$logPrefix afterProject fired for project='${getName()}'")
             configureMirror.execute(getRepositories())
         })
     }

--- a/cmd/gradle/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/cmd/gradle/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -23,13 +23,22 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
             {{- range .Mirrors }}{{ if .ApplyToPluginManagement }}
             withType(MavenArtifactRepository::class.java)
                 .matching(canBeMirrored{{ .ID }})
-                .configureEach(useMirror{{ .ID }})
+                .all(useMirror{{ .ID }})
             {{- end }}{{ end }}
         }
         gradle.beforeSettings(Action {
             configureMirror.execute(getBuildscript().getRepositories())
+            // pluginManagement.repositories is empty here, so adding the mirror first
+            // makes plugin resolution try it before any repos declared in settings.gradle.
             // Only mirrors flagged ApplyToPluginManagement run here — google's mirror URL is incompatible with Gradle's plugin portal.
-            configurePluginManagementMirror.execute(getPluginManagement().getRepositories())
+            val pmRepos = getPluginManagement().getRepositories()
+            {{- range .Mirrors }}{{ if .ApplyToPluginManagement }}
+            pmRepos.maven {
+                setName("BitriseMirror{{ .ID }}")
+                setUrl("{{ .MirrorURL }}")
+            }
+            {{- end }}{{ end }}
+            configurePluginManagementMirror.execute(pmRepos)
         })
         // Remove the settingsEvaluated part if you are using Gradle <6.8
         gradle.settingsEvaluated(Action {

--- a/internal/config/gradle/activate_for_gradle_params.go
+++ b/internal/config/gradle/activate_for_gradle_params.go
@@ -110,10 +110,11 @@ func (params ActivateGradleParams) TemplateInventory(
 	testDistroInventory := params.testDistroTemplateInventory(logger, isDebug)
 
 	return TemplateInventory{
-		Common:     commonInventory,
-		Cache:      cacheInventory,
-		Analytics:  analyticsInventory,
-		TestDistro: testDistroInventory,
+		Common:                commonInventory,
+		Cache:                 cacheInventory,
+		Analytics:             analyticsInventory,
+		TestDistro:            testDistroInventory,
+		MavenCentralMirrorURL: ApacheCentralMirrorURL(envs),
 	}, nil
 }
 

--- a/internal/config/gradle/gradle_init_template_inventory.go
+++ b/internal/config/gradle/gradle_init_template_inventory.go
@@ -50,6 +50,10 @@ type TemplateInventory struct {
 	Cache      CacheTemplateInventory
 	Analytics  AnalyticsTemplateInventory
 	TestDistro TestDistroTemplateInventory
+	// MavenCentralMirrorURL is the Bitrise-hosted apache-central mirror URL,
+	// or "" when the mirror is disabled. Used to route initscript classpath
+	// resolution through the mirror to avoid apache rate-limiting.
+	MavenCentralMirrorURL string
 }
 
 func (inventory TemplateInventory) HasDependencies() bool {

--- a/internal/config/gradle/initd.gradle.kts.gotemplate
+++ b/internal/config/gradle/initd.gradle.kts.gotemplate
@@ -6,6 +6,12 @@ import io.bitrise.gradle.cache.BitriseBuildCacheServiceFactory
 initscript {
     repositories {
         mavenLocal()
+        {{- if .MavenCentralMirrorURL }}
+        maven {
+            name = "bitriseApacheCentralMirror"
+            url = uri("{{ .MavenCentralMirrorURL }}")
+        }
+        {{- end }}
         maven {
             name = "gradlePlugins"
             url = uri("https://plugins.gradle.org/m2/")

--- a/internal/config/gradle/mirror_url.go
+++ b/internal/config/gradle/mirror_url.go
@@ -1,0 +1,35 @@
+package gradleconfig
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+const (
+	// MirrorEnabledEnvKey gates Bitrise-hosted Maven mirror usage. Must equal "true" to enable.
+	MirrorEnabledEnvKey = "BITRISE_MAVENCENTRAL_PROXY_ENABLED"
+	// MirrorDatacenterEnvKey identifies the datacenter, used to build the mirror region slug.
+	MirrorDatacenterEnvKey = "BITRISE_DEN_VM_DATACENTER"
+
+	mirrorURLPattern    = "https://repository-manager-%s.services.bitrise.io:8090/maven/%s"
+	mirrorSegmentApache = "apache-central"
+)
+
+// ApacheCentralMirrorURL returns the Bitrise-hosted apache-central mirror URL
+// for the current datacenter, or "" when the mirror is disabled or no datacenter
+// is set (e.g. local dev).
+func ApacheCentralMirrorURL(envs map[string]string) string {
+	if envs[MirrorEnabledEnvKey] != "true" {
+		return ""
+	}
+
+	dc := envs[MirrorDatacenterEnvKey]
+	if dc == "" {
+		return ""
+	}
+
+	region := strings.TrimRightFunc(strings.ToLower(dc), unicode.IsDigit)
+
+	return fmt.Sprintf(mirrorURLPattern, region, mirrorSegmentApache)
+}


### PR DESCRIPTION
## Summary

Adds an `apache-central` Bitrise mirror for `https://repo.maven.apache.org/maven2`, applied to both project dependency repositories AND `pluginManagement.repositories`. The earlier name-only matcher missed explicit `maven { url = ... }` declarations and missed pluginManagement entirely; this PR fixes both.

### Changes

- **New `mavencentral-apache` mirror entry** in `KnownMirrors` (URL segment `apache-central`). Predicate matches by repo URL: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`.
- **`RepoMirror.GradleMatch`** is now the full Kotlin predicate body (using `r` as the repo) instead of just the equals argument, so URL-based and name-based matchers can coexist.
- **`RepoMirror.ApplyToPluginManagement`** flag — only `apache-central` sets it. The other mirrors (`google`, `mavencentral`) stay out of `pluginManagement.repositories` because their underlying mirror URLs are not compatible with Gradle plugin lookups.
- **Mirror order**: `apache-central` is listed first so its URL-based predicate runs before the name-based `mavencentral` entry.
- **pluginManagement strategy** (in the rendered init script):
  - In `gradle.beforeSettings`, **prepend** a Maven repository pointing at the `apache-central` mirror to `pluginManagement.repositories` (the list is empty at that point, so the first add becomes index 0). Plugin resolution will hit the mirror before falling through to repos declared in `settings.gradle`.
  - The `configureEach` rewrite on pluginManagement was switched to **`.all`** (eager) so URL rewrites fire when a repo is added, not on lazy realization — needed because plugin resolution issues HTTP requests as soon as repos are added.
- Test refactor: `activate_gradle_mirrors_test.go` now looks up mirrors by `FlagName` instead of positional index, so reorders don't break tests.

## Test plan

- [x] `make lint` clean
- [x] `make test-unit` clean
- [ ] Verify on a Bitrise build with `BITRISE_MAVENCENTRAL_PROXY_ENABLED=true` against duckduckgo (workflow `e2e-mavencentral-mirror-duckduck`):
  - No direct HTTP requests to `repo.maven.apache.org/maven2`
  - Plugin resolution requests routed through `/maven/apache-central` (or `/maven/central` / `/maven/google` for the existing matchers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)