### PR TITLE
fix(ACI-4918): exclude no-activity children from RN combined hit rate

### DIFF
--- a/pkg/common/childstats/childstats.go
+++ b/pkg/common/childstats/childstats.go
@@ -189,6 +189,12 @@ type Summary struct {
 	// SkippedCount is the number of entries excluded (malformed only).
 	SkippedCount int
 
+	// NoActivityCount is the number of entries excluded because the child
+	// did no cacheable work (Total == 0). They are excluded from
+	// MeanHitRate / WeightedHitRate / ChildCount / per-tool aggregates so
+	// that idle children don't pull the reported hit rate toward 0%.
+	NoActivityCount int
+
 	// FailedCount is the number of entries that reported Failed=true. Used
 	// by parent wrappers to fail the wrapper invocation when any child
 	// failed (e.g. an xcodebuild child errored even though the parent script
@@ -255,6 +261,21 @@ func (a *Aggregator) Compute() (Summary, error) {
 
 			if a.Logger != nil {
 				a.Logger.Warnf("Skipping malformed child stats entry %s: %v", entryPath, err)
+			}
+
+			continue
+		}
+
+		// Skip entries with no cacheable work — including them only drags
+		// MeanHitRate toward 0% without telling the user anything useful.
+		if entry.Total == 0 {
+			summary.NoActivityCount++
+
+			if a.Logger != nil {
+				a.Logger.Debugf(
+					"Excluding child invocation %s (build tool: %s) from aggregate: no cache activity",
+					entry.ChildInvocationID, entry.BuildTool,
+				)
 			}
 
 			continue

--- a/pkg/common/childstats/childstats_test.go
+++ b/pkg/common/childstats/childstats_test.go
@@ -94,15 +94,16 @@ func TestAggregator_Compute_SimpleMeanAndByTool(t *testing.T) {
 	setHome(t)
 
 	w := NewWriter()
-	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.2}))
-	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "b", BuildTool: "gradle", HitRate: 0.8}))
-	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "c", BuildTool: "ccache", HitRate: 0.5}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.2, Hits: 2, Total: 10}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "b", BuildTool: "gradle", HitRate: 0.8, Hits: 8, Total: 10}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "c", BuildTool: "ccache", HitRate: 0.5, Hits: 5, Total: 10}))
 
 	summary, err := NewAggregator("p").Compute()
 	require.NoError(t, err)
 
 	assert.Equal(t, 3, summary.ChildCount)
 	assert.Equal(t, 0, summary.SkippedCount)
+	assert.Equal(t, 0, summary.NoActivityCount)
 	assert.InDelta(t, 0.5, summary.MeanHitRate, 1e-6)
 
 	gradle, ok := summary.ByTool["gradle"]
@@ -120,12 +121,16 @@ func TestAggregator_Compute_IncludesBaselineWithCount(t *testing.T) {
 	setHome(t)
 
 	w := NewWriter()
-	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.9}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.9, Hits: 9, Total: 10}))
+	// Baseline run: cache disabled but task still ran cacheable steps locally;
+	// writer reports Total > 0 with HitRate 0%. Must still count as baseline.
 	require.NoError(t, w.Write(Entry{
 		ParentInvocationID: "p",
 		ChildInvocationID:  "b",
 		BuildTool:          "gradle",
 		HitRate:            0.0,
+		Hits:               0,
+		Total:              10,
 		BenchmarkPhase:     BenchmarkPhaseBaseline,
 	}))
 
@@ -134,6 +139,7 @@ func TestAggregator_Compute_IncludesBaselineWithCount(t *testing.T) {
 	assert.Equal(t, 2, summary.ChildCount)
 	assert.Equal(t, 1, summary.BaselineCount)
 	assert.Equal(t, 0, summary.SkippedCount)
+	assert.Equal(t, 0, summary.NoActivityCount)
 	assert.InDelta(t, 0.45, summary.MeanHitRate, 1e-6)
 }
 
@@ -168,7 +174,7 @@ func TestAggregator_Compute_SkipsMalformedFiles(t *testing.T) {
 	setHome(t)
 
 	w := NewWriter()
-	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "good", BuildTool: "gradle", HitRate: 0.4}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "good", BuildTool: "gradle", HitRate: 0.4, Hits: 4, Total: 10}))
 
 	bad := filepath.Join(LedgerDir("p"), "broken"+EntryFileSuffix)
 	require.NoError(t, os.WriteFile(bad, []byte("{not json"), 0o600))
@@ -184,7 +190,7 @@ func TestAggregator_Compute_IgnoresUnrelatedFilesAndSubdirs(t *testing.T) {
 	setHome(t)
 
 	w := NewWriter()
-	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.3}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.3, Hits: 3, Total: 10}))
 
 	dir := LedgerDir("p")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("hi"), 0o600))
@@ -202,8 +208,8 @@ func TestSweep_RemovesStaleDirsKeepsFresh(t *testing.T) {
 	setHome(t)
 
 	w := NewWriter()
-	require.NoError(t, w.Write(Entry{ParentInvocationID: "fresh", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.5}))
-	require.NoError(t, w.Write(Entry{ParentInvocationID: "stale", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.5}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "fresh", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.5, Hits: 1, Total: 2}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "stale", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.5, Hits: 1, Total: 2}))
 
 	staleDir := LedgerDir("stale")
 	old := time.Now().Add(-48 * time.Hour)
@@ -227,7 +233,7 @@ func TestSweep_MissingRootIsNoOp(t *testing.T) {
 func TestSweep_IgnoresNonDirEntries(t *testing.T) {
 	setHome(t)
 
-	require.NoError(t, NewWriter().Write(Entry{ParentInvocationID: "p", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.5}))
+	require.NoError(t, NewWriter().Write(Entry{ParentInvocationID: "p", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.5, Hits: 1, Total: 2}))
 
 	root := filepath.Dir(LedgerDir("p"))
 	require.NoError(t, os.WriteFile(filepath.Join(root, "stray.txt"), []byte("hi"), 0o600))
@@ -241,7 +247,7 @@ func TestSweep_IgnoresNonDirEntries(t *testing.T) {
 func TestAggregator_Cleanup_RemovesDir(t *testing.T) {
 	setHome(t)
 
-	require.NoError(t, NewWriter().Write(Entry{ParentInvocationID: "p", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.5}))
+	require.NoError(t, NewWriter().Write(Entry{ParentInvocationID: "p", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0.5, Hits: 1, Total: 2}))
 
 	agg := NewAggregator("p")
 	require.NoError(t, agg.Cleanup())
@@ -257,20 +263,25 @@ func TestAggregator_Compute_CountsFailedEntries(t *testing.T) {
 	setHome(t)
 
 	w := NewWriter()
-	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "ok", BuildTool: "gradle", HitRate: 0.5}))
-	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "fail-1", BuildTool: "xcode", HitRate: 0.3, Failed: true}))
-	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "fail-2", BuildTool: "ccache", HitRate: 0, Failed: true}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "ok", BuildTool: "gradle", HitRate: 0.5, Hits: 1, Total: 2}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "fail-1", BuildTool: "xcode", HitRate: 0.3, Hits: 3, Total: 10, Failed: true}))
+	// fail-2 reports a failure but actually had cache activity (hits=0/total=4) — still counts.
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "fail-2", BuildTool: "ccache", HitRate: 0, Hits: 0, Total: 4, Failed: true}))
 
 	summary, err := NewAggregator("p").Compute()
 	require.NoError(t, err)
 	assert.Equal(t, 3, summary.ChildCount)
 	assert.Equal(t, 2, summary.FailedCount)
+	assert.Equal(t, 0, summary.NoActivityCount)
 }
 
-func TestAggregator_Compute_LegacyEntriesDefaultToNotFailed(t *testing.T) {
+func TestAggregator_Compute_LegacyEntriesAreSkippedAsNoActivity(t *testing.T) {
 	setHome(t)
 
-	// Simulate a legacy entry written by a writer that did not know about Failed.
+	// Legacy entries (pre-Total field) marshal Total=0 even if they reported
+	// a hit rate. Without Total we cannot weigh them; safest is to drop them
+	// from the aggregate so they don't drag MeanHitRate down. The owning
+	// writer is expected to start emitting Total — see ACI-4918 follow-up.
 	dir := LedgerDir("p")
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	legacy := `{"child_invocation_id":"old","parent_invocation_id":"p","build_tool":"gradle","hit_rate":0.5,"schema_version":1}`
@@ -278,6 +289,80 @@ func TestAggregator_Compute_LegacyEntriesDefaultToNotFailed(t *testing.T) {
 
 	summary, err := NewAggregator("p").Compute()
 	require.NoError(t, err)
+	assert.Equal(t, 0, summary.ChildCount)
+	assert.Equal(t, 1, summary.NoActivityCount)
+	assert.Equal(t, 0, summary.FailedCount)
+}
+
+func TestAggregator_Compute_ExcludesNoActivityChildren(t *testing.T) {
+	setHome(t)
+
+	w := NewWriter()
+	// Active child: 80% hit rate over 10 cacheable calls.
+	require.NoError(t, w.Write(Entry{
+		ParentInvocationID: "p", ChildInvocationID: "active", BuildTool: "xcode",
+		HitRate: 0.8, Hits: 8, Total: 10,
+	}))
+	// No-activity child: writer attempted to record but ccache had nothing
+	// cacheable to do. With the old behavior this would have pulled the mean
+	// from 80% down to 40%; it should now be excluded entirely.
+	require.NoError(t, w.Write(Entry{
+		ParentInvocationID: "p", ChildInvocationID: "idle", BuildTool: "ccache",
+		HitRate: 0, Hits: 0, Total: 0,
+	}))
+
+	summary, err := NewAggregator("p").Compute()
+	require.NoError(t, err)
+
 	assert.Equal(t, 1, summary.ChildCount)
-	assert.Equal(t, 0, summary.FailedCount, "missing 'failed' field must default to not-failed")
+	assert.Equal(t, 1, summary.NoActivityCount)
+	assert.InDelta(t, 0.8, summary.MeanHitRate, 1e-6)
+	assert.InDelta(t, 0.8, summary.WeightedHitRate, 1e-6)
+
+	// Per-tool aggregates only include the active child.
+	assert.Equal(t, 1, summary.ByTool["xcode"].Count)
+	_, hasCcache := summary.ByTool["ccache"]
+	assert.False(t, hasCcache, "no-activity tool must not appear in per-tool breakdown")
+}
+
+func TestAggregator_Compute_AllNoActivity(t *testing.T) {
+	setHome(t)
+
+	w := NewWriter()
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "a", BuildTool: "gradle", HitRate: 0, Hits: 0, Total: 0}))
+	require.NoError(t, w.Write(Entry{ParentInvocationID: "p", ChildInvocationID: "b", BuildTool: "ccache", HitRate: 0, Hits: 0, Total: 0}))
+
+	summary, err := NewAggregator("p").Compute()
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, summary.ChildCount)
+	assert.Equal(t, 2, summary.NoActivityCount)
+	assert.Equal(t, float32(0), summary.MeanHitRate)
+	assert.Equal(t, float32(0), summary.WeightedHitRate)
+	assert.Empty(t, summary.ByTool)
+}
+
+func TestAggregator_Compute_BaselineWithNoActivityIsExcluded(t *testing.T) {
+	setHome(t)
+
+	w := NewWriter()
+	require.NoError(t, w.Write(Entry{
+		ParentInvocationID: "p", ChildInvocationID: "active", BuildTool: "gradle",
+		HitRate: 0.6, Hits: 6, Total: 10,
+	}))
+	// Baseline run that ALSO had no cacheable work — the no-activity rule
+	// trumps baseline counting; the mean reflects only the active child.
+	require.NoError(t, w.Write(Entry{
+		ParentInvocationID: "p", ChildInvocationID: "baseline-idle", BuildTool: "gradle",
+		HitRate: 0, Hits: 0, Total: 0,
+		BenchmarkPhase: BenchmarkPhaseBaseline,
+	}))
+
+	summary, err := NewAggregator("p").Compute()
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, summary.ChildCount)
+	assert.Equal(t, 0, summary.BaselineCount, "baseline child with no activity must not be counted")
+	assert.Equal(t, 1, summary.NoActivityCount)
+	assert.InDelta(t, 0.6, summary.MeanHitRate, 1e-6)
 }

--- a/pkg/reactnative/post_run_deps.go
+++ b/pkg/reactnative/post_run_deps.go
@@ -84,9 +84,10 @@ func (d *postRunDeps) run(ctx context.Context, wrapperInvocationID string, args 
 	agg := childstats.NewAggregator(wrapperInvocationID)
 	agg.Logger = d.logger
 	summary, aggErr := agg.Compute()
-	if aggErr != nil {
+	switch {
+	case aggErr != nil:
 		d.logger.TWarnf("Failed to aggregate child invocation hit rates: %v", aggErr)
-	} else if summary.ChildCount > 0 {
+	case summary.ChildCount > 0:
 		d.logger.TInfof(
 			"Cache hit rate (avg of %d child invocations): %.1f%%",
 			summary.ChildCount, summary.MeanHitRate*100,
@@ -106,12 +107,26 @@ func (d *postRunDeps) run(ctx context.Context, wrapperInvocationID string, args 
 			)
 		}
 
+		if summary.NoActivityCount > 0 {
+			d.logger.TInfof(
+				"%d child invocation(s) excluded from the aggregate: no cache activity.",
+				summary.NoActivityCount,
+			)
+		}
+
 		if summary.FailedCount > 0 {
 			d.logger.TInfof(
 				"%d of %d child invocations reported a failure (informational; wrapper success is driven by the wrapped process exit code).",
 				summary.FailedCount, summary.ChildCount,
 			)
 		}
+	case summary.NoActivityCount > 0:
+		// All children present but none had activity — log it so the user
+		// understands why no aggregate hit rate is shown.
+		d.logger.TInfof(
+			"All %d child invocation(s) had no cache activity; skipping combined hit rate.",
+			summary.NoActivityCount,
+		)
 	}
 
 	// Wrapper Success follows the wrapped process's exit code only. We used to


### PR DESCRIPTION
## Summary

[ACI-4918](https://bitrise.atlassian.net/browse/ACI-4918): The combined cache hit rate the `react-native run` wrapper reports on its parent invocation is severely understated when any child invocation does no cacheable work. Idle children contribute `0` to the hit-rate sum but still increment `ChildCount`, so e.g. one xcode child at 80% plus one idle ccache child reads out as 40%.

This PR drops idle children (`Total == 0`) from the aggregate and surfaces the count so the user can see what was excluded.

## Changes

- `pkg/common/childstats/childstats.go`
  - New `Summary.NoActivityCount` field.
  - `Aggregator.Compute()` skips entries with `Total == 0` before any other accounting (baseline, failed, per-tool counters, mean / weighted hit rate). Skipped entries land in `NoActivityCount` only — they don't pollute `BaselineCount` even when the entry is marked baseline.
- `pkg/reactnative/post_run_deps.go`
  - Logs the `NoActivityCount` next to the existing aggregate lines.
  - Adds a dedicated log line for the all-children-no-activity case so the absence of a "Cache hit rate" line has a reason on the build log.
  - Switched the aggregate logging chain from `if/else if` to `switch` (gocritic).
- `pkg/common/childstats/childstats_test.go`
  - Updated existing tests to write entries with `Total > 0` (the old fixtures were unrealistic — production writers always set `Total` when there's activity).
  - New tests:
    - `TestAggregator_Compute_ExcludesNoActivityChildren` — one active + one idle child; mean is 80% (not 40%) and per-tool breakdown excludes the idle tool.
    - `TestAggregator_Compute_AllNoActivity` — all idle → `ChildCount == 0`, `NoActivityCount == N`, empty `ByTool`.
    - `TestAggregator_Compute_BaselineWithNoActivityIsExcluded` — baseline + idle is excluded from both `ChildCount` AND `BaselineCount`.
    - Renamed `TestAggregator_Compute_LegacyEntriesDefaultToNotFailed` → `TestAggregator_Compute_LegacyEntriesAreSkippedAsNoActivity`. Legacy entries (pre-Total) unmarshal to `Total=0` and are now skipped — documents the new behavior.

## Notes / follow-ups

- The gradle plugin writer (and any other RN-side child writer) should populate `Total` for entries that DID do cache work. If a writer reports `HitRate > 0` but `Total == 0` due to a bug, this PR will silently drop the entry instead of pulling the mean toward it. That's safer (the value would have been meaningless without `Total` anyway), but worth a short audit on the plugin side. Flagged as a follow-up in the ticket.

## Test plan

- [ ] `go test -tags unit -race ./pkg/common/childstats/... ./pkg/reactnative/...` passes locally ✅.
- [ ] CI green on this PR.
- [ ] After merge: trigger `react-seek-android-e2e` / `react-seek-ios-e2e` manually and confirm:
  - The `Cache hit rate (avg of N child invocations)` line reports a non-zero rate when any active child has hits.
  - The new `N child invocation(s) excluded from the aggregate: no cache activity.` line appears when ccache had no activity (Android) or wasn't activated (iOS).

[ACI-4918]: https://bitrise.atlassian.net/browse/ACI-4918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ