### PR TITLE
feat: add generic save-file / restore-file commands

### DIFF
--- a/cmd/common/client.go
+++ b/cmd/common/client.go
@@ -18,7 +18,6 @@ const (
 	ClientNameGradleConfigCache = "gradle-config"
 	ClientNameGradle            = "gradle"
 	ClientNameCcache            = "ccache"
-	ClientNameFile              = "file"
 )
 
 type CreateKVClientParams struct {

--- a/cmd/common/client.go
+++ b/cmd/common/client.go
@@ -18,6 +18,7 @@ const (
 	ClientNameGradleConfigCache = "gradle-config"
 	ClientNameGradle            = "gradle"
 	ClientNameCcache            = "ccache"
+	ClientNameFile              = "file"
 )
 
 type CreateKVClientParams struct {

--- a/cmd/file/file.go
+++ b/cmd/file/file.go
@@ -1,0 +1,170 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+)
+
+// nolint:gochecknoglobals,dupl
+var saveFileCmd = &cobra.Command{
+	Use:          "save-file",
+	Short:        "Save a single file to the Bitrise Build Cache under the given key",
+	Long:         `Save a single file to the Bitrise Build Cache under the given key. The file's content is uploaded under the cache key passed via --key.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		logger := log.NewLogger()
+		logger.EnableDebugLog(common.IsDebugLogMode)
+		common.LogCurrentUserInfo(logger)
+
+		logger.TInfof("Save file to Bitrise Build Cache")
+		logger.Infof("(i) Debug mode and verbose logs: %t", common.IsDebugLogMode)
+
+		cacheKey, _ := cmd.Flags().GetString("key")
+		filePath, _ := cmd.Flags().GetString("file")
+
+		if err := saveFile(cmd.Context(), cacheKey, filePath, logger); err != nil {
+			return fmt.Errorf("save file to Bitrise Build Cache: %w", err)
+		}
+
+		logger.TInfof("✅ File saved to Bitrise Build Cache")
+
+		return nil
+	},
+}
+
+// nolint:gochecknoglobals,dupl
+var restoreFileCmd = &cobra.Command{
+	Use:          "restore-file",
+	Short:        "Restore a single file from the Bitrise Build Cache by key",
+	Long:         `Restore a single file from the Bitrise Build Cache by key. The content stored under --key is downloaded and written to --file.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		logger := log.NewLogger()
+		logger.EnableDebugLog(common.IsDebugLogMode)
+		common.LogCurrentUserInfo(logger)
+
+		logger.TInfof("Restore file from Bitrise Build Cache")
+		logger.Infof("(i) Debug mode and verbose logs: %t", common.IsDebugLogMode)
+
+		cacheKey, _ := cmd.Flags().GetString("key")
+		filePath, _ := cmd.Flags().GetString("file")
+
+		if err := restoreFile(cmd.Context(), cacheKey, filePath, logger); err != nil {
+			return fmt.Errorf("restore file from Bitrise Build Cache: %w", err)
+		}
+
+		logger.TInfof("✅ File restored from Bitrise Build Cache")
+
+		return nil
+	},
+}
+
+func init() {
+	common.RootCmd.AddCommand(saveFileCmd)
+	saveFileCmd.Flags().String("key", "", "The cache key under which the file will be stored (required)")
+	saveFileCmd.Flags().String("file", "", "Path to the file to upload (required)")
+	_ = saveFileCmd.MarkFlagRequired("key")
+	_ = saveFileCmd.MarkFlagRequired("file")
+
+	common.RootCmd.AddCommand(restoreFileCmd)
+	restoreFileCmd.Flags().String("key", "", "The cache key under which the file is stored (required)")
+	restoreFileCmd.Flags().String("file", "", "Path where the restored file will be written (required)")
+	_ = restoreFileCmd.MarkFlagRequired("key")
+	_ = restoreFileCmd.MarkFlagRequired("file")
+}
+
+func newKVClient(ctx context.Context, logger log.Logger) (*kv.Client, error) {
+	logger.Infof("(i) Check Auth Config")
+	allEnvs := utils.AllEnvs()
+	authConfig, err := configcommon.ReadAuthConfigFromEnvironments(allEnvs)
+	if err != nil {
+		return nil, fmt.Errorf("read auth config from environments: %w", err)
+	}
+
+	kvClient, err := common.CreateKVClient(ctx,
+		common.CreateKVClientParams{
+			CacheOperationID: uuid.NewString(),
+			ClientName:       common.ClientNameFile,
+			AuthConfig:       authConfig,
+			Envs:             allEnvs,
+			CommandFunc: func(name string, v ...string) (string, error) {
+				output, err := exec.CommandContext(ctx, name, v...).Output()
+
+				return string(output), err
+			},
+			Logger: logger,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("create kv client: %w", err)
+	}
+
+	return kvClient, nil
+}
+
+func saveFile(ctx context.Context, cacheKey, filePath string, logger log.Logger) error {
+	if cacheKey == "" {
+		return errors.New("--key is required")
+	}
+	if filePath == "" {
+		return errors.New("--file is required")
+	}
+
+	if _, err := os.Stat(filePath); err != nil {
+		return fmt.Errorf("stat file %q: %w", filePath, err)
+	}
+
+	logger.Infof("(i) Cache key: %s", cacheKey)
+	logger.Infof("(i) File: %s", filePath)
+
+	kvClient, err := newKVClient(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	logger.TInfof("Uploading %s for key %s", filePath, cacheKey)
+	if err := kvClient.UploadFileToBuildCache(ctx, filePath, cacheKey); err != nil {
+		return fmt.Errorf("upload file to build cache: %w", err)
+	}
+
+	return nil
+}
+
+func restoreFile(ctx context.Context, cacheKey, filePath string, logger log.Logger) error {
+	if cacheKey == "" {
+		return errors.New("--key is required")
+	}
+	if filePath == "" {
+		return errors.New("--file is required")
+	}
+
+	logger.Infof("(i) Cache key: %s", cacheKey)
+	logger.Infof("(i) File: %s", filePath)
+
+	kvClient, err := newKVClient(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	logger.TInfof("Downloading %s for key %s", filePath, cacheKey)
+	if err := kvClient.DownloadFileFromBuildCache(ctx, filePath, cacheKey); err != nil {
+		if errors.Is(err, kv.ErrCacheNotFound) {
+			return fmt.Errorf("no cache item found for key %q: %w", cacheKey, err)
+		}
+
+		return fmt.Errorf("download file from build cache: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/file/file.go
+++ b/cmd/file/file.go
@@ -1,20 +1,13 @@
 package file
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"os"
-	"os/exec"
 
 	"github.com/bitrise-io/go-utils/v2/log"
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	pkgfile "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/file"
 )
 
 // nolint:gochecknoglobals,dupl
@@ -24,8 +17,7 @@ var saveFileCmd = &cobra.Command{
 	Long:         `Save a single file to the Bitrise Build Cache under the given key. The file's content is uploaded under the cache key passed via --key.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		logger := log.NewLogger()
-		logger.EnableDebugLog(common.IsDebugLogMode)
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 		common.LogCurrentUserInfo(logger)
 
 		logger.TInfof("Save file to Bitrise Build Cache")
@@ -34,7 +26,11 @@ var saveFileCmd = &cobra.Command{
 		cacheKey, _ := cmd.Flags().GetString("key")
 		filePath, _ := cmd.Flags().GetString("file")
 
-		if err := saveFile(cmd.Context(), cacheKey, filePath, logger); err != nil {
+		helper := pkgfile.NewHelper(pkgfile.HelperParams{
+			Logger:       logger,
+			DebugLogging: common.IsDebugLogMode,
+		})
+		if err := helper.Save(cmd.Context(), cacheKey, filePath); err != nil {
 			return fmt.Errorf("save file to Bitrise Build Cache: %w", err)
 		}
 
@@ -51,8 +47,7 @@ var restoreFileCmd = &cobra.Command{
 	Long:         `Restore a single file from the Bitrise Build Cache by key. The content stored under --key is downloaded and written to --file.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		logger := log.NewLogger()
-		logger.EnableDebugLog(common.IsDebugLogMode)
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 		common.LogCurrentUserInfo(logger)
 
 		logger.TInfof("Restore file from Bitrise Build Cache")
@@ -61,7 +56,11 @@ var restoreFileCmd = &cobra.Command{
 		cacheKey, _ := cmd.Flags().GetString("key")
 		filePath, _ := cmd.Flags().GetString("file")
 
-		if err := restoreFile(cmd.Context(), cacheKey, filePath, logger); err != nil {
+		helper := pkgfile.NewHelper(pkgfile.HelperParams{
+			Logger:       logger,
+			DebugLogging: common.IsDebugLogMode,
+		})
+		if err := helper.Restore(cmd.Context(), cacheKey, filePath); err != nil {
 			return fmt.Errorf("restore file from Bitrise Build Cache: %w", err)
 		}
 
@@ -83,88 +82,4 @@ func init() {
 	restoreFileCmd.Flags().String("file", "", "Path where the restored file will be written (required)")
 	_ = restoreFileCmd.MarkFlagRequired("key")
 	_ = restoreFileCmd.MarkFlagRequired("file")
-}
-
-func newKVClient(ctx context.Context, logger log.Logger) (*kv.Client, error) {
-	logger.Infof("(i) Check Auth Config")
-	allEnvs := utils.AllEnvs()
-	authConfig, err := configcommon.ReadAuthConfigFromEnvironments(allEnvs)
-	if err != nil {
-		return nil, fmt.Errorf("read auth config from environments: %w", err)
-	}
-
-	kvClient, err := common.CreateKVClient(ctx,
-		common.CreateKVClientParams{
-			CacheOperationID: uuid.NewString(),
-			ClientName:       common.ClientNameFile,
-			AuthConfig:       authConfig,
-			Envs:             allEnvs,
-			CommandFunc: func(name string, v ...string) (string, error) {
-				output, err := exec.CommandContext(ctx, name, v...).Output()
-
-				return string(output), err
-			},
-			Logger: logger,
-		})
-	if err != nil {
-		return nil, fmt.Errorf("create kv client: %w", err)
-	}
-
-	return kvClient, nil
-}
-
-func saveFile(ctx context.Context, cacheKey, filePath string, logger log.Logger) error {
-	if cacheKey == "" {
-		return errors.New("--key is required")
-	}
-	if filePath == "" {
-		return errors.New("--file is required")
-	}
-
-	if _, err := os.Stat(filePath); err != nil {
-		return fmt.Errorf("stat file %q: %w", filePath, err)
-	}
-
-	logger.Infof("(i) Cache key: %s", cacheKey)
-	logger.Infof("(i) File: %s", filePath)
-
-	kvClient, err := newKVClient(ctx, logger)
-	if err != nil {
-		return err
-	}
-
-	logger.TInfof("Uploading %s for key %s", filePath, cacheKey)
-	if err := kvClient.UploadFileToBuildCache(ctx, filePath, cacheKey); err != nil {
-		return fmt.Errorf("upload file to build cache: %w", err)
-	}
-
-	return nil
-}
-
-func restoreFile(ctx context.Context, cacheKey, filePath string, logger log.Logger) error {
-	if cacheKey == "" {
-		return errors.New("--key is required")
-	}
-	if filePath == "" {
-		return errors.New("--file is required")
-	}
-
-	logger.Infof("(i) Cache key: %s", cacheKey)
-	logger.Infof("(i) File: %s", filePath)
-
-	kvClient, err := newKVClient(ctx, logger)
-	if err != nil {
-		return err
-	}
-
-	logger.TInfof("Downloading %s for key %s", filePath, cacheKey)
-	if err := kvClient.DownloadFileFromBuildCache(ctx, filePath, cacheKey); err != nil {
-		if errors.Is(err, kv.ErrCacheNotFound) {
-			return fmt.Errorf("no cache item found for key %q: %w", cacheKey, err)
-		}
-
-		return fmt.Errorf("download file from build cache: %w", err)
-	}
-
-	return nil
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/bazel"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/ccache"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/file"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/gradle"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/reactnative"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode"

--- a/pkg/file/helper.go
+++ b/pkg/file/helper.go
@@ -1,0 +1,211 @@
+// Package file provides a public API for storing and retrieving a single
+// file in the Bitrise Build Cache by an arbitrary key. It exists so Go-based
+// steps can reuse the save-file / restore-file functionality without shelling
+// out to the bitrise-build-cache CLI.
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/google/uuid"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+)
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+// HelperParams configures the file save/restore Helper.
+type HelperParams struct {
+	// Envs is the set of environment variables used to read auth config and
+	// endpoint overrides. If nil, the current process environment is read.
+	Envs map[string]string
+
+	// EndpointURL overrides the build cache endpoint URL.
+	// If empty, the URL is selected from Envs (BITRISE_BUILD_CACHE_ENDPOINT) or
+	// falls back to the configured default.
+	EndpointURL string
+
+	// DebugLogging enables verbose debug output on the default logger.
+	// Ignored when Logger is set.
+	DebugLogging bool
+
+	// Logger overrides the default logger. If nil, a default logger is created.
+	Logger log.Logger
+
+	// CommandFunc is used to run external commands when collecting cache
+	// metadata (git, hostname, etc.). If nil, exec.Command is used.
+	CommandFunc configcommon.CommandFunc
+}
+
+// ErrCacheNotFound is returned (wrapped) by Restore when no entry exists for
+// the given key.
+var ErrCacheNotFound = kv.ErrCacheNotFound
+
+// ClientName is the kv.Client name reported for save-file / restore-file
+// operations. Exported so the cmd layer can use the same identifier.
+const ClientName = "file"
+
+// Helper saves and restores a single file in the Bitrise Build Cache.
+//
+// The zero value is not usable — construct via NewHelper.
+type Helper struct {
+	logger      log.Logger
+	envs        map[string]string
+	endpointURL string
+	commandFunc configcommon.CommandFunc
+}
+
+// NewHelper returns a Helper configured from params, applying defaults for any
+// nil fields. It does not perform any network or filesystem I/O — that happens
+// in Save / Restore.
+func NewHelper(params HelperParams) *Helper {
+	envs := params.Envs
+	if envs == nil {
+		envs = utils.AllEnvs()
+	}
+
+	logger := params.Logger
+	if logger == nil {
+		logger = log.NewLogger(log.WithDebugLog(params.DebugLogging))
+	}
+
+	commandFunc := params.CommandFunc
+	if commandFunc == nil {
+		commandFunc = defaultCommandFunc
+	}
+
+	return &Helper{
+		logger:      logger,
+		envs:        envs,
+		endpointURL: params.EndpointURL,
+		commandFunc: commandFunc,
+	}
+}
+
+// Save uploads the contents of filePath into the Bitrise Build Cache under the
+// given key. Returns an error if key or filePath is empty, the file cannot be
+// read, or the upload fails.
+func (h *Helper) Save(ctx context.Context, key, filePath string) error {
+	if err := validateArgs(key, filePath); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(filePath); err != nil {
+		return fmt.Errorf("stat file %q: %w", filePath, err)
+	}
+
+	h.logger.Infof("(i) Cache key: %s", key)
+	h.logger.Infof("(i) File: %s", filePath)
+
+	kvClient, err := h.newKVClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	h.logger.TInfof("Uploading %s for key %s", filePath, key)
+	if err := kvClient.UploadFileToBuildCache(ctx, filePath, key); err != nil {
+		return fmt.Errorf("upload file to build cache: %w", err)
+	}
+
+	return nil
+}
+
+// Restore downloads the cache entry stored under key and writes it to filePath,
+// creating any missing parent directories. Returns an error wrapping
+// ErrCacheNotFound if no entry exists for the given key.
+func (h *Helper) Restore(ctx context.Context, key, filePath string) error {
+	if err := validateArgs(key, filePath); err != nil {
+		return err
+	}
+
+	h.logger.Infof("(i) Cache key: %s", key)
+	h.logger.Infof("(i) File: %s", filePath)
+
+	kvClient, err := h.newKVClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	h.logger.TInfof("Downloading %s for key %s", filePath, key)
+	if err := kvClient.DownloadFileFromBuildCache(ctx, filePath, key); err != nil {
+		if errors.Is(err, kv.ErrCacheNotFound) {
+			return fmt.Errorf("no cache item found for key %q: %w", key, err)
+		}
+
+		return fmt.Errorf("download file from build cache: %w", err)
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Private — Helper internals
+// ---------------------------------------------------------------------------
+
+func (h *Helper) newKVClient(ctx context.Context) (*kv.Client, error) {
+	authConfig, err := configcommon.ReadAuthConfigFromEnvironments(h.envs)
+	if err != nil {
+		return nil, fmt.Errorf("read auth config from environments: %w", err)
+	}
+
+	endpointURL := configcommon.SelectCacheEndpointURL(h.endpointURL, h.envs)
+	h.logger.Debugf("Build Cache Endpoint URL: %s", endpointURL)
+
+	host, insecureGRPC, err := kv.ParseURLGRPC(endpointURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse endpoint URL %q: %w", endpointURL, err)
+	}
+
+	client, err := kv.NewClient(kv.NewClientParams{
+		UseInsecure:         insecureGRPC,
+		Host:                host,
+		DialTimeout:         5 * time.Second,
+		ClientName:          ClientName,
+		AuthConfig:          authConfig,
+		Logger:              h.logger,
+		CacheConfigMetadata: configcommon.NewMetadata(h.envs, h.commandFunc, h.logger),
+		CacheOperationID:    uuid.NewString(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("new kv client: %w", err)
+	}
+
+	if err := client.GetCapabilitiesWithRetry(ctx); err != nil {
+		return nil, fmt.Errorf("get capabilities: %w", err)
+	}
+
+	return client, nil
+}
+
+// ---------------------------------------------------------------------------
+// Private — package-level helpers
+// ---------------------------------------------------------------------------
+
+func validateArgs(key, filePath string) error {
+	if key == "" {
+		return errors.New("key must not be empty")
+	}
+
+	if filePath == "" {
+		return errors.New("file path must not be empty")
+	}
+
+	return nil
+}
+
+func defaultCommandFunc(name string, v ...string) (string, error) {
+	//nolint:noctx // configcommon.CommandFunc has no context parameter; callers can inject their own.
+	output, err := exec.Command(name, v...).Output()
+
+	return string(output), err
+}


### PR DESCRIPTION
## Summary
- Adds two new top-level subcommands that store/retrieve a single file in the Bitrise Build Cache by an arbitrary key:
  - `bitrise-build-cache save-file --key <k> --file <path>`
  - `bitrise-build-cache restore-file --key <k> --file <path>`
- Both `--key` and `--file` are required; auth/endpoint are picked up from the standard `BITRISE_BUILD_CACHE_*` env vars like the other commands.
- Reuses `kv.Client.UploadFileToBuildCache` / `DownloadFileFromBuildCache`. New `ClientNameFile = "file"` constant added for telemetry.

## Test plan
- [x] `make lint` clean
- [x] `make test-unit` clean
- [ ] Manual smoke test: run against a real workspace token to upload a small file with `save-file`, then `restore-file` it back to a different path and diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)