### PR TITLE
feat(ACI-4876): print RN invocation details URL after BE confirms save

### DIFF
--- a/pkg/reactnative/post_run_deps.go
+++ b/pkg/reactnative/post_run_deps.go
@@ -23,6 +23,13 @@ import (
 // Private — post-run analytics
 // ---------------------------------------------------------------------------
 
+// MsgRNInvocationSaved is the log line emitted after the BE confirms the
+// React Native wrapper invocation was persisted. The URL points at the
+// per-invocation details page in the Bitrise app. Mirrors the equivalent
+// xcode and gradle messages so users (especially on non-Bitrise CI) can
+// jump straight to the invocation in the Bitrise UI.
+const MsgRNInvocationSaved = "React Native invocation saved. Visit 👉 https://app.bitrise.io/build-cache/invocations/react-native/%s"
+
 // postRunDeps handles post-run analytics: invocation reporting, ccache stats
 // collection, and invocation relation registration.
 type postRunDeps struct {
@@ -128,6 +135,10 @@ func (d *postRunDeps) run(ctx context.Context, wrapperInvocationID string, args 
 
 	if err := d.sendInvocation(*inv); err != nil {
 		d.logger.TWarnf("Failed to send run invocation analytics: %v", err)
+	} else {
+		// BE confirmed the invocation was stored — surface the details URL
+		// so users can jump to it from the build log.
+		d.logger.TInfof(MsgRNInvocationSaved, wrapperInvocationID)
 	}
 
 	if err := agg.Cleanup(); err != nil {


### PR DESCRIPTION
## Summary

Gradle and Xcode invocations already print the per-invocation Bitrise UI URL once the BE confirms the analytics PUT succeeded (cmd/xcode/xcodebuild.go:46+357). The React Native wrapper was missing this, so users — especially on non-Bitrise CI — had no quick jump-to-invocation link in the build log.

- New `MsgRNInvocationSaved` constant in `pkg/reactnative/post_run_deps.go` mirroring the xcode wording.
- Emit it from `postRunDeps.run` only on the non-error path of `sendInvocation`, so the URL appears only when the BE has actually accepted the invocation. URL pattern matches the gradle one already in use: `https://app.bitrise.io/build-cache/invocations/react-native/<id>`.

## Context

- Jira: [ACI-4876](https://bitrise.atlassian.net/browse/ACI-4876)
- Reproducer build (no URL today): https://app.bitrise.io/app/73269df6-7b60-41e1-ae84-52d1d7760758/build/f2b214b2-c498-43d6-8e6c-4b9d8a4cd644

## Test plan

- [x] `make lint` clean
- [x] `make test-unit` green (pkg/reactnative tests pass; no behavioural change to existing flow)
- [ ] Re-run an RN wrapper build with this CLI and confirm the `Invocation saved. Visit 👉 ...` line appears at the end of the wrapper output
- [ ] Confirm no URL is printed when the BE PUT fails (the warn path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4876]: https://bitrise.atlassian.net/browse/ACI-4876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ