### PR TITLE
ci: attach verification-metadata-mirror.xml to GitHub releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,7 @@ release:
     For reference, the verification metadata is available as an attached assset.
   extra_files:
     - glob: ./cmd/gradle/asset/verification-metadata.xml
+    - glob: ./cmd/gradle/asset/verification-metadata-mirror.xml
 
 
 before:


### PR DESCRIPTION
## Summary

PR #301 started generating `cmd/gradle/asset/verification-metadata-mirror.xml` in the CI bundle, but the `.goreleaser.yaml` `extra_files` list still only references the origin asset, so v2.4.5 published with only `verification-metadata.xml` attached to the GitHub release. This adds the mirror file so future releases attach both reference XMLs.

## Why

Customers using Gradle dependency verification with the Bitrise Maven mirror active (the default for all Android builds since the mirror auto-activation rollout) need the mirror-specific checksums; the plain origin metadata fails verification when the mirror serves the artifacts. Having the file on the release page lets them grab it the same way they grab `verification-metadata.xml` today.

## Test plan

- [ ] After merge + new release, GitHub release page lists both `verification-metadata.xml` and `verification-metadata-mirror.xml` as assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)