### PR TITLE
ACI-4867 feat: mirror jitpack.io

### DIFF
--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -65,6 +65,9 @@ func TestActivate(t *testing.T) {
 			expectContains: []string{
 				"https://repository-manager-ams.services.bitrise.io:8090/maven/central",
 				"https://repository-manager-ams.services.bitrise.io:8090/maven/google",
+				"https://repository-manager-ams.services.bitrise.io:8090/maven/jitpack",
+				`"https://jitpack.io"`,
+				`"https://www.jitpack.io"`,
 			},
 		},
 		{

--- a/internal/config/gradle/mirrors/mirror.go
+++ b/internal/config/gradle/mirrors/mirror.go
@@ -25,6 +25,7 @@ var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
 	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`, ApplyToPluginManagement: true},
 	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: `r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME) || r.getUrl().toString().trimEnd('/') in setOf("https://repo1.maven.org/maven2", "https://jcenter.bintray.com")`, UseAsRobolectricRepo: true},
 	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
+	{FlagName: "jitpack", TemplateID: "JitPack", URLSegment: "jitpack", GradleMatch: `r.getUrl().toString().trimEnd('/') in setOf("https://jitpack.io", "https://www.jitpack.io")`},
 }
 
 //go:embed asset/gradle-mirrors.init.gradle.kts.gotemplate


### PR DESCRIPTION
## Summary
- Add `jitpack` entry to `KnownMirrors` so repos declared with URL `https://jitpack.io` (or `https://www.jitpack.io`) are redirected to the Bitrise jitpack mirror.
- New cobra flag `--jitpack` registers automatically via the existing `init()` loop.

## Why
JitPack is rate-limited per anonymous IP and slow on cache miss (builds artifacts from GitHub on demand). Many React Native third-party libraries declare jitpack in their own `node_modules/<lib>/android/build.gradle`, e.g. `maven { url 'https://www.jitpack.io' }`. Those repos leak past existing `mavencentral` / `google` / `gradle-plugin-portal` mirror predicates and hit jitpack directly under high CI load.

## Notes
- Mirror URL segment is `jitpack` — must match the path Bitrise infra serves at `repository-manager-{region}.services.bitrise.io:8090/maven/<segment>`. Confirm with infra before merging.
- Predicate matches by URL only (no name match) — jitpack repos are typically declared via `maven { url ... }` with no fixed name.
- `ApplyToPluginManagement: false` — jitpack is rarely used for plugin classpath; keep pluginManagement scope unchanged.
- Both `https://jitpack.io` and `https://www.jitpack.io` covered (both forms appear in the wild).

## Test plan
- [ ] Confirm Bitrise infra serves a jitpack mirror at the expected URL segment
- [ ] Run an Android RN build that pulls a jitpack-hosted artifact — verify the request hits the mirror, not jitpack.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)