### PR TITLE
ACI-4870 feat: warn at gradle-mirrors activation when scripts use apply(from = ...)

### DIFF
--- a/internal/config/gradle/mirrors/activate.go
+++ b/internal/config/gradle/mirrors/activate.go
@@ -19,10 +19,11 @@ const DatacenterEnvKey = "BITRISE_DEN_VM_DATACENTER"
 
 // Params bundles the inputs needed to write the Gradle mirrors init script.
 type Params struct {
-	GradleHome string       // absolute path to the Gradle home (e.g. ~/.gradle expanded)
-	Mirrors    []RepoMirror // mirrors to install
-	Datacenter string       // datacenter (e.g. "AMS1") used to build the mirror URL
-	Enabled    bool         // when false, Activate is a no-op
+	GradleHome  string       // absolute path to the Gradle home (e.g. ~/.gradle expanded)
+	Mirrors     []RepoMirror // mirrors to install
+	Datacenter  string       // datacenter (e.g. "AMS1") used to build the mirror URL
+	Enabled     bool         // when false, Activate is a no-op
+	ProjectRoot string       // project root scanned for scope-gap warnings; empty disables scanning
 }
 
 type templateEntry struct {
@@ -102,6 +103,10 @@ func Activate(logger log.Logger, osProxy utils.OsProxy, params Params) error {
 	}
 
 	logger.Infof("Gradle mirrors activated")
+
+	if params.ProjectRoot != "" {
+		LogScopeGapWarnings(logger, osProxy, params.ProjectRoot)
+	}
 
 	return nil
 }

--- a/internal/config/gradle/mirrors/scope_gap.go
+++ b/internal/config/gradle/mirrors/scope_gap.go
@@ -1,0 +1,74 @@
+package mirrors
+
+import (
+	"path/filepath"
+	"regexp"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+)
+
+// gradleScriptCandidates are the script files scanned at activation time.
+// We check the project root + the conventional Android `app/` module dir.
+// Anything declared inside `apply(from = ...)`-loaded scripts' own
+// buildscript {} blocks is invisible to the init script — those scripts'
+// ScriptHandler instances are not reachable from gradle.beforeSettings or
+// gradle.beforeProject hooks. Surfacing the file makes the gap actionable.
+//
+//nolint:gochecknoglobals
+var gradleScriptCandidates = []string{
+	"settings.gradle",
+	"settings.gradle.kts",
+	"build.gradle",
+	"build.gradle.kts",
+	filepath.Join("app", "build.gradle"),
+	filepath.Join("app", "build.gradle.kts"),
+}
+
+//nolint:gochecknoglobals
+var (
+	applyFromKotlinRe = regexp.MustCompile(`apply\s*\(\s*from\s*=`)
+	applyFromGroovyRe = regexp.MustCompile(`\bapply\s+from\s*:`)
+)
+
+// LogScopeGapWarnings scans the project for Gradle scripts that pull in other
+// scripts via `apply(from = ...)`. Repositories declared inside those applied
+// scripts' own buildscript {} blocks are not redirected by the mirror init
+// script, so dependencies they resolve still hit the upstream repo and may
+// fail with rate limits or verification mismatches.
+func LogScopeGapWarnings(logger log.Logger, osProxy utils.OsProxy, projectRoot string) {
+	hits := scanForApplyFrom(osProxy, projectRoot)
+	if len(hits) == 0 {
+		return
+	}
+
+	logger.Warnf("Detected %d Gradle script(s) using `apply(from = ...)`:", len(hits))
+
+	for _, h := range hits {
+		logger.Warnf("  - %s", h)
+	}
+
+	logger.Warnf("Bitrise repository mirrors do NOT cover repositories declared inside applied scripts' own buildscript {} blocks.")
+	logger.Warnf("If those scripts declare e.g. mavenCentral() in a buildscript {} block, dependencies fetched from there go to the upstream repo and may hit rate limits or verification failures.")
+	logger.Warnf("Recommended: move plugin classpath into settings.gradle.kts pluginManagement {}, which the mirror covers.")
+}
+
+func scanForApplyFrom(osProxy utils.OsProxy, projectRoot string) []string {
+	var hits []string
+
+	for _, name := range gradleScriptCandidates {
+		path := filepath.Join(projectRoot, name)
+
+		content, ok, err := osProxy.ReadFileIfExists(path)
+		if err != nil || !ok {
+			continue
+		}
+
+		if applyFromKotlinRe.MatchString(content) || applyFromGroovyRe.MatchString(content) {
+			hits = append(hits, path)
+		}
+	}
+
+	return hits
+}

--- a/internal/config/gradle/mirrors/scope_gap_test.go
+++ b/internal/config/gradle/mirrors/scope_gap_test.go
@@ -1,0 +1,137 @@
+//go:build unit
+
+package mirrors_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+)
+
+func TestLogScopeGapWarnings(t *testing.T) {
+	tests := []struct {
+		name           string
+		files          map[string]string
+		expectWarnings bool
+		expectFiles    []string
+	}{
+		{
+			name:           "empty project — no warnings",
+			files:          map[string]string{},
+			expectWarnings: false,
+		},
+		{
+			name: "settings.gradle.kts with apply(from = ...) — warns",
+			files: map[string]string{
+				"settings.gradle.kts": `apply(from = "shared.gradle.kts")` + "\n",
+			},
+			expectWarnings: true,
+			expectFiles:    []string{"settings.gradle.kts"},
+		},
+		{
+			name: "settings.gradle.kts without apply from — no warning",
+			files: map[string]string{
+				"settings.gradle.kts": `pluginManagement {}` + "\n",
+			},
+			expectWarnings: false,
+		},
+		{
+			name: "Groovy apply from: form — warns",
+			files: map[string]string{
+				"settings.gradle": `apply from: 'shared.gradle'` + "\n",
+			},
+			expectWarnings: true,
+			expectFiles:    []string{"settings.gradle"},
+		},
+		{
+			name: "app/build.gradle.kts with apply(from = ...) — warns",
+			files: map[string]string{
+				filepath.Join("app", "build.gradle.kts"): `apply(from = uri("https://example.com/x.gradle.kts"))` + "\n",
+			},
+			expectWarnings: true,
+			expectFiles:    []string{filepath.Join("app", "build.gradle.kts")},
+		},
+		{
+			name: "multiple files with apply from — all reported",
+			files: map[string]string{
+				"settings.gradle.kts":                    `apply(from = "x.gradle.kts")` + "\n",
+				filepath.Join("app", "build.gradle.kts"): `apply(from = "y.gradle.kts")` + "\n",
+			},
+			expectWarnings: true,
+			expectFiles: []string{
+				"settings.gradle.kts",
+				filepath.Join("app", "build.gradle.kts"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+
+			for rel, content := range tt.files {
+				abs := filepath.Join(tmp, rel)
+				require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+				require.NoError(t, os.WriteFile(abs, []byte(content), 0o644))
+			}
+
+			logger := &mocks.Logger{}
+			logger.On("Warnf", mock.Anything).Return()
+			logger.On("Warnf", mock.Anything, mock.Anything).Return()
+			logger.On("Warnf", mock.Anything, mock.Anything, mock.Anything).Return()
+
+			mirrors.LogScopeGapWarnings(logger, utils.DefaultOsProxy{}, tmp)
+
+			if !tt.expectWarnings {
+				logger.AssertNotCalled(t, "Warnf", mock.Anything)
+				logger.AssertNotCalled(t, "Warnf", mock.Anything, mock.Anything)
+
+				return
+			}
+
+			calls := warnfCalls(logger)
+			joined := joinCalls(calls)
+
+			for _, f := range tt.expectFiles {
+				assert.Contains(t, joined, f, "expected warning to mention %q", f)
+			}
+
+			assert.Contains(t, joined, "apply(from", "expected primary warning to mention apply(from")
+			assert.Contains(t, joined, "pluginManagement", "expected recommendation to mention pluginManagement")
+		})
+	}
+}
+
+func warnfCalls(logger *mocks.Logger) []mock.Call {
+	var out []mock.Call
+
+	for _, c := range logger.Calls {
+		if c.Method == "Warnf" {
+			out = append(out, c)
+		}
+	}
+
+	return out
+}
+
+func joinCalls(calls []mock.Call) string {
+	var s string
+
+	for _, c := range calls {
+		for _, a := range c.Arguments {
+			if str, ok := a.(string); ok {
+				s += str + "\n"
+			}
+		}
+	}
+
+	return s
+}

--- a/pkg/gradle/mirrors/activator.go
+++ b/pkg/gradle/mirrors/activator.go
@@ -28,6 +28,11 @@ type ActivatorParams struct {
 	// Empty means DefaultGradleHome.
 	GradleHome string
 
+	// ProjectRoot is the directory scanned for scope-gap warnings (Gradle
+	// scripts using `apply(from = ...)`). Empty falls back to the current
+	// working directory; "-" disables scanning.
+	ProjectRoot string
+
 	// SelectedFlags lists the mirror flag names to enable (e.g. "mavencentral",
 	// "google"). Empty means all mirrors in mirrorsconfig.KnownMirrors.
 	SelectedFlags []string
@@ -66,6 +71,7 @@ type Activator struct {
 	pathModifier pathutil.PathModifier
 
 	gradleHome    string
+	projectRoot   string
 	selectedFlags []string
 	datacenter    string
 	enabled       *bool
@@ -105,6 +111,7 @@ func NewActivator(params ActivatorParams) *Activator {
 		pathModifier: pathModifier,
 
 		gradleHome:    gradleHome,
+		projectRoot:   params.ProjectRoot,
 		selectedFlags: params.SelectedFlags,
 		datacenter:    params.Datacenter,
 		enabled:       params.Enabled,
@@ -128,12 +135,14 @@ func (a *Activator) Activate(_ context.Context) error {
 	enabled := a.resolveEnabled()
 	datacenter := a.resolveDatacenter()
 	selected := mirrorsconfig.FilterByFlagNames(a.selectedFlags)
+	projectRoot := a.resolveProjectRoot()
 
 	if err := mirrorsconfig.Activate(a.logger, a.osProxy, mirrorsconfig.Params{
-		GradleHome: gradleHome,
-		Mirrors:    selected,
-		Datacenter: datacenter,
-		Enabled:    enabled,
+		GradleHome:  gradleHome,
+		Mirrors:     selected,
+		Datacenter:  datacenter,
+		Enabled:     enabled,
+		ProjectRoot: projectRoot,
 	}); err != nil {
 		return fmt.Errorf("activate gradle mirrors: %w", err)
 	}
@@ -159,4 +168,22 @@ func (a *Activator) resolveDatacenter() string {
 	}
 
 	return a.envs[mirrorsconfig.DatacenterEnvKey]
+}
+
+func (a *Activator) resolveProjectRoot() string {
+	switch a.projectRoot {
+	case "-":
+		return ""
+	case "":
+		cwd, err := a.osProxy.Getwd()
+		if err != nil {
+			a.logger.Debugf("Could not determine working directory for scope-gap scan: %s", err)
+
+			return ""
+		}
+
+		return cwd
+	default:
+		return a.projectRoot
+	}
 }


### PR DESCRIPTION
## Summary

- Detect `apply(from = ...)` (Kotlin DSL) and `apply from:` (Groovy) in `settings.gradle{,.kts}`, root `build.gradle{,.kts}`, and `app/build.gradle{,.kts}` at activation time.
- Log a multi-line warning naming each match plus a recommendation to move plugin classpath into `settings.gradle.kts pluginManagement {}`.
- New `ProjectRoot` field on `mirrors.ActivatorParams` / internal `mirrors.Params`. Empty in `ActivatorParams` falls back to cwd; `"-"` disables scanning. Internal `Params.ProjectRoot` empty disables scanning (no fallback).

## Why

Customers reported Gradle builds bypassing the mirror despite `activate-gradle-mirrors` running successfully (e.g. `repo.maven.apache.org/maven2` 429s, `verification-metadata.xml` mismatches). Investigation across two customer build logs showed two distinct causes — one was workflow-side (no activation step on parallel pipeline workflows), the other a real scope gap in our init script:

The mirror init script's lifecycle hooks (`gradle.beforeSettings`, `gradle.beforeProject`) cover the well-known `RepositoryHandler` instances on `Settings.buildscript`, `Settings.pluginManagement`, `dependencyResolutionManagement`, and project-level `buildscript`/`repositories`. They do **not** cover repositories declared inside scripts loaded via `apply(from = ...)` — those scripts get their own `ScriptHandler` that isn't reachable from any standard Gradle hook.

When a project does `apply(from = "shared.gradle.kts")` and the applied script declares its own `buildscript { repositories { mavenCentral() } dependencies { classpath("...") } }`, classpath resolution bypasses the mirror.

This PR doesn't fix the gap — it surfaces it so customers can self-diagnose and apply the documented refactor (move the classpath into `settings.gradle.kts pluginManagement {}`).

## Out of scope (future tickets)

- `BuildOperationListener` approach to actually intercept applied-script `ScriptHandler`s (Gradle internal API, version-fragile).
- HTTPS forward-proxy approach (infra work, universal coverage).
- Detection for `gradle/verification-metadata.xml` presence (separate product follow-up).

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test -tags unit -race ./internal/config/gradle/mirrors/... ./pkg/gradle/mirrors/...` — pass
- [x] `go test -tags unit -race ./...` — pass
- [ ] Manual: run `bitrise-build-cache-cli activate gradle-mirrors -d` against a project with `apply(from = ...)` in settings.gradle.kts, verify warning is logged.
- [ ] Manual: run against a clean project without `apply(from = ...)`, verify no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)