### PR TITLE
feat: robolectric repo mirror + gate gradle-plugins URL on supported regions

### DIFF
--- a/internal/config/gradle/mirror_url.go
+++ b/internal/config/gradle/mirror_url.go
@@ -2,8 +2,8 @@ package gradleconfig
 
 import (
 	"fmt"
-	"strings"
-	"unicode"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors"
 )
 
 const (
@@ -18,7 +18,9 @@ const (
 
 // GradlePluginsMirrorURL returns the Bitrise-hosted gradle-plugins mirror URL
 // (proxying https://plugins.gradle.org/m2/) for the current datacenter, or ""
-// when the mirror is disabled or no datacenter is set (e.g. local dev).
+// when the mirror is disabled, no datacenter is set (e.g. local dev), or the
+// datacenter is outside the regions where a Bitrise mirror is deployed
+// (e.g. customer-private GCP envs like US_EAST4).
 func GradlePluginsMirrorURL(envs map[string]string) string {
 	if envs[MirrorEnabledEnvKey] != "true" {
 		return ""
@@ -29,7 +31,10 @@ func GradlePluginsMirrorURL(envs map[string]string) string {
 		return ""
 	}
 
-	region := strings.TrimRightFunc(strings.ToLower(dc), unicode.IsDigit)
+	region := mirrors.DatacenterToRegion(dc)
+	if !mirrors.IsSupportedRegion(region) {
+		return ""
+	}
 
 	return fmt.Sprintf(mirrorURLPattern, region, mirrorSegmentGradlePlugins)
 }

--- a/internal/config/gradle/mirror_url_test.go
+++ b/internal/config/gradle/mirror_url_test.go
@@ -1,0 +1,45 @@
+package gradleconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGradlePluginsMirrorURL(t *testing.T) {
+	cases := map[string]struct {
+		envs map[string]string
+		want string
+	}{
+		"disabled": {
+			envs: map[string]string{MirrorDatacenterEnvKey: "AMS1"},
+			want: "",
+		},
+		"enabled but no datacenter": {
+			envs: map[string]string{MirrorEnabledEnvKey: "true"},
+			want: "",
+		},
+		"AMS1": {
+			envs: map[string]string{MirrorEnabledEnvKey: "true", MirrorDatacenterEnvKey: "AMS1"},
+			want: "https://repository-manager-ams.services.bitrise.io:8090/maven/gradle-plugins",
+		},
+		"IAD1": {
+			envs: map[string]string{MirrorEnabledEnvKey: "true", MirrorDatacenterEnvKey: "IAD1"},
+			want: "https://repository-manager-iad.services.bitrise.io:8090/maven/gradle-plugins",
+		},
+		"unsupported ATL1": {
+			envs: map[string]string{MirrorEnabledEnvKey: "true", MirrorDatacenterEnvKey: "ATL1"},
+			want: "",
+		},
+		"unsupported customer-private GCP US_EAST4": {
+			envs: map[string]string{MirrorEnabledEnvKey: "true", MirrorDatacenterEnvKey: "US_EAST4"},
+			want: "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, GradlePluginsMirrorURL(tc.envs))
+		})
+	}
+}

--- a/internal/config/gradle/mirrors/activate.go
+++ b/internal/config/gradle/mirrors/activate.go
@@ -30,6 +30,7 @@ type templateEntry struct {
 	GradleMatch             string
 	MirrorURL               string
 	ApplyToPluginManagement bool
+	UseAsRobolectricRepo    bool
 }
 
 type templateData struct {
@@ -73,6 +74,7 @@ func Activate(logger log.Logger, osProxy utils.OsProxy, params Params) error {
 			GradleMatch:             m.GradleMatch,
 			MirrorURL:               url,
 			ApplyToPluginManagement: m.ApplyToPluginManagement,
+			UseAsRobolectricRepo:    m.UseAsRobolectricRepo,
 		})
 		logger.Debugf("Mirror %s: region=%s, URL=%s", m.FlagName, region, url)
 	}

--- a/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -56,5 +56,12 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
         gradle.afterProject(Action {
             configureMirror.execute(getRepositories())
         })
+{{- range .Mirrors }}{{- if eq .ID "Central" }}
+        gradle.afterProject(Action {
+            tasks.withType(Test::class.java).configureEach {
+                systemProperty("robolectric.dependency.repo.url", "{{ .MirrorURL }}")
+            }
+        })
+{{- end }}{{- end }}
     }
 }

--- a/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -56,12 +56,12 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
         gradle.afterProject(Action {
             configureMirror.execute(getRepositories())
         })
-{{- range .Mirrors }}{{- if eq .ID "Central" }}
+        {{- range .Mirrors }}{{ if .UseAsRobolectricRepo }}
         gradle.afterProject(Action {
             tasks.withType(Test::class.java).configureEach {
                 systemProperty("robolectric.dependency.repo.url", "{{ .MirrorURL }}")
             }
         })
-{{- end }}{{- end }}
+        {{- end }}{{ end }}
     }
 }

--- a/internal/config/gradle/mirrors/mirror.go
+++ b/internal/config/gradle/mirrors/mirror.go
@@ -15,6 +15,7 @@ type RepoMirror struct {
 	URLSegment              string // last path segment in the mirror URL, e.g. "central"
 	GradleMatch             string // Kotlin predicate body (using `r` as the repo) that decides whether the repo should be mirrored
 	ApplyToPluginManagement bool   // also apply this mirror to pluginManagement.repositories
+	UseAsRobolectricRepo    bool   // also expose this mirror via the robolectric.dependency.repo.url system property on Test tasks
 }
 
 // KnownMirrors is the registry of supported mirrors.
@@ -22,7 +23,7 @@ type RepoMirror struct {
 // (e.g. apache-central) must run before name-based ones that overwrite the URL.
 var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
 	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`, ApplyToPluginManagement: true},
-	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: `r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME) || r.getUrl().toString().trimEnd('/') in setOf("https://repo1.maven.org/maven2", "https://jcenter.bintray.com")`},
+	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: `r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME) || r.getUrl().toString().trimEnd('/') in setOf("https://repo1.maven.org/maven2", "https://jcenter.bintray.com")`, UseAsRobolectricRepo: true},
 	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
 }
 


### PR DESCRIPTION
## Summary

Two related changes to the gradle-mirrors path:

1. **Robolectric installation through the Bitrise Maven Central mirror.** Robolectric resolves its Android SDK jars at test time via the `robolectric.dependency.repo.url` system property; without overriding that, the Test task hits Maven Central directly even when the rest of the build is mirrored. Added a `UseAsRobolectricRepo bool` flag on `RepoMirror` and an `afterProject` block in the init template that sets `robolectric.dependency.repo.url` on every `Test` task to the matching mirror URL. The `mavencentral` mirror opts in via the new flag — previous draft of this used `{{ if eq .ID "Central" }}` partial matching on the template ID, replaced with the explicit boolean (mirroring the existing `ApplyToPluginManagement` pattern).

2. **Gate `GradlePluginsMirrorURL` on the supported-region allowlist.** `internal/config/gradle/mirror_url.go` was building `repository-manager-<region>...` URLs from any datacenter, bypassing the allowlist that `internal/config/gradle/mirrors.Activate` already honors. On customer-private GCP environments (e.g. `US_EAST4`) this emitted `repository-manager-us_east.services.bitrise.io:8090` into the build-cache init script's `pluginManagement.maven { url = uri(...) }` block, and the customer's GCP network couldn't reach that host — `Connect timed out`. The CLI v2.4.1 allowlist (PR #296) correctly skipped the standalone `activate-gradle-mirrors` step but didn't cover this code path. Now both paths share `mirrors.DatacenterToRegion` + `mirrors.IsSupportedRegion`, so unsupported DCs cleanly produce no mirror URL.

## Test plan

- [x] `make test-unit`
- [x] `make lint`
- [x] New `TestGradlePluginsMirrorURL` covers `AMS1` / `IAD1` (mirror URL emitted), `ATL1` and `US_EAST4` (empty), disabled, and missing-DC.
- [x] Existing `mirrors.TestActivate` cases still pass — robolectric block now keys off `UseAsRobolectricRepo` and is generated only for `mavencentral`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)