### PR TITLE
ci: add manually-triggered rn-wrapping-e2e pipeline

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -20,6 +20,7 @@ app:
 
 include:
 - path: bitrise_rn_config/bitrise.yml
+- path: e2e_rn_wrap_rollout.yml
 
 workflows:
   release:

--- a/e2e_rn_wrap_rollout.yml
+++ b/e2e_rn_wrap_rollout.yml
@@ -32,7 +32,13 @@ app:
     # react-seek-{android,ios}-e2e workflows use, so the wrap helpers
     # exercise the same code path RN customers see.
     - SEEK_RN_REPO: git@github.com:bitrise-io/SeekReactNative.git
-    - ANDROID_SAMPLE_REPO: https://github.com/bitrise-samples/sample-apps-android-simple.git
+    - ANDROID_SAMPLE_REPO: git@github.com:bitrise-samples/sample-apps-android-simple.git
+    # Hardcoded test app dirs — used by both the setup bundles and the
+    # inner workflows. Inner workflows can't see envman vars from the
+    # outer bundle (each `bitrise run <inner>` starts with a fresh
+    # envstore), so we keep the paths as constants here.
+    - WRAP_TEST_ANDROID_DIR: /tmp/wrap-test-android
+    - WRAP_TEST_RN_DIR: /tmp/wrap-test-rn
     # Hardcoded branch reference for every wrap PR. Flip to default branch
     # post-merge.
     - WRAP_HELPER_REF: feat/use-cli-wrap-helper
@@ -94,9 +100,8 @@ step_bundles:
             - content: |-
                 #!/usr/bin/env bash
                 set -euxo pipefail
-                rm -rf /tmp/wrap-test-android
-                git clone --depth 1 "$ANDROID_SAMPLE_REPO" /tmp/wrap-test-android
-                envman add --key WRAP_TEST_ANDROID_DIR --value /tmp/wrap-test-android
+                rm -rf "$WRAP_TEST_ANDROID_DIR"
+                git clone --depth 1 "$ANDROID_SAMPLE_REPO" "$WRAP_TEST_ANDROID_DIR"
 
   # Activate React Native cache + clone SeekReactNative for the iOS / RN wrap tests.
   rn-wrap-activate-rn-ios:
@@ -118,9 +123,8 @@ step_bundles:
             - content: |-
                 #!/usr/bin/env bash
                 set -euxo pipefail
-                rm -rf /tmp/wrap-test-rn
-                git clone --depth 1 "$SEEK_RN_REPO" /tmp/wrap-test-rn
-                envman add --key WRAP_TEST_RN_DIR --value /tmp/wrap-test-rn
+                rm -rf "$WRAP_TEST_RN_DIR"
+                git clone --depth 1 "$SEEK_RN_REPO" "$WRAP_TEST_RN_DIR"
 
 workflows:
   # ---------------------------------------------------------------------------

--- a/e2e_rn_wrap_rollout.yml
+++ b/e2e_rn_wrap_rollout.yml
@@ -1,0 +1,528 @@
+format_version: "13"
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
+# Manually-triggered pipeline that validates the React Native wrap-helper
+# rollout across the bitrise-steplib steps that adopt
+# `pkg/reactnative/wrap`. For each step, a small workflow:
+#
+#   1. Builds the CLI from this repo's source.
+#   2. Activates the React Native build cache via the freshly-built CLI so
+#      `wrap.Detect` will report ReactNativeEnabled=true.
+#   3. Runs the step under test from its `feat/use-cli-wrap-helper` PR
+#      branch via `bitrise run` so the inner step's stdout/stderr can be
+#      captured to a log file.
+#   4. Asserts that the step printed the wrap-engagement line
+#      ("wrapping (gradle|xcodebuild|npm) with /usr/local/bin/bitrise-build-cache").
+#
+# The actual build is allowed to fail — we only care that the wrap helper
+# engaged correctly and didn't crash the step before the underlying compile
+# command was constructed.
+#
+# Pipeline is intentionally NOT in the trigger_map — run manually from the
+# Bitrise UI ("Start Build" → pick `rn-wrapping-e2e` pipeline) or via
+# `bitrise trigger`.
+#
+# After the wrap PRs are merged and their `feat/use-cli-wrap-helper` branches
+# deleted, flip the `STEP_REF` env vars below from `feat/use-cli-wrap-helper`
+# to `master` / `main`.
+
+app:
+  envs:
+    # Test app refs. SeekReactNative is the same RN project the
+    # react-seek-{android,ios}-e2e workflows use, so the wrap helpers
+    # exercise the same code path RN customers see.
+    - SEEK_RN_REPO: git@github.com:bitrise-io/SeekReactNative.git
+    - ANDROID_SAMPLE_REPO: https://github.com/bitrise-samples/sample-apps-android-simple.git
+    # Hardcoded branch reference for every wrap PR. Flip to default branch
+    # post-merge.
+    - WRAP_HELPER_REF: feat/use-cli-wrap-helper
+    # Where each per-step workflow tees its inner-run log so the assert
+    # script can grep it.
+    - WRAP_LOG_PATH: /tmp/rn-wrap-rollout.log
+
+pipelines:
+  rn-wrapping-e2e:
+    # Manually triggered. Excluded from trigger_map.
+    workflows:
+      rn-wrap-android-build: {}
+      rn-wrap-android-unit-test: {}
+      rn-wrap-android-lint: {}
+      rn-wrap-gradle-unit-test: {}
+      rn-wrap-gradle-runner: {}
+      rn-wrap-xcode-archive: {}
+      rn-wrap-xcode-test: {}
+      rn-wrap-xcode-analyze: {}
+      rn-wrap-xcode-build-for-test: {}
+      rn-wrap-xcode-build-for-simulator: {}
+      rn-wrap-npm: {}
+
+step_bundles:
+  # Build the CLI binary from this repo and put it on PATH so the wrap pkg
+  # (compiled into each step under test) finds it during wrap.Detect.
+  rn-wrap-build-cli:
+    steps:
+      - script@1:
+          title: Build CLI binary
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -euxo pipefail
+                go build -o /usr/local/bin/bitrise-build-cache .
+                bitrise-build-cache version
+
+  # Activate React Native cache + clone Android sample app for the wrap-rollout test.
+  rn-wrap-activate-rn-android:
+    steps:
+      - bundle::rn-wrap-build-cli: {}
+      - script@1:
+          title: Activate React Native build cache
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -euxo pipefail
+                bitrise-build-cache activate react-native
+                bitrise-build-cache status --feature=react-native --quiet
+      - script@1:
+          title: Clone Android sample app
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -euxo pipefail
+                rm -rf /tmp/wrap-test-android
+                git clone --depth 1 "$ANDROID_SAMPLE_REPO" /tmp/wrap-test-android
+                envman add --key WRAP_TEST_ANDROID_DIR --value /tmp/wrap-test-android
+
+  # Activate React Native cache + clone SeekReactNative for the iOS / RN wrap tests.
+  rn-wrap-activate-rn-ios:
+    steps:
+      - bundle::rn-wrap-build-cli: {}
+      - script@1:
+          title: Activate React Native build cache
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -euxo pipefail
+                bitrise-build-cache activate react-native
+                bitrise-build-cache status --feature=react-native --quiet
+      - activate-ssh-key@4:
+          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+      - script@1:
+          title: Clone SeekReactNative
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -euxo pipefail
+                rm -rf /tmp/wrap-test-rn
+                git clone --depth 1 "$SEEK_RN_REPO" /tmp/wrap-test-rn
+                envman add --key WRAP_TEST_RN_DIR --value /tmp/wrap-test-rn
+
+workflows:
+  # ---------------------------------------------------------------------------
+  # Helper assertion workflow body
+  # ---------------------------------------------------------------------------
+  # Each per-step workflow runs a nested `bitrise run <inner>` via a script
+  # step so the inner step's stdout can be teed to $WRAP_LOG_PATH. The script
+  # step then greps for the expected wrap-engagement line. The inner step's
+  # exit code is intentionally NOT propagated — a failed compile after the
+  # wrap engaged is still a successful wrap-rollout test.
+
+  # ---------------------------------------------------------------------------
+  # Android / Gradle steps
+  # ---------------------------------------------------------------------------
+
+  rn-wrap-android-build:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.medium
+    steps:
+      - bundle::rn-wrap-activate-rn-android: {}
+      - script@1:
+          title: Run android-build via PR branch + capture
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -uo pipefail
+                rm -f "$WRAP_LOG_PATH"
+                set +e
+                bitrise run rn-wrap-android-build-inner 2>&1 | tee "$WRAP_LOG_PATH"
+                set -e
+                grep -E "wrapping gradle with .*bitrise-build-cache" "$WRAP_LOG_PATH" \
+                  || { echo "ERROR: wrap did not engage in android-build"; exit 1; }
+                echo "OK: wrap engaged in android-build"
+      - deploy-to-bitrise-io@2: {}
+
+  rn-wrap-android-build-inner:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.medium
+    steps:
+      - git::https://github.com/bitrise-steplib/bitrise-step-android-build.git@feat/use-cli-wrap-helper:
+          title: bitrise-step-android-build (PR branch)
+          inputs:
+            - project_location: $WRAP_TEST_ANDROID_DIR
+            - module: app
+            - variant: debug
+            - build_type: apk
+
+  rn-wrap-android-unit-test:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.medium
+    steps:
+      - bundle::rn-wrap-activate-rn-android: {}
+      - script@1:
+          title: Run android-unit-test via PR branch + capture
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -uo pipefail
+                rm -f "$WRAP_LOG_PATH"
+                set +e
+                bitrise run rn-wrap-android-unit-test-inner 2>&1 | tee "$WRAP_LOG_PATH"
+                set -e
+                grep -E "wrapping gradle with .*bitrise-build-cache" "$WRAP_LOG_PATH" \
+                  || { echo "ERROR: wrap did not engage in android-unit-test"; exit 1; }
+                echo "OK: wrap engaged in android-unit-test"
+      - deploy-to-bitrise-io@2: {}
+
+  rn-wrap-android-unit-test-inner:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.medium
+    steps:
+      - git::https://github.com/bitrise-steplib/bitrise-step-android-unit-test.git@feat/use-cli-wrap-helper:
+          title: bitrise-step-android-unit-test (PR branch)
+          inputs:
+            - project_location: $WRAP_TEST_ANDROID_DIR
+
+  rn-wrap-android-lint:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.medium
+    steps:
+      - bundle::rn-wrap-activate-rn-android: {}
+      - script@1:
+          title: Run android-lint via PR branch + capture
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -uo pipefail
+                rm -f "$WRAP_LOG_PATH"
+                set +e
+                bitrise run rn-wrap-android-lint-inner 2>&1 | tee "$WRAP_LOG_PATH"
+                set -e
+                grep -E "wrapping gradle with .*bitrise-build-cache" "$WRAP_LOG_PATH" \
+                  || { echo "ERROR: wrap did not engage in android-lint"; exit 1; }
+                echo "OK: wrap engaged in android-lint"
+      - deploy-to-bitrise-io@2: {}
+
+  rn-wrap-android-lint-inner:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.medium
+    steps:
+      - git::https://github.com/bitrise-steplib/bitrise-step-android-lint.git@feat/use-cli-wrap-helper:
+          title: bitrise-step-android-lint (PR branch)
+          inputs:
+            - project_location: $WRAP_TEST_ANDROID_DIR
+
+  rn-wrap-gradle-unit-test:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.medium
+    steps:
+      - bundle::rn-wrap-activate-rn-android: {}
+      - script@1:
+          title: Run gradle-unit-test via PR branch + capture
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -uo pipefail
+                rm -f "$WRAP_LOG_PATH"
+                set +e
+                bitrise run rn-wrap-gradle-unit-test-inner 2>&1 | tee "$WRAP_LOG_PATH"
+                set -e
+                grep -E "wrapping gradle with .*bitrise-build-cache" "$WRAP_LOG_PATH" \
+                  || { echo "ERROR: wrap did not engage in gradle-unit-test"; exit 1; }
+                echo "OK: wrap engaged in gradle-unit-test"
+      - deploy-to-bitrise-io@2: {}
+
+  rn-wrap-gradle-unit-test-inner:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.medium
+    steps:
+      - git::https://github.com/bitrise-steplib/steps-gradle-unit-test.git@feat/use-cli-wrap-helper:
+          title: steps-gradle-unit-test (PR branch)
+          inputs:
+            - project_root_dir: $WRAP_TEST_ANDROID_DIR
+            - test_task: testDebugUnitTest
+
+  rn-wrap-gradle-runner:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.medium
+    steps:
+      - bundle::rn-wrap-activate-rn-android: {}
+      - script@1:
+          title: Run gradle-runner via PR branch + capture
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -uo pipefail
+                rm -f "$WRAP_LOG_PATH"
+                set +e
+                bitrise run rn-wrap-gradle-runner-inner 2>&1 | tee "$WRAP_LOG_PATH"
+                set -e
+                grep -E "wrapping gradle with .*bitrise-build-cache" "$WRAP_LOG_PATH" \
+                  || { echo "ERROR: wrap did not engage in gradle-runner"; exit 1; }
+                echo "OK: wrap engaged in gradle-runner"
+      - deploy-to-bitrise-io@2: {}
+
+  rn-wrap-gradle-runner-inner:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.medium
+    steps:
+      - git::https://github.com/bitrise-steplib/steps-gradle-runner.git@feat/use-cli-wrap-helper:
+          title: steps-gradle-runner (PR branch)
+          inputs:
+            - gradle_task: assembleDebug
+            - gradlew_path: $WRAP_TEST_ANDROID_DIR/gradlew
+
+  # ---------------------------------------------------------------------------
+  # Xcode steps (iOS via SeekReactNative)
+  # ---------------------------------------------------------------------------
+
+  rn-wrap-xcode-archive:
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2.mac.medium
+    steps:
+      - bundle::rn-wrap-activate-rn-ios: {}
+      - script@1:
+          title: Run xcode-archive via PR branch + capture
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -uo pipefail
+                rm -f "$WRAP_LOG_PATH"
+                set +e
+                bitrise run rn-wrap-xcode-archive-inner 2>&1 | tee "$WRAP_LOG_PATH"
+                set -e
+                grep -E "wrapping xcodebuild with .*bitrise-build-cache" "$WRAP_LOG_PATH" \
+                  || { echo "ERROR: wrap did not engage in xcode-archive"; exit 1; }
+                echo "OK: wrap engaged in xcode-archive"
+      - deploy-to-bitrise-io@2: {}
+
+  rn-wrap-xcode-archive-inner:
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2.mac.medium
+    steps:
+      - git::https://github.com/bitrise-io/steps-xcode-archive.git@feat/use-cli-wrap-helper:
+          title: steps-xcode-archive (PR branch)
+          inputs:
+            - project_path: $WRAP_TEST_RN_DIR/ios/SeekReactNative.xcworkspace
+            - scheme: SeekReactNative
+            - distribution_method: development
+            - automatic_code_signing: api-key
+
+  rn-wrap-xcode-test:
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2.mac.medium
+    steps:
+      - bundle::rn-wrap-activate-rn-ios: {}
+      - script@1:
+          title: Run xcode-test via PR branch + capture
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -uo pipefail
+                rm -f "$WRAP_LOG_PATH"
+                set +e
+                bitrise run rn-wrap-xcode-test-inner 2>&1 | tee "$WRAP_LOG_PATH"
+                set -e
+                grep -E "wrapping xcodebuild with .*bitrise-build-cache" "$WRAP_LOG_PATH" \
+                  || { echo "ERROR: wrap did not engage in xcode-test"; exit 1; }
+                echo "OK: wrap engaged in xcode-test"
+      - deploy-to-bitrise-io@2: {}
+
+  rn-wrap-xcode-test-inner:
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2.mac.medium
+    steps:
+      - git::https://github.com/bitrise-io/steps-xcode-test.git@feat/use-cli-wrap-helper:
+          title: steps-xcode-test (PR branch)
+          inputs:
+            - project_path: $WRAP_TEST_RN_DIR/ios/SeekReactNative.xcworkspace
+            - scheme: SeekReactNative
+            - destination: platform=iOS Simulator,name=iPhone 15
+
+  rn-wrap-xcode-analyze:
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2.mac.medium
+    steps:
+      - bundle::rn-wrap-activate-rn-ios: {}
+      - script@1:
+          title: Run xcode-analyze via PR branch + capture
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -uo pipefail
+                rm -f "$WRAP_LOG_PATH"
+                set +e
+                bitrise run rn-wrap-xcode-analyze-inner 2>&1 | tee "$WRAP_LOG_PATH"
+                set -e
+                grep -E "wrapping xcodebuild with .*bitrise-build-cache" "$WRAP_LOG_PATH" \
+                  || { echo "ERROR: wrap did not engage in xcode-analyze"; exit 1; }
+                echo "OK: wrap engaged in xcode-analyze"
+      - deploy-to-bitrise-io@2: {}
+
+  rn-wrap-xcode-analyze-inner:
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2.mac.medium
+    steps:
+      - git::https://github.com/bitrise-steplib/steps-xcode-analyze.git@feat/use-cli-wrap-helper:
+          title: steps-xcode-analyze (PR branch)
+          inputs:
+            - project_path: $WRAP_TEST_RN_DIR/ios/SeekReactNative.xcworkspace
+            - scheme: SeekReactNative
+
+  rn-wrap-xcode-build-for-test:
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2.mac.medium
+    steps:
+      - bundle::rn-wrap-activate-rn-ios: {}
+      - script@1:
+          title: Run xcode-build-for-test via PR branch + capture
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -uo pipefail
+                rm -f "$WRAP_LOG_PATH"
+                set +e
+                bitrise run rn-wrap-xcode-build-for-test-inner 2>&1 | tee "$WRAP_LOG_PATH"
+                set -e
+                grep -E "wrapping xcodebuild with .*bitrise-build-cache" "$WRAP_LOG_PATH" \
+                  || { echo "ERROR: wrap did not engage in xcode-build-for-test"; exit 1; }
+                echo "OK: wrap engaged in xcode-build-for-test"
+      - deploy-to-bitrise-io@2: {}
+
+  rn-wrap-xcode-build-for-test-inner:
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2.mac.medium
+    steps:
+      - git::https://github.com/bitrise-steplib/steps-xcode-build-for-test.git@feat/use-cli-wrap-helper:
+          title: steps-xcode-build-for-test (PR branch)
+          inputs:
+            - project_path: $WRAP_TEST_RN_DIR/ios/SeekReactNative.xcworkspace
+            - scheme: SeekReactNative
+            - destination: generic/platform=iOS Simulator
+
+  rn-wrap-xcode-build-for-simulator:
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2.mac.medium
+    steps:
+      - bundle::rn-wrap-activate-rn-ios: {}
+      - script@1:
+          title: Run xcode-build-for-simulator via PR branch + capture
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -uo pipefail
+                rm -f "$WRAP_LOG_PATH"
+                set +e
+                bitrise run rn-wrap-xcode-build-for-simulator-inner 2>&1 | tee "$WRAP_LOG_PATH"
+                set -e
+                grep -E "wrapping xcodebuild with .*bitrise-build-cache" "$WRAP_LOG_PATH" \
+                  || { echo "ERROR: wrap did not engage in xcode-build-for-simulator"; exit 1; }
+                echo "OK: wrap engaged in xcode-build-for-simulator"
+      - deploy-to-bitrise-io@2: {}
+
+  rn-wrap-xcode-build-for-simulator-inner:
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2.mac.medium
+    steps:
+      - git::https://github.com/bitrise-steplib/steps-xcode-build-for-simulator.git@feat/use-cli-wrap-helper:
+          title: steps-xcode-build-for-simulator (PR branch)
+          inputs:
+            - project_path: $WRAP_TEST_RN_DIR/ios/SeekReactNative.xcworkspace
+            - scheme: SeekReactNative
+
+  # ---------------------------------------------------------------------------
+  # NPM
+  # ---------------------------------------------------------------------------
+
+  rn-wrap-npm:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.medium
+    steps:
+      - bundle::rn-wrap-activate-rn-ios: {}
+      - script@1:
+          title: Run npm via PR branch + capture
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -uo pipefail
+                rm -f "$WRAP_LOG_PATH"
+                set +e
+                bitrise run rn-wrap-npm-inner 2>&1 | tee "$WRAP_LOG_PATH"
+                set -e
+                grep -E "wrapping npm with .*bitrise-build-cache" "$WRAP_LOG_PATH" \
+                  || { echo "ERROR: wrap did not engage in steps-npm"; exit 1; }
+                echo "OK: wrap engaged in steps-npm"
+      - deploy-to-bitrise-io@2: {}
+
+  rn-wrap-npm-inner:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.medium
+    steps:
+      - git::https://github.com/bitrise-steplib/steps-npm.git@feat/use-cli-wrap-helper:
+          title: steps-npm (PR branch)
+          inputs:
+            - workdir: $WRAP_TEST_RN_DIR
+            - command: --version

--- a/e2e_rn_wrap_rollout.yml
+++ b/e2e_rn_wrap_rollout.yml
@@ -57,7 +57,6 @@ pipelines:
       rn-wrap-android-unit-test: {}
       rn-wrap-android-lint: {}
       rn-wrap-gradle-unit-test: {}
-      rn-wrap-gradle-runner: {}
       rn-wrap-xcode-archive: {}
       rn-wrap-xcode-test: {}
       rn-wrap-xcode-analyze: {}
@@ -101,13 +100,19 @@ step_bundles:
                 bitrise-build-cache activate react-native
                 bitrise-build-cache status --feature=react-native --quiet
       - script@1:
-          title: Clone SeekReactNative
+          title: Clone SeekReactNative + JS / pod deps
           inputs:
             - content: |-
                 #!/usr/bin/env bash
                 set -euxo pipefail
                 rm -rf "$WRAP_TEST_RN_DIR"
                 git clone --depth 1 "$SEEK_RN_REPO" "$WRAP_TEST_RN_DIR"
+                cd "$WRAP_TEST_RN_DIR"
+                yarn install --frozen-lockfile
+                if [[ "$(uname)" == "Darwin" ]]; then
+                    cd ios
+                    pod install
+                fi
 
 workflows:
   # ---------------------------------------------------------------------------

--- a/e2e_rn_wrap_rollout.yml
+++ b/e2e_rn_wrap_rollout.yml
@@ -33,15 +33,14 @@ app:
     # invocations from inside a single RN project all pick up the wrap
     # helper. This is the same RN project the react-seek-{android,ios}-e2e
     # workflows use.
-    - SEEK_RN_REPO: git@github.com:bitrise-io/SeekReactNative.git
     # Hardcoded test app dirs — used by both the setup bundles and the
     # inner workflows. Inner workflows can't see envman vars from the
     # outer bundle (each `bitrise run <inner>` starts with a fresh
     # envstore), so we keep the paths as constants here.
     # WRAP_TEST_ANDROID_DIR / WRAP_TEST_RN_DIR both point inside the
     # same SeekReactNative checkout (android/ and root respectively).
-    - WRAP_TEST_RN_DIR: /tmp/wrap-test-rn
-    - WRAP_TEST_ANDROID_DIR: /tmp/wrap-test-rn/android
+    - WRAP_TEST_RN_DIR: $BITRISE_SOURCE_DIR/_seek
+    - WRAP_TEST_ANDROID_DIR: $BITRISE_SOURCE_DIR/_seek/android
     # Hardcoded branch reference for every wrap PR. Flip to default branch
     # post-merge.
     - WRAP_HELPER_REF: feat/use-cli-wrap-helper
@@ -100,18 +99,24 @@ step_bundles:
                 bitrise-build-cache activate react-native
                 bitrise-build-cache status --feature=react-native --quiet
       - script@1:
-          title: Clone SeekReactNative + JS / pod deps
+          title: Clone Seek app
           inputs:
             - content: |-
                 #!/usr/bin/env bash
-                set -euxo pipefail
-                rm -rf "$WRAP_TEST_RN_DIR"
-                git clone --depth 1 "$SEEK_RN_REPO" "$WRAP_TEST_RN_DIR"
-                cd "$WRAP_TEST_RN_DIR"
-                npm install --legacy-peer-deps --no-audit --no-fund
+                set -exo pipefail
+                cd "$BITRISE_SOURCE_DIR"
+                rm -rf _seek
+                git clone --depth 1 "$SEEK_URL" --branch "$SEEK_TAG" _seek
+      - script@1:
+          title: Configure and install dependencies
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -exo pipefail
                 if [[ "$(uname)" == "Darwin" ]]; then
-                    cd ios
-                    pod install
+                    bash "$BITRISE_SOURCE_DIR/scripts/react_e2e_setup_seek_ios.sh"
+                else
+                    bash "$BITRISE_SOURCE_DIR/scripts/react_e2e_setup_seek_android.sh"
                 fi
 
 workflows:

--- a/e2e_rn_wrap_rollout.yml
+++ b/e2e_rn_wrap_rollout.yml
@@ -59,8 +59,14 @@ pipelines:
 step_bundles:
   # Build the CLI binary from this repo and put it on PATH so the wrap pkg
   # (compiled into each step under test) finds it during wrap.Detect.
+  # Also leaves the CLI repo checked out at $BITRISE_SOURCE_DIR so the nested
+  # `bitrise run <inner>` invocations later can find this same bitrise.yml
+  # (with its `include:` of e2e_rn_wrap_rollout.yml).
   rn-wrap-build-cli:
     steps:
+      - activate-ssh-key@4:
+          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+      - git-clone@8: {}
       - script@1:
           title: Build CLI binary
           inputs:

--- a/e2e_rn_wrap_rollout.yml
+++ b/e2e_rn_wrap_rollout.yml
@@ -28,17 +28,20 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
-    # Test app refs. SeekReactNative is the same RN project the
-    # react-seek-{android,ios}-e2e workflows use, so the wrap helpers
-    # exercise the same code path RN customers see.
+    # SeekReactNative serves all wrap-rollout workflows: the wrap-rollout
+    # validates that gradle (android/) and xcodebuild (ios/) and npm
+    # invocations from inside a single RN project all pick up the wrap
+    # helper. This is the same RN project the react-seek-{android,ios}-e2e
+    # workflows use.
     - SEEK_RN_REPO: git@github.com:bitrise-io/SeekReactNative.git
-    - ANDROID_SAMPLE_REPO: git@github.com:bitrise-samples/sample-apps-android-simple.git
     # Hardcoded test app dirs — used by both the setup bundles and the
     # inner workflows. Inner workflows can't see envman vars from the
     # outer bundle (each `bitrise run <inner>` starts with a fresh
     # envstore), so we keep the paths as constants here.
-    - WRAP_TEST_ANDROID_DIR: /tmp/wrap-test-android
+    # WRAP_TEST_ANDROID_DIR / WRAP_TEST_RN_DIR both point inside the
+    # same SeekReactNative checkout (android/ and root respectively).
     - WRAP_TEST_RN_DIR: /tmp/wrap-test-rn
+    - WRAP_TEST_ANDROID_DIR: /tmp/wrap-test-rn/android
     # Hardcoded branch reference for every wrap PR. Flip to default branch
     # post-merge.
     - WRAP_HELPER_REF: feat/use-cli-wrap-helper
@@ -82,8 +85,11 @@ step_bundles:
                 go build -o /usr/local/bin/bitrise-build-cache .
                 bitrise-build-cache version
 
-  # Activate React Native cache + clone Android sample app for the wrap-rollout test.
-  rn-wrap-activate-rn-android:
+  # Activate React Native cache + clone SeekReactNative. Used by every
+  # wrap-rollout workflow regardless of platform — its android/ subdir
+  # backs gradle steps, ios/ backs xcodebuild steps, and the repo root
+  # backs the npm step.
+  rn-wrap-setup-app:
     steps:
       - bundle::rn-wrap-build-cli: {}
       - script@1:
@@ -94,29 +100,6 @@ step_bundles:
                 set -euxo pipefail
                 bitrise-build-cache activate react-native
                 bitrise-build-cache status --feature=react-native --quiet
-      - script@1:
-          title: Clone Android sample app
-          inputs:
-            - content: |-
-                #!/usr/bin/env bash
-                set -euxo pipefail
-                rm -rf "$WRAP_TEST_ANDROID_DIR"
-                git clone --depth 1 "$ANDROID_SAMPLE_REPO" "$WRAP_TEST_ANDROID_DIR"
-
-  # Activate React Native cache + clone SeekReactNative for the iOS / RN wrap tests.
-  rn-wrap-activate-rn-ios:
-    steps:
-      - bundle::rn-wrap-build-cli: {}
-      - script@1:
-          title: Activate React Native build cache
-          inputs:
-            - content: |-
-                #!/usr/bin/env bash
-                set -euxo pipefail
-                bitrise-build-cache activate react-native
-                bitrise-build-cache status --feature=react-native --quiet
-      - activate-ssh-key@4:
-          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - script@1:
           title: Clone SeekReactNative
           inputs:
@@ -146,7 +129,7 @@ workflows:
         stack: linux-docker-android-22.04
         machine_type_id: g2.linux.medium
     steps:
-      - bundle::rn-wrap-activate-rn-android: {}
+      - bundle::rn-wrap-setup-app: {}
       - script@1:
           title: Run android-build via PR branch + capture
           is_always_run: true
@@ -183,7 +166,7 @@ workflows:
         stack: linux-docker-android-22.04
         machine_type_id: g2.linux.medium
     steps:
-      - bundle::rn-wrap-activate-rn-android: {}
+      - bundle::rn-wrap-setup-app: {}
       - script@1:
           title: Run android-unit-test via PR branch + capture
           is_always_run: true
@@ -217,7 +200,7 @@ workflows:
         stack: linux-docker-android-22.04
         machine_type_id: g2.linux.medium
     steps:
-      - bundle::rn-wrap-activate-rn-android: {}
+      - bundle::rn-wrap-setup-app: {}
       - script@1:
           title: Run android-lint via PR branch + capture
           is_always_run: true
@@ -251,7 +234,7 @@ workflows:
         stack: linux-docker-android-22.04
         machine_type_id: g2.linux.medium
     steps:
-      - bundle::rn-wrap-activate-rn-android: {}
+      - bundle::rn-wrap-setup-app: {}
       - script@1:
           title: Run gradle-unit-test via PR branch + capture
           is_always_run: true
@@ -286,7 +269,7 @@ workflows:
         stack: linux-docker-android-22.04
         machine_type_id: g2.linux.medium
     steps:
-      - bundle::rn-wrap-activate-rn-android: {}
+      - bundle::rn-wrap-setup-app: {}
       - script@1:
           title: Run gradle-runner via PR branch + capture
           is_always_run: true
@@ -325,7 +308,7 @@ workflows:
         stack: osx-xcode-edge
         machine_type_id: g2.mac.medium
     steps:
-      - bundle::rn-wrap-activate-rn-ios: {}
+      - bundle::rn-wrap-setup-app: {}
       - script@1:
           title: Run xcode-archive via PR branch + capture
           is_always_run: true
@@ -362,7 +345,7 @@ workflows:
         stack: osx-xcode-edge
         machine_type_id: g2.mac.medium
     steps:
-      - bundle::rn-wrap-activate-rn-ios: {}
+      - bundle::rn-wrap-setup-app: {}
       - script@1:
           title: Run xcode-test via PR branch + capture
           is_always_run: true
@@ -398,7 +381,7 @@ workflows:
         stack: osx-xcode-edge
         machine_type_id: g2.mac.medium
     steps:
-      - bundle::rn-wrap-activate-rn-ios: {}
+      - bundle::rn-wrap-setup-app: {}
       - script@1:
           title: Run xcode-analyze via PR branch + capture
           is_always_run: true
@@ -433,7 +416,7 @@ workflows:
         stack: osx-xcode-edge
         machine_type_id: g2.mac.medium
     steps:
-      - bundle::rn-wrap-activate-rn-ios: {}
+      - bundle::rn-wrap-setup-app: {}
       - script@1:
           title: Run xcode-build-for-test via PR branch + capture
           is_always_run: true
@@ -469,7 +452,7 @@ workflows:
         stack: osx-xcode-edge
         machine_type_id: g2.mac.medium
     steps:
-      - bundle::rn-wrap-activate-rn-ios: {}
+      - bundle::rn-wrap-setup-app: {}
       - script@1:
           title: Run xcode-build-for-simulator via PR branch + capture
           is_always_run: true
@@ -508,7 +491,7 @@ workflows:
         stack: linux-docker-android-22.04
         machine_type_id: g2.linux.medium
     steps:
-      - bundle::rn-wrap-activate-rn-ios: {}
+      - bundle::rn-wrap-setup-app: {}
       - script@1:
           title: Run npm via PR branch + capture
           is_always_run: true

--- a/e2e_rn_wrap_rollout.yml
+++ b/e2e_rn_wrap_rollout.yml
@@ -108,7 +108,7 @@ step_bundles:
                 rm -rf "$WRAP_TEST_RN_DIR"
                 git clone --depth 1 "$SEEK_RN_REPO" "$WRAP_TEST_RN_DIR"
                 cd "$WRAP_TEST_RN_DIR"
-                yarn install --frozen-lockfile
+                npm install --legacy-peer-deps --no-audit --no-fund
                 if [[ "$(uname)" == "Darwin" ]]; then
                     cd ios
                     pod install


### PR DESCRIPTION
## Summary

Adds a manually-triggered pipeline `rn-wrapping-e2e` that validates the React Native wrap-helper rollout across the 11 step PRs adopting `pkg/reactnative/wrap`.

For each step under test, a workflow:

1. Builds the CLI from this repo's source.
2. Activates the React Native build cache via the freshly-built CLI so `wrap.Detect` reports `ReactNativeEnabled=true`.
3. Runs the step under test from its `feat/use-cli-wrap-helper` PR branch via a nested `bitrise run` so the inner step's stdout/stderr can be teed to a log file.
4. Asserts the step printed the wrap-engagement line `wrapping (gradle|xcodebuild|npm) with /usr/local/bin/bitrise-build-cache`.

Build success is **not** required — we only care that the wrap helper engaged correctly without crashing the step before the underlying compile command was constructed. `is_always_run: true` on the assert keeps it running even when the step itself fails (missing certs, missing test devices, etc).

## Pipeline shape

- Pipeline is intentionally NOT in `trigger_map` — run manually from the Bitrise UI ("Start Build" → pick `rn-wrapping-e2e` pipeline) or via `bitrise trigger`.
- Each step gets an outer workflow (setup + nested run + assert + deploy) and an inner workflow (just the step under test). Outer/inner split lets the outer tee the inner's bitrise-cli output for grep.
- Setup logic lives in `step_bundles.rn-wrap-build-cli` / `rn-wrap-activate-rn-{android,ios}`.
- New file: `e2e_rn_wrap_rollout.yml`. Included from `bitrise.yml` via the existing `include:` directive (mirrors `bitrise_rn_config/bitrise.yml`).

## Step coverage (11)

| Step | PR | Pattern |
|---|---|---|
| bitrise-step-android-build | #59 | inline gradle |
| bitrise-step-android-unit-test | #45 | inline gradle |
| bitrise-step-android-lint | #34 | inline gradle |
| steps-gradle-unit-test | #28 | inline gradle |
| steps-gradle-runner | #126 | inline gradle (via v2.6.0 dep bump) |
| steps-xcode-archive | #424 | factory xcodebuild |
| steps-xcode-test | #275 | factory xcodebuild |
| steps-xcode-analyze | #47 | factory xcodebuild |
| steps-xcode-build-for-test | #83 | factory xcodebuild |
| steps-xcode-build-for-simulator | #58 | inline-on-v1 xcodebuild |
| steps-npm | #61 | factory npm |

## Out of scope

- `steps-xcode-archive-mac` (PR #53) and `steps-xcode-test-mac` (PR #36) — both v1-stack inline-on-v1, but they need a macOS scheme. SeekReactNative doesn't expose one. Deferred until we have a small macOS sample app.

## Follow-up after the wrap PRs merge

Flip every `git::<repo>@feat/use-cli-wrap-helper` reference in `e2e_rn_wrap_rollout.yml` to each repo's default branch (`master` / `main`). After that the pipeline tests `master`-state of every step.

Tracking ticket: [ACI-4808](https://bitrise.atlassian.net/browse/ACI-4808).

## Test plan

- [x] `bitrise validate` clean
- [ ] Trigger the pipeline manually from the Bitrise UI, confirm at least the gradle and xcodebuild assertion paths produce the expected wrap-engagement log line and the assert step exits 0
- [ ] Verify deploy step uploads the captured wrap log artifact for failure investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4808]: https://bitrise.atlassian.net/browse/ACI-4808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ