### PR TITLE
fix(ACI-4875): inject CLI version via ldflags, dedupe log to once per process

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,9 @@ builds:
   - binary: bitrise-build-cache
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common.injectedVersion={{.Version}}
     goos:
       - linux
       # - windows

--- a/internal/config/common/cli_version.go
+++ b/internal/config/common/cli_version.go
@@ -4,42 +4,78 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
-	"slices"
 	"strings"
+	"sync"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 )
 
-func GetCLIVersion(logger log.Logger) string {
+// injectedVersion is the CLI version stamped at build time via:
+//
+//	-ldflags "-X github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common.injectedVersion=<ver>"
+//
+// Goreleaser sets this on every release build. Local `go build` leaves it
+// empty and we fall back to debug.ReadBuildInfo below.
+//
+//nolint:gochecknoglobals
+var injectedVersion string
+
+//nolint:gochecknoglobals
+var versionLogOnce sync.Once
+
+// GetCLIVersion returns the CLI version, resolved in this order:
+//
+//  1. The build-time injected `injectedVersion` (set by goreleaser ldflags).
+//  2. When the CLI is imported as a library (e.g. from a Bitrise step),
+//     the bitrise-build-cache-cli entry in debug.BuildInfo.Deps.
+//  3. The main module's debug.BuildInfo Main.Version, when it's a real
+//     module-aware tag (i.e. not the "(devel)" placeholder Go reports for
+//     ad-hoc local builds).
+//  4. "devel" as a last-resort sentinel.
+//
+// The logger parameter is kept for call-site compatibility; resolution is
+// non-failing so it isn't used here.
+func GetCLIVersion(_ log.Logger) string {
+	if v := strings.TrimSpace(injectedVersion); v != "" {
+		return v
+	}
+
 	bi, ok := debug.ReadBuildInfo()
 	if !ok {
-		logger.Infof("Failed to read build info")
-
-		return "unknown"
+		return "devel"
 	}
 
-	// Find the bitrise-build-cache-cli module in the build info.
-	// If ran from source, it will be the main module.
-	// If ran from a step, it will be a dependency module.
-	modules := []*debug.Module{&bi.Main}
-	modules = append(modules, bi.Deps...)
-	idx := slices.IndexFunc(modules, func(c *debug.Module) bool { return strings.Contains(c.Path, "bitrise-build-cache-cli") })
-	if idx == -1 || idx >= len(modules) {
-		logger.Infof("Failed to find bitrise-build-cache-cli module in build info")
+	for _, mod := range bi.Deps {
+		if mod == nil {
+			continue
+		}
 
-		return "unknown"
+		if !strings.Contains(mod.Path, "bitrise-build-cache-cli") {
+			continue
+		}
+
+		if v := strings.TrimSpace(mod.Version); v != "" {
+			return v
+		}
 	}
 
-	return modules[idx].Version
+	if v := strings.TrimSpace(bi.Main.Version); v != "" && v != "(devel)" {
+		return v
+	}
+
+	return "devel"
 }
 
-// LogCLIVersion writes a single line with the resolved CLI version to STDERR.
+// LogCLIVersion writes a single line with the resolved CLI version to STDERR,
+// at most once per process. Subsequent calls are no-ops, which lets every
+// public entry point (cobra PersistentPreRun hooks, pkg/* Activator/Runner
+// methods used by step libraries) call this without producing duplicate lines.
+//
 // Stderr (not stdout) is intentional: some callers — e.g. xcodebuild wrappers
 // fronted by `@react-native-community/cli-platform-apple` — parse the CLI's
 // stdout as JSON. Writing the version line to stdout breaks that JSON parse.
-// Call this from public entry points (cobra root PersistentPreRun, pkg/*
-// Activator/Runner methods) so each invocation records which CLI the caller
-// is running.
 func LogCLIVersion(logger log.Logger) {
-	_, _ = fmt.Fprintf(os.Stderr, "Bitrise Build Cache CLI version: %s\n", GetCLIVersion(logger))
+	versionLogOnce.Do(func() {
+		_, _ = fmt.Fprintf(os.Stderr, "Bitrise Build Cache CLI version: %s\n", GetCLIVersion(logger))
+	})
 }

--- a/internal/config/common/cli_version_test.go
+++ b/internal/config/common/cli_version_test.go
@@ -1,0 +1,89 @@
+//go:build unit
+
+package common
+
+import (
+	"io"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetVersionLogOnce(t *testing.T) {
+	t.Helper()
+	versionLogOnce = sync.Once{}
+}
+
+func TestGetCLIVersion_PrefersInjectedVersion(t *testing.T) {
+	prev := injectedVersion
+	t.Cleanup(func() { injectedVersion = prev })
+
+	injectedVersion = "v9.9.9"
+	assert.Equal(t, "v9.9.9", GetCLIVersion(log.NewLogger()))
+}
+
+func TestGetCLIVersion_TrimsInjectedVersion(t *testing.T) {
+	prev := injectedVersion
+	t.Cleanup(func() { injectedVersion = prev })
+
+	injectedVersion = "  v1.2.3  "
+	assert.Equal(t, "v1.2.3", GetCLIVersion(log.NewLogger()))
+}
+
+func TestGetCLIVersion_FallsBackWhenInjectedEmpty(t *testing.T) {
+	prev := injectedVersion
+	t.Cleanup(func() { injectedVersion = prev })
+
+	injectedVersion = ""
+	// Without ldflags injection we should resolve via debug.BuildInfo or
+	// land on the "devel" sentinel — never an empty string.
+	assert.NotEmpty(t, GetCLIVersion(log.NewLogger()))
+}
+
+func TestLogCLIVersion_PrintsAtMostOncePerProcess(t *testing.T) {
+	prev := injectedVersion
+	t.Cleanup(func() { injectedVersion = prev })
+
+	resetVersionLogOnce(t)
+	injectedVersion = "v1.2.3"
+
+	stderr := captureStderr(t, func() {
+		for i := 0; i < 5; i++ {
+			LogCLIVersion(log.NewLogger())
+		}
+	})
+
+	assert.Equal(t, "Bitrise Build Cache CLI version: v1.2.3\n", stderr)
+}
+
+// captureStderr swaps os.Stderr for a pipe, runs fn, restores the original
+// stderr, and returns whatever fn wrote.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stderr = w
+
+	done := make(chan string, 1)
+	go func() {
+		buf, _ := io.ReadAll(r)
+		done <- string(buf)
+	}()
+
+	defer func() {
+		os.Stderr = origStderr
+	}()
+
+	fn()
+
+	require.NoError(t, w.Close())
+
+	return <-done
+}


### PR DESCRIPTION
## Summary

Two issues from the ACI-4869 version-logging rollout:

- **Released binaries reported `(devel)`.** `debug.ReadBuildInfo()` returns `(devel)` for `Main.Version` when goreleaser builds the binary outside a module-aware tagged context, and the dependency-side lookup (`bi.Deps`) only works for library callers (steps importing the CLI). Binary path had no real version source.
- **Version line printed many times per process.** Every `pkg/*` entry point (ccache.Activator + StorageHelper, reactnative Activator + Runner, gradle/mirrors.Activator) plus both cobra PersistentPreRun hooks emitted the line. In the reproducer build, RN activate printed it 4× in one process and 9× across the workflow.

## Changes

- `internal/config/common/cli_version.go`
  - New build-time-injected `injectedVersion` var. Resolution order: `injectedVersion` → `bi.Deps` bitrise-build-cache-cli entry → `bi.Main.Version` if not `(devel)` → `"devel"` sentinel. Whitespace trimmed at each level.
  - `LogCLIVersion` wrapped in `sync.Once`: each process emits the line at most once, regardless of how many entry points the same binary or step-library run touches. No need to prune call sites — they're now belt-and-braces.
- `.goreleaser.yaml` builds pass `-X .../internal/config/common.injectedVersion={{.Version}}` (plus `-s -w` for size).
- Unit tests cover injected-version preference, whitespace trim, fallback returning non-empty, and once-per-process log behaviour.

## Context

- Jira: [ACI-4875](https://bitrise.atlassian.net/browse/ACI-4875)
- Reproducer build: https://app.bitrise.io/app/73269df6-7b60-41e1-ae84-52d1d7760758/build/f2b214b2-c498-43d6-8e6c-4b9d8a4cd644 (CLI v2.4.9 step, version line printed 9× as `(devel)`).

## Verified locally

- `go build -ldflags '... injectedVersion=v9.9.9-test' .` → `bitrise-build-cache version` prints `v9.9.9-test`; stderr banner shows the same.
- `go build .` (no ldflags) → falls back to `bi.Main.Version` / `(devel)` as expected.
- `make lint`, `make test-unit`: green.

## Test plan

- [x] `make test-unit` green
- [x] `make lint` clean
- [x] Manual build with and without ldflags
- [ ] Cut a test release via goreleaser and confirm released binary reports the tag (not `(devel)`) on `bitrise-build-cache version` and on the activation banner
- [ ] Re-run the reproducer build with the released binary and confirm at most one `Bitrise Build Cache CLI version: vX.Y.Z` line per CLI subprocess

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4875]: https://bitrise.atlassian.net/browse/ACI-4875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ