### PR TITLE
feat: allowlist supported datacenters for gradle-mirrors activation

### DIFF
--- a/internal/config/gradle/mirrors/activate.go
+++ b/internal/config/gradle/mirrors/activate.go
@@ -59,6 +59,11 @@ func Activate(logger log.Logger, osProxy utils.OsProxy, params Params) error {
 	}
 
 	region := DatacenterToRegion(params.Datacenter)
+	if !IsSupportedRegion(region) {
+		logger.Infof("Datacenter %q (region %q) has no Bitrise mirror deployment, skipping Gradle mirror activation", params.Datacenter, region)
+
+		return nil
+	}
 
 	entries := make([]templateEntry, 0, len(params.Mirrors))
 	for _, m := range params.Mirrors {

--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -54,6 +54,11 @@ func TestActivate(t *testing.T) {
 			expectCreated: false,
 		},
 		{
+			name:          "unsupported datacenter",
+			params:        mirrors.Params{Enabled: true, Datacenter: "ATL1", Mirrors: allMirrors},
+			expectCreated: false,
+		},
+		{
 			name:          "AMS1 all mirrors",
 			params:        mirrors.Params{Enabled: true, Datacenter: "AMS1", Mirrors: allMirrors},
 			expectCreated: true,
@@ -150,5 +155,19 @@ func TestDatacenterToRegion(t *testing.T) {
 
 	for in, want := range cases {
 		assert.Equal(t, want, mirrors.DatacenterToRegion(in), "input=%q", in)
+	}
+}
+
+func TestIsSupportedRegion(t *testing.T) {
+	cases := map[string]bool{
+		"iad": true,
+		"ord": true,
+		"ams": true,
+		"atl": false,
+		"":    false,
+	}
+
+	for in, want := range cases {
+		assert.Equal(t, want, mirrors.IsSupportedRegion(in), "input=%q", in)
 	}
 }

--- a/internal/config/gradle/mirrors/mirror.go
+++ b/internal/config/gradle/mirrors/mirror.go
@@ -71,3 +71,19 @@ func DatacenterToRegion(dc string) string {
 
 	return strings.TrimRightFunc(lower, unicode.IsDigit)
 }
+
+// SupportedRegions lists the datacenter region slugs that have a Bitrise mirror
+// deployed. Datacenters outside this set are skipped during activation.
+var SupportedRegions = []string{"iad", "ord", "ams"} //nolint:gochecknoglobals
+
+// IsSupportedRegion reports whether the given region slug (e.g. "iad") has a
+// Bitrise mirror deployment.
+func IsSupportedRegion(region string) bool {
+	for _, r := range SupportedRegions {
+		if r == region {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## Summary
- Only `IAD*`/`ORD*`/`AMS*` datacenters have a Bitrise mirror deployment, so restrict mirror activation to those.
- Other datacenters (e.g. `ATL1`) now log an info message and skip activation gracefully instead of writing an init script that points at a non-existent mirror host.
- Added `SupportedRegions` / `IsSupportedRegion` helper next to `DatacenterToRegion` and a corresponding skip branch in `Activate`.

## Test plan
- [x] `go test -tags unit -race ./internal/config/gradle/mirrors/...`
- [x] `make test-unit`
- [x] `make lint`
- [x] New `TestActivate` case for unsupported DC (`ATL1`) asserts no init script is written
- [x] New `TestIsSupportedRegion` covers iad/ord/ams/atl/empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)