### PR TITLE
ci: rewrite dependency matrix to iterate CLI releases

### DIFF
--- a/assets/dependency-matrix-header.md
+++ b/assets/dependency-matrix-header.md
@@ -22,6 +22,13 @@ Different consumer steps may bundle different CLI versions, so the plugin versio
 - The remote cache plugin `io.bitrise.gradle:remote-cache` is published to Maven Central and implements the client for the Bitrise remote build cache.
 - The test distribution plugin `io.bitrise.gradle:test-distribution` is published to Maven Central and integrates with Bitrise Test Distribution.
 
-If you want to pin the dependencies (Gradle dependency verification metadata), pin the activating step to a full patch version in your workflow. The matching CLI version's release page also has `verification-metadata.xml` (and `verification-metadata-mirror.xml` from v2.4.6 onward, for builds where the Bitrise Maven Central mirror is active) attached as assets — use it to seed your `gradle/verification-metadata.xml`.
+## Gradle dependency verification
+
+If you use Gradle's [dependency verification](https://docs.gradle.org/current/userguide/dependency_verification.html), pin the activating step to a full patch version in your workflow and seed your `gradle/verification-metadata.xml` from the matching CLI release. Each CLI release page attaches a reference asset:
+
+- `verification-metadata.xml` — checksums for artifacts as served by the original Maven Central / Google / plugin-portal repositories. Use this when the Bitrise Maven Central mirror is **not** active in your workflow.
+- `verification-metadata-mirror.xml` (from `v2.4.6` onward) — checksums for artifacts as served by the **Bitrise Maven Central mirror**. The mirror is on by default for all Bitrise Android builds, so this is the file most workflows need; the plain origin file will fail verification when the mirror serves the artifacts.
+
+For the full setup walkthrough — including which step in your workflow activates the mirror, how to lock that step's version, and how to regenerate the metadata when the CLI is updated — see [Gradle dependency verification for the Maven Central mirror](https://docs.google.com/document/d/1mrquZ-n7dNNmQo0o4ddzY73JTsY5xkYRgRKARoKNFvs/edit).
 
 ## Releases

--- a/assets/dependency-matrix-header.md
+++ b/assets/dependency-matrix-header.md
@@ -1,16 +1,27 @@
-# Gradle Build Cache Step Releases
+# Bitrise Build Cache CLI — Dependency Matrix
 
-This page lists the releases of the [Bitrise Build Cache for Gradle](https://devcenter.bitrise.io/en/dependencies-and-caching/remote-build-caching/remote-build-cache-for-gradle.html) step and relevant dependencies. To start using it, please refer to the linked DevCenter [page](https://devcenter.bitrise.io/en/dependencies-and-caching/remote-build-caching/remote-build-cache-for-gradle.html#configuring-the-bitrise-build-cache-for-gradle-in-the-bitrise-ci-environment).
+This page lists every released version of the [Bitrise Build Cache CLI](https://github.com/bitrise-io/bitrise-build-cache-cli) and the corresponding plugin versions it pins for Gradle builds (Analytics, Remote Cache, Test Distribution).
+
+## Where the CLI runs
+
+The CLI is downloaded and invoked by several Bitrise steps. Pinning any of these steps to a specific patch version effectively pins the CLI version (and therefore the plugin versions) used in your build:
+
+- [Activate Gradle Remote Cache](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache) — `activate-build-cache-for-gradle`
+- [Activate React Native Features](https://github.com/bitrise-steplib/bitrise-step-activate-react-native-features) — `activate-react-native-features` (RN cache)
+- [Activate Gradle Features](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-features) — `activate-gradle-features` (experimental)
+- [Install missing Android SDK components](https://github.com/bitrise-steplib/steps-install-missing-android-tools) — `install-missing-android-tools`
+- [Activate Gradle Mirrors](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-mirrors) — `activate-gradle-mirrors`
+- [Gradle Runner](https://github.com/bitrise-steplib/steps-gradle-runner) — `gradle-runner`
+
+Different consumer steps may bundle different CLI versions, so the plugin versions in your build depend on which step actually runs first in your workflow. To find the CLI version a build used, look at the activating step's log — it prints the CLI version near the top of its section. Then look up that row below.
 
 ## Components
 
-The relationship between the step and the dependencies is as follows:
+- The Bitrise Build Cache CLI ([repository link](https://github.com/bitrise-io/bitrise-build-cache-cli)) supports multiple commands; the relevant one here is `activate gradle` (or `enable-for gradle` in older versions), which writes the Gradle init script `$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts` that pulls in the remote cache, analytics, and test-distribution plugins with the versions listed below.
+- The analytics plugin `io.bitrise.gradle:gradle-analytics` is published to Maven Central and provides build analytics (e.g. [critical path](https://bitrise.io/changelog/enhanced-gradle-critical-path/24815)).
+- The remote cache plugin `io.bitrise.gradle:remote-cache` is published to Maven Central and implements the client for the Bitrise remote build cache.
+- The test distribution plugin `io.bitrise.gradle:test-distribution` is published to Maven Central and integrates with Bitrise Test Distribution.
 
-- The Bitrise Build Cache for Gradle step (`activate-build-cache-for-gradle`, [repository link](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache)) installs a specific version of the CLI.
-- The Bitrise Build Cache CLI ([repository link](https://github.com/bitrise-io/bitrise-build-cache-cli)) supports multiple commands, but the relevant one is `enable-for gradle`, which creates the Gradle init script in `$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts` that pulls in the remote cache and analytics plugins with specific versions for the build.
-- The analytics plugin `io.bitrise.gradle:gradle-analytics` is published to Maven Central and provides build analytics information (e.g., [critical path](https://bitrise.io/changelog/enhanced-gradle-critical-path/24815)).
-- The remote cache plugin `io.bitrise.gradle:remote-cache` is published to Maven Central and implements the client for the Bitrise remote Build Cache.
-
-If you want to pin the dependencies (Gradle verification metadata), you should pin the full (patch) step version in your Bitrise workflows. Then, select the corresponding CLI version and use it to generate the init script before writing the dependency verification metadata. This ensures that the same dependencies are used. Additionally, you can find the verification metadata generated in the CLI releases from v0.15.2 onwards.
+If you want to pin the dependencies (Gradle dependency verification metadata), pin the activating step to a full patch version in your workflow. The matching CLI version's release page also has `verification-metadata.xml` (and `verification-metadata-mirror.xml` from v2.4.6 onward, for builds where the Bitrise Maven Central mirror is active) attached as assets — use it to seed your `gradle/verification-metadata.xml`.
 
 ## Releases

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1146,15 +1146,6 @@ step_bundles:
 
                 pandoc --version
       - script:
-          title: Install go versions
-          inputs:
-            - content: |
-                #!/bin/bash
-                set -ex
-
-                asdf install golang 1.23.8
-                asdf install golang 1.21.5
-      - script:
           title: Generate dependency matrix
           inputs:
             - content: |

--- a/scripts/generate-dependency-matrix.sh
+++ b/scripts/generate-dependency-matrix.sh
@@ -6,86 +6,86 @@ mkdir -p docs
 export RESULT_MD_PATH="docs/dependency-matrix.md"
 export MD_HEADER_PATH="assets/dependency-matrix-header.md"
 export CLI_RELEASE_URL_PREFIX="https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag"
+export CLI_DOWNLOAD_URL_PREFIX="https://github.com/bitrise-io/bitrise-build-cache-cli/releases/download"
 
 export BITRISE_BUILD_CACHE_WORKSPACE_ID=322a005426441b60
+# `activate gradle --test-distribution` requires this; on Bitrise CI it is set automatically.
+export BITRISE_APP_SLUG="${BITRISE_APP_SLUG:-dependency-matrix}"
 
 cat $MD_HEADER_PATH > $RESULT_MD_PATH
 export tmpdir=$(mktemp -d)
 
 pushd $tmpdir
 
-git clone https://github.com/bitrise-io/bitrise-steplib.git
-git clone https://github.com/bitrise-io/bitrise-build-cache-cli.git
-git clone https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache.git
+git clone --filter=blob:none --no-checkout https://github.com/bitrise-io/bitrise-build-cache-cli.git
+cd bitrise-build-cache-cli
+git fetch --tags --no-recurse-submodules origin
+cd ..
 
 export tmp_md="release-table.md"
-echo "| Step version | CLI version | Analytics plugin version | Cache plugin version | Test Distribution plugin version |" >> $tmp_md
-echo "|--------------|-------------|--------------------------|----------------------|----------------------------------|" >> $tmp_md
+echo "| CLI version | Release date | Analytics plugin version | Cache plugin version | Test Distribution plugin version |" >> $tmp_md
+echo "|-------------|--------------|--------------------------|----------------------|----------------------------------|" >> $tmp_md
 
+# List CLI release tags in descending semver order — only stable vMAJOR.MINOR.PATCH (no -rc, -beta etc.).
+cli_versions=$(cd bitrise-build-cache-cli && git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
 
-find "bitrise-steplib/steps/activate-build-cache-for-gradle" -mindepth 1 -maxdepth 1 -type d | while read -r dir; do
-  basename "$dir"
-done |
-sort -Vr | while read -r step_version; do
-  step_commit=$(grep "commit: " "bitrise-steplib/steps/activate-build-cache-for-gradle/$step_version/step.yml" | sed -n -E 's/.*commit: ([a-f0-9]+).*/\1/p')
+for cli_version in $cli_versions; do
+  echo "==== Processing CLI $cli_version ===="
 
-  if [[ -z "$step_commit" ]]; then
-    echo "Step: $step_version does not have a commit"
+  semver_regex='^v([0-9]+)\.([0-9]+)\.([0-9]+)$'
+  if [[ ! $cli_version =~ $semver_regex ]]; then
+    echo "Skipping non-semver tag $cli_version"
+    continue
+  fi
+  major="${BASH_REMATCH[1]}"
+  minor="${BASH_REMATCH[2]}"
+  patch="${BASH_REMATCH[3]}"
+
+  version_no_v="${cli_version#v}"
+  download_url="$CLI_DOWNLOAD_URL_PREFIX/$cli_version/bitrise-build-cache_${version_no_v}_linux_amd64.tar.gz"
+
+  cli_dir=$(mktemp -d)
+  if ! curl --retry 3 -sSfL -o "$cli_dir/cli.tar.gz" "$download_url"; then
+    echo "Could not download $download_url — skipping"
+    rm -rf "$cli_dir"
+    continue
+  fi
+  tar -xzf "$cli_dir/cli.tar.gz" -C "$cli_dir"
+  cli_bin="$cli_dir/bitrise-build-cache"
+  if [ ! -x "$cli_bin" ]; then
+    echo "Binary missing in $cli_dir — skipping"
+    rm -rf "$cli_dir"
     continue
   fi
 
-  echo "Step: $step_version points to step commit $step_commit"
+  # Reset gradle init dir so we only see this version's output.
+  rm -f "$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts"
 
-  cd bitrise-step-activate-gradle-remote-cache
-  git checkout "$step_commit"
-
-  cli_version=$(grep 'export BITRISE_BUILD_CACHE_CLI_VERSION=' "step.sh" | sed -n -E 's/.*="(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/p')
-  echo "CLI version: $cli_version"
-
-  if [[ -z "$cli_version" ]]; then
-      echo "Step: $step_commit does not have a CLI version env var"
-      cd ..
-      continue
-  fi
-
-  cd ../bitrise-build-cache-cli
-  git checkout "$cli_version"
-
-  semver_regex='v?([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z.-]+))?(\+([0-9A-Za-z.-]+))?'
-
-  if [[ $cli_version =~ $semver_regex ]]; then
-    major="${BASH_REMATCH[1]}"
-    minor="${BASH_REMATCH[2]}"
-    patch="${BASH_REMATCH[3]}"
+  # Match the historical command-name change: `activate gradle` exists from v0.16.10 onwards.
+  if (( major > 0 )) || (( major == 0 && minor > 16 )) || (( major == 0 && minor == 16 && patch >= 10 )); then
+    "$cli_bin" activate gradle --cache --test-distribution -d || true
   else
-    echo "No semantic version found"
-    exit 1
+    "$cli_bin" enable-for gradle || true
   fi
 
-  if (( major > 0 )); then
-    go run main.go activate gradle --cache --test-distribution -d
-  elif (( major == 0 && minor > 16 )); then
-    go run main.go activate gradle --cache --test-distribution -d
-  elif (( major == 0 && minor == 16 && patch >= 10 )); then
-    go run main.go activate gradle --cache --test-distribution -d
-  else
-    go run main.go enable-for gradle
-  fi
-
-  if [ ! -f "$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts" ]; then
-    echo "Gradle build cache not enabled in $HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts"
-    cd ..
+  init_script="$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts"
+  if [ ! -f "$init_script" ]; then
+    echo "Init script not generated for $cli_version — skipping"
+    rm -rf "$cli_dir"
     continue
   fi
 
-  analytics_version=$(grep 'classpath("io.bitrise.gradle:gradle-analytics:' "$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts" | sed -n -E 's/.*gradle-analytics:([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
-  cache_version=$(grep 'classpath("io.bitrise.gradle:remote-cache:' "$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts" | sed -n -E 's/.*remote-cache:([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
-  test_distro_version=$(grep 'classpath("io.bitrise.gradle:test-distribution:' "$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts" | sed -n -E 's/.*test-distribution:([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
+  analytics_version=$(grep 'classpath("io.bitrise.gradle:gradle-analytics:' "$init_script" | sed -n -E 's/.*gradle-analytics:([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
+  cache_version=$(grep 'classpath("io.bitrise.gradle:remote-cache:' "$init_script" | sed -n -E 's/.*remote-cache:([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
+  test_distro_version=$(grep 'classpath("io.bitrise.gradle:test-distribution:' "$init_script" | sed -n -E 's/.*test-distribution:([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
 
-  echo "Gradle build cache enabled with analytics version: $analytics_version, cache version: $cache_version, test-distribution version: $test_distro_version"
-  cd ..
+  release_date=$(cd bitrise-build-cache-cli && git log -1 --format=%as "$cli_version")
 
-  echo "| $step_version | [$cli_version]($CLI_RELEASE_URL_PREFIX/$cli_version) | $analytics_version | $cache_version | $test_distro_version |" >> $tmp_md
+  echo "$cli_version → analytics=$analytics_version cache=$cache_version test-distro=$test_distro_version (released $release_date)"
+
+  echo "| [$cli_version]($CLI_RELEASE_URL_PREFIX/$cli_version) | $release_date | ${analytics_version:--} | ${cache_version:--} | ${test_distro_version:--} |" >> $tmp_md
+
+  rm -rf "$cli_dir"
 done
 
 popd


### PR DESCRIPTION
## Summary

The dependency matrix used to walk step.yml versions in `bitrise-steplib/steps/activate-build-cache-for-gradle` and resolve each step version back to the CLI it shipped. That worked when only one step bundled the CLI, but the CLI is now embedded in several steps (Activate Gradle Remote Cache, Activate Gradle Mirrors, Activate React Native Features, Activate Gradle Features, Install Missing Android Tools, Gradle Runner) and they can ship different CLI versions independently. A step-indexed matrix only covers one installer and silently misses the rest.

Pivot the matrix to be CLI-release-indexed:

- For each stable `vMAJOR.MINOR.PATCH` CLI tag, download the `linux_amd64` release binary, run `activate gradle --cache --test-distribution -d` (or `enable-for gradle` on pre-`0.16.10` releases), and parse the generated init script for the Analytics / Remote Cache / Test Distribution plugin versions.
- Emit one row per CLI release with the release date.

Also drops the steplib clone, the gradle-step clone, and the asdf go installs from the workflow — we now run release binaries instead of `go run main.go`.

## Header

Rewritten to list all six consumer step repos and their links so users can find their installer regardless of which step the workflow uses, plus a callout that the matching CLI release page also has `verification-metadata.xml` (and `verification-metadata-mirror.xml` from v2.4.6+) attached for projects using Gradle dependency verification.

## Test plan

- [x] Smoke-tested locally on `v2.4.7`, `v2.4.6`, `v2.0.0`, and `v0.16.10` — all produce the expected init script and parse cleanly.
- [ ] CI run regenerates `docs/dependency-matrix.md` on `gh-pages` and the rendered page lists every CLI release with non-empty plugin columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)