### PR TITLE
feat: disable jitpack mirror (returning 401)

### DIFF
--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -65,11 +65,12 @@ func TestActivate(t *testing.T) {
 			expectContains: []string{
 				"https://repository-manager-ams.services.bitrise.io:8090/maven/central",
 				"https://repository-manager-ams.services.bitrise.io:8090/maven/google",
-				"https://repository-manager-ams.services.bitrise.io:8090/maven/jitpack",
-				`"https://jitpack.io"`,
-				`"https://www.jitpack.io"`,
 				"https://repository-manager-ams.services.bitrise.io:8090/maven/gradle-plugins",
 				`r.getUrl().toString().trimEnd('/').equals("https://plugins.gradle.org/m2")`,
+			},
+			expectNotContain: []string{
+				"https://repository-manager-ams.services.bitrise.io:8090/maven/jitpack",
+				`"https://jitpack.io"`,
 			},
 		},
 		{

--- a/internal/config/gradle/mirrors/mirror.go
+++ b/internal/config/gradle/mirrors/mirror.go
@@ -25,7 +25,6 @@ var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
 	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`, ApplyToPluginManagement: true},
 	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: `r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME) || r.getUrl().toString().trimEnd('/') in setOf("https://repo1.maven.org/maven2", "https://jcenter.bintray.com")`, UseAsRobolectricRepo: true},
 	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
-	{FlagName: "jitpack", TemplateID: "JitPack", URLSegment: "jitpack", GradleMatch: `r.getUrl().toString().trimEnd('/') in setOf("https://jitpack.io", "https://www.jitpack.io")`},
 	{FlagName: "gradle-plugin-portal", TemplateID: "PluginPortal", URLSegment: "gradle-plugins", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://plugins.gradle.org/m2")`, ApplyToPluginManagement: true},
 }
 


### PR DESCRIPTION
## Summary

- Drop the `jitpack` entry from `KnownMirrors` in `internal/config/gradle/mirrors/mirror.go`. The cobra `--jitpack` flag is auto-derived from `KnownMirrors` and disappears with it.
- Update `TestActivate` AMS1-all-mirrors case to assert jitpack URL/predicate is NOT in the generated init script.

## Why

Bitrise's jitpack mirror endpoint is returning HTTP 401, breaking customer builds that route through it. Pulling the entry causes Gradle to fall back to direct `https://jitpack.io` resolution while the mirror is unavailable.

This is a temporary disable — the entry can be restored once the upstream auth issue is fixed.

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test -tags unit -race ./internal/config/gradle/mirrors/... ./pkg/gradle/mirrors/...` — pass
- [ ] Manual: confirm generated `bitrise-gradle-mirrors.init.gradle.kts` no longer contains the jitpack predicate when running with all mirrors enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)