### PR TITLE
fix(ACI-4877): RN wrapper success follows wrapped process exit code

### DIFF
--- a/internal/ccache/analytics/invocations_test.go
+++ b/internal/ccache/analytics/invocations_test.go
@@ -295,9 +295,17 @@ func TestCcacheStats_Success(t *testing.T) {
 		assert.False(t, s.Success())
 	})
 
-	t.Run("compile failed → not success", func(t *testing.T) {
-		s := CcacheStats{CompileFailed: 2}
-		assert.False(t, s.Success())
+	t.Run("compiler-side failures do not flip success", func(t *testing.T) {
+		// compile_failed / preprocessor_error / bad_input_file / bad_output_file
+		// reflect the invoked compiler exiting non-zero (e.g. autoconf probes,
+		// transient build races) — ccache itself worked fine.
+		s := CcacheStats{
+			CompileFailed:     5,
+			PreprocessorError: 2,
+			BadInputFile:      1,
+			BadOutputFile:     1,
+		}
+		assert.True(t, s.Success())
 	})
 
 	t.Run("storage misses do not flip success", func(t *testing.T) {
@@ -312,12 +320,17 @@ func TestCcacheStats_ErrorSummary(t *testing.T) {
 		assert.Empty(t, CcacheStats{}.ErrorSummary())
 	})
 
-	t.Run("lists every non-zero error counter", func(t *testing.T) {
-		s := CcacheStats{InternalError: 2, CompileFailed: 1, BadInputFile: 4}
+	t.Run("lists every non-zero ccache-internal error counter", func(t *testing.T) {
+		s := CcacheStats{InternalError: 2, MissingCacheFile: 1, ModifiedInputFile: 4}
 		got := s.ErrorSummary()
 		assert.Contains(t, got, "internal_error=2")
-		assert.Contains(t, got, "compile_failed=1")
-		assert.Contains(t, got, "bad_input_file=4")
+		assert.Contains(t, got, "missing_cache_file=1")
+		assert.Contains(t, got, "modified_input_file=4")
+	})
+
+	t.Run("compiler-side errors are not listed in summary", func(t *testing.T) {
+		s := CcacheStats{CompileFailed: 7, PreprocessorError: 3, BadInputFile: 1, BadOutputFile: 1}
+		assert.Empty(t, s.ErrorSummary())
 	})
 }
 
@@ -341,11 +354,11 @@ func TestNewCcacheInvocation_DerivesHitRateSuccessError(t *testing.T) {
 
 	t.Run("internal errors propagate as success=false + summary string", func(t *testing.T) {
 		stats := CcacheStats{
-			CacheableCalls: 10,
-			CacheHit:       5,
-			CacheHitRate:   0.5,
-			InternalError:  1,
-			CompileFailed:  3,
+			CacheableCalls:    10,
+			CacheHit:          5,
+			CacheHitRate:      0.5,
+			InternalError:     1,
+			ModifiedInputFile: 3,
 		}
 
 		inv := NewCcacheInvocation("c", "p", time.Now(), stats, 0, 0, auth, meta)
@@ -353,6 +366,20 @@ func TestNewCcacheInvocation_DerivesHitRateSuccessError(t *testing.T) {
 		assert.InDelta(t, 0.5, inv.HitRate, 1e-6)
 		assert.False(t, inv.Success)
 		assert.Contains(t, inv.Error, "internal_error=1")
-		assert.Contains(t, inv.Error, "compile_failed=3")
+		assert.Contains(t, inv.Error, "modified_input_file=3")
+	})
+
+	t.Run("compiler-side errors keep success=true", func(t *testing.T) {
+		stats := CcacheStats{
+			CacheableCalls: 10,
+			CacheHit:       9,
+			CacheHitRate:   0.9,
+			CompileFailed:  2,
+		}
+
+		inv := NewCcacheInvocation("c", "p", time.Now(), stats, 0, 0, auth, meta)
+
+		assert.True(t, inv.Success)
+		assert.Empty(t, inv.Error)
 	})
 }

--- a/internal/ccache/analytics/types.go
+++ b/internal/ccache/analytics/types.go
@@ -90,11 +90,15 @@ func (s CcacheStats) HasActivity() bool {
 	return s.CacheableCalls+s.UncacheableCalls > 0
 }
 
-// Success reports whether ccache did its job without internal/IO/compile errors
-// during the run. Storage hits/misses are normal and do NOT affect Success —
-// only conditions that indicate ccache itself misbehaved or the user's build
-// hit a hard error are counted. The intent is the same as the Success bool on
-// the wrapper invocation: did the tool perform its task correctly?
+// Success reports whether ccache itself did its job without internal/IO errors
+// during the run. Storage hits/misses are normal and do NOT affect Success.
+// Counters that reflect the *invoked compiler* failing (compile_failed,
+// preprocessor_error, bad_input_file, bad_output_file) are NOT counted here —
+// those mean the user's compilation/preprocessing exited non-zero, which is
+// orthogonal to whether ccache itself worked. Only counters that indicate
+// ccache itself misbehaved (internal error, missing compiler, file hashing,
+// missing cache file, modified-during-compile, compiler identity check) flip
+// Success to false.
 func (s CcacheStats) Success() bool {
 	return s.errorCount() == 0
 }
@@ -116,7 +120,7 @@ func (s CcacheStats) ErrorSummary() string {
 
 // errorFieldCount is len(errorFields(...)) — kept in sync with the helper
 // to size the slice in ErrorSummary without re-counting at every call.
-const errorFieldCount = 10
+const errorFieldCount = 6
 
 func (s CcacheStats) errorCount() int {
 	total := 0
@@ -132,15 +136,18 @@ type errorField struct {
 	count int
 }
 
+// errorFields lists the ccache-internal error counters that flip Success to
+// false. compile_failed / preprocessor_error / bad_input_file / bad_output_file
+// are deliberately excluded — those increment when the *invoked compiler*
+// fails (e.g. autoconf-style probe compiles, NDK build hiccups, transient
+// races during parallel Gradle builds), not when ccache misbehaves. Including
+// them caused successful RN Android builds with high hit rates to be reported
+// as failed ccache invocations.
 func errorFields(s CcacheStats) []errorField {
 	return []errorField{
 		{"internal_error", s.InternalError},
-		{"compile_failed", s.CompileFailed},
 		{"compiler_check_failed", s.CompilerCheckFailed},
-		{"preprocessor_error", s.PreprocessorError},
 		{"could_not_find_compiler", s.CouldNotFindCompiler},
-		{"bad_input_file", s.BadInputFile},
-		{"bad_output_file", s.BadOutputFile},
 		{"error_hashing_extra_file", s.ErrorHashingExtraFile},
 		{"missing_cache_file", s.MissingCacheFile},
 		{"modified_input_file", s.ModifiedInputFile},

--- a/pkg/reactnative/post_run_deps.go
+++ b/pkg/reactnative/post_run_deps.go
@@ -100,18 +100,20 @@ func (d *postRunDeps) run(ctx context.Context, wrapperInvocationID string, args 
 		}
 
 		if summary.FailedCount > 0 {
-			d.logger.TWarnf(
-				"%d of %d child invocations reported a failure — marking the wrapper run as failed.",
+			d.logger.TInfof(
+				"%d of %d child invocations reported a failure (informational; wrapper success is driven by the wrapped process exit code).",
 				summary.FailedCount, summary.ChildCount,
 			)
 		}
 	}
 
-	wrapperSuccess := execErr == nil && summary.FailedCount == 0
-	wrapperErr := execErr
-	if wrapperErr == nil && summary.FailedCount > 0 {
-		wrapperErr = fmt.Errorf("%d of %d child invocations failed", summary.FailedCount, summary.ChildCount)
-	}
+	// Wrapper Success follows the wrapped process's exit code only. We used to
+	// also fail the wrapper when any child reported Failed=true, but child
+	// failure flags are noisy (e.g. ccache marks a run failed on user-side
+	// compile errors that don't affect ccache itself) and made successful
+	// builds report as failed wrappers. FailedCount stays in the summary for
+	// observability; the only signal that flips Success here is execErr.
+	wrapperSuccess := execErr == nil
 
 	inv := multiplatform.NewInvocation(multiplatform.InvocationRunStats{
 		InvocationDate: time.Now().Add(-duration),
@@ -120,7 +122,7 @@ func (d *postRunDeps) run(ctx context.Context, wrapperInvocationID string, args 
 		Command:        command,
 		FullCommand:    fullCommand,
 		Success:        wrapperSuccess,
-		Error:          wrapperErr,
+		Error:          execErr,
 		BuildTool:      "react-native",
 		Wrapper:        "bitrise-build-cache-cli react-native",
 		HitRate:        summary.MeanHitRate,


### PR DESCRIPTION
## Summary

- RN wrapper invocation was getting marked failed despite `BUILD SUCCESSFUL` and 90%+ ccache hit rate. Root cause: ccache wrote `Failed=true` to the child stats ledger based on `CcacheStats.Success()`, which counted compiler-side failures (`compile_failed`, `preprocessor_error`, `bad_input_file`, `bad_output_file`) as ccache failures. Those counters fire when the invoked compiler itself exits non-zero — normal during RN Android (autoconf-style probes, parallel CMake/NDK) — and are unrelated to ccache health.
- Narrowed `errorFields()` to ccache-internal counters only: `internal_error`, `compiler_check_failed`, `could_not_find_compiler`, `error_hashing_extra_file`, `missing_cache_file`, `modified_input_file`. `errorFieldCount` 10 → 6.
- Decoupled RN wrapper `Success` from `summary.FailedCount`. Wrapper success now follows the wrapped process exit code (`execErr`) only. `FailedCount` is still aggregated and logged (info, not warn) but no longer flips wrapper success or wraps an error.
- iOS dodged this because xcelerate handles iOS, not ccache.

## Context

- Jira: [ACI-4877](https://bitrise.atlassian.net/browse/ACI-4877)
- Reproducer build: https://app.bitrise.io/app/73269df6-7b60-41e1-ae84-52d1d7760758/build/06a57610-0b3d-44e5-95a1-0642bd7c8c14 (`BUILD SUCCESSFUL`, 92% ccache hit rate, wrapper marked failed).
- Original child→wrapper failure propagation came from #287; that mechanism is kept structurally (the `Failed` field + `Summary.FailedCount` remain) but no longer auto-fails the wrapper. Future explicit-mark flows can reuse them.

## Test plan

- [x] `make test-unit` green
- [x] `make lint-fix` clean
- [ ] Re-run the reproducer build on a CLI binary built from this branch and confirm the RN wrapper invocation reports Success=true with 90%+ hit rate
- [ ] Confirm xcode wrapper analytics path unaffected (xcode child still writes `Failed = !inv.Success`, ccache change does not touch xcode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4877]: https://bitrise.atlassian.net/browse/ACI-4877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ