### PR TITLE
feat: export per-mirror proxy URL env vars on activation

### DIFF
--- a/internal/config/gradle/mirrors/activate.go
+++ b/internal/config/gradle/mirrors/activate.go
@@ -17,6 +17,18 @@ const EnabledEnvKey = "BITRISE_MAVENCENTRAL_PROXY_ENABLED"
 // DatacenterEnvKey identifies the Bitrise datacenter the build runs in.
 const DatacenterEnvKey = "BITRISE_DEN_VM_DATACENTER"
 
+// MirrorURLEnvKeyPrefix is the prefix for per-mirror URL env vars exported on
+// activation: `BITRISE_MAVENCENTRAL_PROXY_URL_<TemplateID>` (e.g.
+// `BITRISE_MAVENCENTRAL_PROXY_URL_ApacheCentral`).
+const MirrorURLEnvKeyPrefix = "BITRISE_MAVENCENTRAL_PROXY_URL_"
+
+// Exporter exports an env var for the rest of the workflow. Implemented by
+// internal/envexport.EnvExporter (sets process env, calls envman on Bitrise CI,
+// and writes to GITHUB_ENV on GitHub Actions).
+type Exporter interface {
+	Export(key, value string)
+}
+
 // Params bundles the inputs needed to write the Gradle mirrors init script.
 type Params struct {
 	GradleHome  string       // absolute path to the Gradle home (e.g. ~/.gradle expanded)
@@ -24,6 +36,7 @@ type Params struct {
 	Datacenter  string       // datacenter (e.g. "AMS1") used to build the mirror URL
 	Enabled     bool         // when false, Activate is a no-op
 	ProjectRoot string       // project root scanned for scope-gap warnings; empty disables scanning
+	Exporter    Exporter     // when non-nil, exports BITRISE_MAVENCENTRAL_PROXY_URL_<ID> per activated mirror
 }
 
 type templateEntry struct {
@@ -103,6 +116,14 @@ func Activate(logger log.Logger, osProxy utils.OsProxy, params Params) error {
 	}
 
 	logger.Infof("Gradle mirrors activated")
+
+	if params.Exporter != nil {
+		for _, e := range entries {
+			key := MirrorURLEnvKeyPrefix + e.ID
+			params.Exporter.Export(key, e.MirrorURL)
+			logger.Debugf("Exported %s=%s", key, e.MirrorURL)
+		}
+	}
 
 	if params.ProjectRoot != "" {
 		LogScopeGapWarnings(logger, osProxy, params.ProjectRoot)

--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -151,6 +151,52 @@ func TestFilterByFlagNames(t *testing.T) {
 	})
 }
 
+type recordingExporter struct {
+	exported map[string]string
+}
+
+func (r *recordingExporter) Export(key, value string) {
+	if r.exported == nil {
+		r.exported = map[string]string{}
+	}
+	r.exported[key] = value
+}
+
+func TestActivate_ExportsMirrorURLs(t *testing.T) {
+	exp := &recordingExporter{}
+	tmpDir := t.TempDir()
+
+	err := mirrors.Activate(log.NewLogger(), utils.DefaultOsProxy{}, mirrors.Params{
+		GradleHome: tmpDir,
+		Mirrors:    mirrors.KnownMirrors,
+		Datacenter: "AMS1",
+		Enabled:    true,
+		Exporter:   exp,
+	})
+	require.NoError(t, err)
+
+	for _, m := range mirrors.KnownMirrors {
+		key := mirrors.MirrorURLEnvKeyPrefix + m.TemplateID
+		want := "https://repository-manager-ams.services.bitrise.io:8090/maven/" + m.URLSegment
+		assert.Equal(t, want, exp.exported[key], "exported value for %s", key)
+	}
+}
+
+func TestActivate_NoExportWhenSkipped(t *testing.T) {
+	exp := &recordingExporter{}
+	tmpDir := t.TempDir()
+
+	err := mirrors.Activate(log.NewLogger(), utils.DefaultOsProxy{}, mirrors.Params{
+		GradleHome: tmpDir,
+		Mirrors:    mirrors.KnownMirrors,
+		Datacenter: "ATL1", // unsupported region
+		Enabled:    true,
+		Exporter:   exp,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, exp.exported, "no env vars should be exported when activation skips")
+}
+
 func TestDatacenterToRegion(t *testing.T) {
 	cases := map[string]string{
 		"AMS1": "ams",

--- a/pkg/gradle/mirrors/activator.go
+++ b/pkg/gradle/mirrors/activator.go
@@ -12,6 +12,7 @@ import (
 
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/envexport"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
@@ -143,6 +144,7 @@ func (a *Activator) Activate(_ context.Context) error {
 		Datacenter:  datacenter,
 		Enabled:     enabled,
 		ProjectRoot: projectRoot,
+		Exporter:    envexport.New(a.envs, a.logger),
 	}); err != nil {
 		return fmt.Errorf("activate gradle mirrors: %w", err)
 	}


### PR DESCRIPTION
## Summary

When `gradle-mirrors` activation succeeds, export one env var per activated mirror:

`BITRISE_MAVENCENTRAL_PROXY_URL_<TemplateID> = <mirror URL>`

For the current `KnownMirrors` registry that's:

| Env var | Value (e.g. AMS1) |
| --- | --- |
| `BITRISE_MAVENCENTRAL_PROXY_URL_ApacheCentral` | `https://repository-manager-ams.services.bitrise.io:8090/maven/apache-central` |
| `BITRISE_MAVENCENTRAL_PROXY_URL_Central` | `https://repository-manager-ams.services.bitrise.io:8090/maven/central` |
| `BITRISE_MAVENCENTRAL_PROXY_URL_Google` | `https://repository-manager-ams.services.bitrise.io:8090/maven/google` |
| `BITRISE_MAVENCENTRAL_PROXY_URL_PluginPortal` | `https://repository-manager-ams.services.bitrise.io:8090/maven/gradle-plugins` |

Export is done via the existing `envexport.EnvExporter`, so it sets the var in the current process, calls `envman` on Bitrise CI, and writes to `GITHUB_ENV` on GitHub Actions. No exports happen when activation is skipped (disabled, no datacenter, no mirrors selected, unsupported region).

This lets downstream steps resolve the path-specific proxy URL without recomputing it from datacenter / URL segment, e.g. for projects that need to reference the central or apache-central proxy from a non-Gradle context.

## Test plan

- [x] `make test-unit`
- [x] `make lint`
- [x] New `TestActivate_ExportsMirrorURLs` covers every mirror in `KnownMirrors` for AMS1.
- [x] New `TestActivate_NoExportWhenSkipped` confirms an unsupported DC (`ATL1`) exports nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)