### PR TITLE
fix: preserve gradlePluginPortal in pluginManagement after mirror prepend

### DIFF
--- a/cmd/gradle/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/cmd/gradle/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -38,6 +38,12 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                 setUrl("{{ .MirrorURL }}")
             }
             {{- end }}{{ end }}
+            // Adding any repo above suppresses Gradle's default
+            // pluginManagement.repositories = [gradlePluginPortal()] for projects without
+            // an explicit pluginManagement {} block. Re-add it explicitly so plugin
+            // resolution can fall back to the portal when the prepended mirrors don't
+            // serve the artifact (e.g. plugins that aren't on maven central).
+            pmRepos.gradlePluginPortal()
             configurePluginManagementMirror.execute(pmRepos)
         })
         // Remove the settingsEvaluated part if you are using Gradle <6.8


### PR DESCRIPTION
## Summary

Fixes a regression introduced in v2.3.1+ (#291) where the gradle-mirrors init script broke plugin resolution for projects without an explicit `pluginManagement {}` block in `settings.gradle.kts`.

### Root cause

In `gradle.beforeSettings`, the init script prepends a maven repo (`BitriseMirrorApacheCentral`) to `pluginManagement.repositories`. Gradle normally auto-fills the default `[gradlePluginPortal()]` only when `pluginManagement.repositories` is **empty** at first read. By adding our mirror programmatically, the list is no longer empty → Gradle skips the auto-default → `gradlePluginPortal()` is never present → plugins that only live on plugins.gradle.org (e.g. `org.gradle.kotlin.kotlin-dsl`, `com.github.gmazzo.buildconfig`) become unresolvable.

### Fix

After prepending the mirror, explicitly call `pmRepos.gradlePluginPortal()`. Gradle's `RepositoryHandler` dedupes by repo name (`Gradle Central Plugin Repository`), so this is a no-op for projects that already declare `gradlePluginPortal()` in their `pluginManagement {}` block.

```kotlin
val pmRepos = getPluginManagement().getRepositories()
pmRepos.maven { setName("BitriseMirrorApacheCentral"); setUrl("...apache-central") }
pmRepos.gradlePluginPortal()  // <-- preserve Gradle's default that was implicitly suppressed
configurePluginManagementMirror.execute(pmRepos)
```

### Hit by

- [myfitnesspal/mfp-android build d2814fc4](https://app.bitrise.io/app/b01fa7cd213aa2b1/build/d2814fc4-4b7f-4bf1-9665-30a71fe2b4f8) — `Plugin [id: 'org.gradle.kotlin.kotlin-dsl', version: '5.2.0'] was not found... Searched in the following repositories: BitriseMirrorApacheCentral` (only the apache-central mirror was searched; `gradlePluginPortal` was missing).

## Test plan

- [x] `make lint` clean
- [x] `make test-unit` clean
- [ ] Re-run mfp-android PR — plugin resolution should now succeed (apache-central tried first, then gradlePluginPortal as fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)