### PR TITLE
ACI-4869 feat: log CLI version on each entry point

### DIFF
--- a/cmd/common/activate.go
+++ b/cmd/common/activate.go
@@ -1,8 +1,10 @@
 package common
 
 import (
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/common/childstats"
 )
 
@@ -13,6 +15,10 @@ var ActivateCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Long: `Activate Gradle, Bazel, etc. plugins
 Call the subcommands with the name of the tool you want to activate plugins for.`,
 	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		// Cobra runs only the closest ancestor PersistentPreRun, so this overrides
+		// RootCmd's CLI-version log line — re-emit it here.
+		configcommon.LogCLIVersion(log.NewLogger(log.WithDebugLog(IsDebugLogMode)))
+
 		// Opportunistic sweep of stale child-invocation ledger dirs.
 		// Best-effort: failures must not block activation.
 		_ = childstats.Sweep(childstats.DefaultSweepTTL)

--- a/cmd/common/root.go
+++ b/cmd/common/root.go
@@ -3,7 +3,10 @@ package common
 import (
 	"os"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
+
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -19,6 +22,14 @@ It creates the necessary config to enable Build Cache and Command Exec/Invocatio
 In case of Gradle it's done via creating or modifying the following two files: $HOME/.gradle/init.d/bitrise-build-cache.init.gradle and $HOME/.gradle/gradle.properties (adding org.gradle.caching=true to gradle.properties).
 
 In case of Bazel it's done via creating or modifying $HOME/.bazelrc.`,
+	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+		// `version` already prints the CLI version itself; skip the duplicate log line.
+		if cmd.Name() == "version" {
+			return
+		}
+
+		configcommon.LogCLIVersion(log.NewLogger(log.WithDebugLog(IsDebugLogMode)))
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/config/common/cli_version.go
+++ b/internal/config/common/cli_version.go
@@ -30,3 +30,11 @@ func GetCLIVersion(logger log.Logger) string {
 
 	return modules[idx].Version
 }
+
+// LogCLIVersion writes a single info-level log line with the resolved CLI
+// version. Call it from public entry points (cobra root PersistentPreRun,
+// pkg/* Activator/Runner methods) so each invocation records which CLI the
+// caller is running.
+func LogCLIVersion(logger log.Logger) {
+	logger.Infof("Bitrise Build Cache CLI version: %s", GetCLIVersion(logger))
+}

--- a/internal/config/common/cli_version.go
+++ b/internal/config/common/cli_version.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"fmt"
+	"os"
 	"runtime/debug"
 	"slices"
 	"strings"
@@ -31,10 +33,13 @@ func GetCLIVersion(logger log.Logger) string {
 	return modules[idx].Version
 }
 
-// LogCLIVersion writes a single info-level log line with the resolved CLI
-// version. Call it from public entry points (cobra root PersistentPreRun,
-// pkg/* Activator/Runner methods) so each invocation records which CLI the
-// caller is running.
+// LogCLIVersion writes a single line with the resolved CLI version to STDERR.
+// Stderr (not stdout) is intentional: some callers — e.g. xcodebuild wrappers
+// fronted by `@react-native-community/cli-platform-apple` — parse the CLI's
+// stdout as JSON. Writing the version line to stdout breaks that JSON parse.
+// Call this from public entry points (cobra root PersistentPreRun, pkg/*
+// Activator/Runner methods) so each invocation records which CLI the caller
+// is running.
 func LogCLIVersion(logger log.Logger) {
-	logger.Infof("Bitrise Build Cache CLI version: %s", GetCLIVersion(logger))
+	_, _ = fmt.Fprintf(os.Stderr, "Bitrise Build Cache CLI version: %s\n", GetCLIVersion(logger))
 }

--- a/pkg/ccache/activator.go
+++ b/pkg/ccache/activator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
@@ -94,6 +95,7 @@ func NewActivator(params ActivatorParams) *Activator {
 // Activate creates the ccache config and exports the required environment
 // variables via envman.
 func (a *Activator) Activate(ctx context.Context) error {
+	configcommon.LogCLIVersion(a.logger)
 	a.logger.TInfof("Activate Bitrise Build Cache for C++")
 
 	config, err := ccacheconfig.NewConfig(a.envs, a.osProxy, ccacheconfig.Params{

--- a/pkg/ccache/storage_helper.go
+++ b/pkg/ccache/storage_helper.go
@@ -120,6 +120,8 @@ func NewStorageHelper(params StorageHelperParams) (*StorageHelper, error) {
 // that proxies ccache secondary storage requests. It blocks until ctx is
 // cancelled or the configured idle timeout is reached.
 func (h *StorageHelper) Start(ctx context.Context) error {
+	configcommon.LogCLIVersion(h.logger)
+
 	kvClient, err := createKVClient(ctx, h.config, h.params.Envs, h.params.InvocationID)
 	if err != nil {
 		return fmt.Errorf("create KV client: %w", err)

--- a/pkg/gradle/mirrors/activator.go
+++ b/pkg/gradle/mirrors/activator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
@@ -116,6 +117,7 @@ func NewActivator(params ActivatorParams) *Activator {
 // env var), or when no datacenter is available, Activate logs the reason and
 // returns nil.
 func (a *Activator) Activate(_ context.Context) error {
+	configcommon.LogCLIVersion(a.logger)
 	a.logger.TInfof("Activate Bitrise mirrors for Gradle")
 
 	gradleHome, err := a.pathModifier.AbsPath(a.gradleHome)

--- a/pkg/reactnative/activator.go
+++ b/pkg/reactnative/activator.go
@@ -84,6 +84,7 @@ func NewActivator(params ActivatorParams) *Activator {
 // Activate runs the full React Native build cache activation flow:
 // install dependencies → activate sub-systems → start storage helper → save config.
 func (a *Activator) Activate(ctx context.Context) error {
+	configcommon.LogCLIVersion(a.logger)
 	a.logger.TInfof("Activate Bitrise Build Cache for React Native")
 
 	if err := installDeps(ctx, a.logger, a.cpp != nil); err != nil {

--- a/pkg/reactnative/runner.go
+++ b/pkg/reactnative/runner.go
@@ -11,6 +11,7 @@ import (
 
 	ccacheipc "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache"
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
@@ -106,6 +107,8 @@ func NewRunner(params RunnerParams) *Runner {
 // Run injects a BITRISE_INVOCATION_ID into environ and delegates execution to ExecFn.
 // If wrapperInvocationID is empty, a random UUID is used.
 func (r *Runner) Run(ctx context.Context, args []string, wrapperInvocationID string, environ []string) error {
+	configcommon.LogCLIVersion(r.logger)
+
 	if wrapperInvocationID == "" {
 		r.logger.TInfof("No invocation ID provided, generating a random one")
 


### PR DESCRIPTION
## Summary
Add a single info-level log line printing the resolved CLI version on every CLI invocation — both binary calls and Go-module library callers (the steps that import the CLI: `bitrise-step-activate-gradle-mirrors`, `steps-install-missing-android-tools`, `steps-gradle-runner`, etc.). Goal: when reading customer-report build logs, immediately know which CLI version is actually running.

## Why
Recently triaged customer issues required correlating CLI behaviour with version, but step logs didn't surface the CLI version anywhere. Adding it explicitly removes that ambiguity.

## How
- New helper `internal/config/common.LogCLIVersion` wrapping the existing `GetCLIVersion` (uses `runtime/debug.ReadBuildInfo` to look up either the main module — binary use — or the `bitrise-build-cache-cli/v2` entry in `BuildInfo.Deps` — library use). No new build-time injection needed.
- Cobra binary entry: wired into `RootCmd.PersistentPreRun`. The `version` subcommand already prints the CLI version, so we suppress the duplicate log line there. Cobra only runs the closest ancestor `PersistentPreRun`, so the existing `ActivateCmd.PersistentPreRun` was extended too — otherwise `activate ...` subcommands would shadow the root hook and skip the log line.
- Library entry: added the call to public top-level methods used by step repos:
  - `pkg/ccache.Activator.Activate`, `pkg/ccache.StorageHelper.Start`
  - `pkg/reactnative.Activator.Activate`, `pkg/reactnative.Runner.Run`
  - `pkg/gradle/mirrors.Activator.Activate`

## Ticket
ACI-4869 — https://bitrise.atlassian.net/browse/ACI-4869

## Test plan
- [x] `go build ./...` clean
- [x] `make lint` clean
- [x] `go test -tags unit -race ./...` green
- [ ] CI green
- [ ] Verify in a real customer-style step run that the log line appears once per entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)