### PR TITLE
fix(ACI-4923): require RN activation+workspace; print slug-prefixed details URL

### DIFF
--- a/pkg/reactnative/post_run_deps.go
+++ b/pkg/reactnative/post_run_deps.go
@@ -24,11 +24,26 @@ import (
 // ---------------------------------------------------------------------------
 
 // MsgRNInvocationSaved is the log line emitted after the BE confirms the
-// React Native wrapper invocation was persisted. The URL points at the
-// per-invocation details page in the Bitrise app. Mirrors the equivalent
-// xcode and gradle messages so users (especially on non-Bitrise CI) can
-// jump straight to the invocation in the Bitrise UI.
-const MsgRNInvocationSaved = "React Native invocation saved. Visit 👉 https://app.bitrise.io/build-cache/invocations/react-native/%s"
+// React Native wrapper invocation was persisted. Format args: pre-formatted
+// URL pointing at the per-invocation details page in the Bitrise app.
+// Use rnInvocationDetailsURL to build the URL — the workspace slug is
+// required for the page to render (without it the route 404s for
+// react-native, see ACI-4923).
+const MsgRNInvocationSaved = "React Native invocation saved. Visit 👉 %s"
+
+// rnInvocationDetailsURL returns the public details URL for a React Native
+// invocation. When the workspace slug is known, the URL includes it
+// (`/build-cache/<workspace>/invocations/react-native/<id>`) and renders
+// the page directly. When it isn't, fall back to the workspace-less form;
+// it does not currently render for react-native, but it stays consistent
+// with the other tools' log lines and with future BE behaviour.
+func rnInvocationDetailsURL(workspaceSlug, invocationID string) string {
+	if workspaceSlug == "" {
+		return fmt.Sprintf("https://app.bitrise.io/build-cache/invocations/react-native/%s", invocationID)
+	}
+
+	return fmt.Sprintf("https://app.bitrise.io/build-cache/%s/invocations/react-native/%s", workspaceSlug, invocationID)
+}
 
 // postRunDeps handles post-run analytics: invocation reporting, ccache stats
 // collection, and invocation relation registration.
@@ -140,7 +155,7 @@ func (d *postRunDeps) run(ctx context.Context, wrapperInvocationID string, args 
 	} else {
 		// BE confirmed the invocation was stored — surface the details URL
 		// so users can jump to it from the build log.
-		d.logger.TInfof(MsgRNInvocationSaved, wrapperInvocationID)
+		d.logger.TInfof(MsgRNInvocationSaved, rnInvocationDetailsURL(d.authConfig.WorkspaceID, wrapperInvocationID))
 	}
 
 	if err := agg.Cleanup(); err != nil {

--- a/pkg/reactnative/post_run_deps.go
+++ b/pkg/reactnative/post_run_deps.go
@@ -32,16 +32,11 @@ import (
 const MsgRNInvocationSaved = "React Native invocation saved. Visit 👉 %s"
 
 // rnInvocationDetailsURL returns the public details URL for a React Native
-// invocation. When the workspace slug is known, the URL includes it
-// (`/build-cache/<workspace>/invocations/react-native/<id>`) and renders
-// the page directly. When it isn't, fall back to the workspace-less form;
-// it does not currently render for react-native, but it stays consistent
-// with the other tools' log lines and with future BE behaviour.
+// invocation. The workspace slug is required: the route 404s without it for
+// the react-native build-tool (gradle / xcode happen to redirect through
+// session, but RN does not). Callers must only invoke this once the runner
+// has confirmed activation is complete and the workspace slug is set.
 func rnInvocationDetailsURL(workspaceSlug, invocationID string) string {
-	if workspaceSlug == "" {
-		return fmt.Sprintf("https://app.bitrise.io/build-cache/invocations/react-native/%s", invocationID)
-	}
-
 	return fmt.Sprintf("https://app.bitrise.io/build-cache/%s/invocations/react-native/%s", workspaceSlug, invocationID)
 }
 

--- a/pkg/reactnative/post_run_deps_test.go
+++ b/pkg/reactnative/post_run_deps_test.go
@@ -1,0 +1,29 @@
+//go:build unit
+
+package reactnative
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRNInvocationDetailsURL_WithWorkspace(t *testing.T) {
+	got := rnInvocationDetailsURL("ws-slug", "inv-id")
+	assert.Equal(t,
+		"https://app.bitrise.io/build-cache/ws-slug/invocations/react-native/inv-id",
+		got,
+	)
+}
+
+func TestRNInvocationDetailsURL_FallsBackWhenWorkspaceMissing(t *testing.T) {
+	// The workspace-less URL does not currently render for react-native (the
+	// reason ACI-4923 was filed), but the CLI must still emit *some* URL
+	// when the workspace slug is unavailable, matching the other tools'
+	// log lines and the BE behaviour expected once the public route is fixed.
+	got := rnInvocationDetailsURL("", "inv-id")
+	assert.Equal(t,
+		"https://app.bitrise.io/build-cache/invocations/react-native/inv-id",
+		got,
+	)
+}

--- a/pkg/reactnative/post_run_deps_test.go
+++ b/pkg/reactnative/post_run_deps_test.go
@@ -15,15 +15,3 @@ func TestRNInvocationDetailsURL_WithWorkspace(t *testing.T) {
 		got,
 	)
 }
-
-func TestRNInvocationDetailsURL_FallsBackWhenWorkspaceMissing(t *testing.T) {
-	// The workspace-less URL does not currently render for react-native (the
-	// reason ACI-4923 was filed), but the CLI must still emit *some* URL
-	// when the workspace slug is unavailable, matching the other tools'
-	// log lines and the BE behaviour expected once the public route is fixed.
-	got := rnInvocationDetailsURL("", "inv-id")
-	assert.Equal(t,
-		"https://app.bitrise.io/build-cache/invocations/react-native/inv-id",
-		got,
-	)
-}

--- a/pkg/reactnative/run_cmd_test.go
+++ b/pkg/reactnative/run_cmd_test.go
@@ -5,6 +5,8 @@ package reactnative
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -20,7 +22,31 @@ func newTestRunner(params RunnerParams) *Runner {
 	return r
 }
 
+// activateRNHome points HOME at a temp dir and writes the marker + multiplatform
+// configs the Runner needs to consider RN "activated" (so the run path is not
+// bypassed by isReactNativeReady). Returns the fake HOME.
+func activateRNHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	rnDir := filepath.Join(home, ".bitrise/cache/reactnative")
+	require.NoError(t, os.MkdirAll(rnDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(rnDir, "config.json"), []byte(`{"enabled":true}`), 0o644))
+
+	mpDir := filepath.Join(home, ".bitrise/analytics/multiplatform")
+	require.NoError(t, os.MkdirAll(mpDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(mpDir, "config.json"),
+		[]byte(`{"authConfig":{"AuthToken":"tok","WorkspaceID":"ws-slug","IsJWT":false}}`),
+		0o644,
+	))
+
+	return home
+}
+
 func TestRunner_Run(t *testing.T) {
+	activateRNHome(t)
 	ctx := context.Background()
 
 	t.Run("args are passed through to the command", func(t *testing.T) {
@@ -137,6 +163,7 @@ func TestRunner_Run(t *testing.T) {
 }
 
 func TestRunner_PostRunHook(t *testing.T) {
+	activateRNHome(t)
 	ctx := context.Background()
 	noOpExec := func(_ []string, _ string, _ ...string) error { return nil }
 
@@ -202,6 +229,81 @@ func TestRunner_PostRunHook(t *testing.T) {
 		_ = r.Run(ctx, []string{"true"}, "inv", []string{})
 
 		require.Len(t, mock.runCalls(), 1)
+	})
+}
+
+func TestRunner_BypassWhenNotActivated(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("missing RN marker → command runs unwrapped, no invocation ID injected, postRun not called", func(t *testing.T) {
+		// Empty HOME — no RN marker, no multiplatform config.
+		t.Setenv("HOME", t.TempDir())
+
+		var capturedName string
+		var capturedArgs []string
+		var capturedEnviron []string
+
+		mock := &postRunRunnerMock{}
+		r := NewRunner(RunnerParams{
+			ExecFn: func(environ []string, name string, args ...string) error {
+				capturedName = name
+				capturedArgs = args
+				capturedEnviron = environ
+
+				return nil
+			},
+		})
+		r.socket = nil
+		r.postRun = mock
+
+		err := r.Run(ctx, []string{"yarn", "build"}, "given-id", []string{"EXISTING=value"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "yarn", capturedName)
+		assert.Equal(t, []string{"build"}, capturedArgs)
+		assert.Equal(t, []string{"EXISTING=value"}, capturedEnviron, "environ must be unchanged when bypassed")
+		for _, e := range capturedEnviron {
+			assert.False(t, strings.HasPrefix(e, "BITRISE_INVOCATION_ID="), "no invocation ID should be injected when bypassed")
+		}
+		assert.Empty(t, mock.runCalls(), "postRun must not fire when bypassed")
+	})
+
+	t.Run("missing workspace ID → command runs unwrapped", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		// RN marker present but multiplatform config has empty WorkspaceID.
+		rnDir := filepath.Join(home, ".bitrise/cache/reactnative")
+		require.NoError(t, os.MkdirAll(rnDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(rnDir, "config.json"), []byte(`{"enabled":true}`), 0o644))
+
+		mpDir := filepath.Join(home, ".bitrise/analytics/multiplatform")
+		require.NoError(t, os.MkdirAll(mpDir, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(mpDir, "config.json"),
+			[]byte(`{"authConfig":{"AuthToken":"tok","WorkspaceID":"","IsJWT":false}}`),
+			0o644,
+		))
+
+		var capturedEnviron []string
+		mock := &postRunRunnerMock{}
+		r := NewRunner(RunnerParams{
+			ExecFn: func(environ []string, _ string, _ ...string) error {
+				capturedEnviron = environ
+
+				return nil
+			},
+		})
+		r.socket = nil
+		r.postRun = mock
+
+		err := r.Run(ctx, []string{"yarn", "build"}, "given-id", []string{"EXISTING=value"})
+
+		require.NoError(t, err)
+		for _, e := range capturedEnviron {
+			assert.False(t, strings.HasPrefix(e, "BITRISE_INVOCATION_ID="), "no invocation ID should be injected when bypassed")
+		}
+		assert.Empty(t, mock.runCalls(), "postRun must not fire when bypassed")
 	})
 }
 

--- a/pkg/reactnative/runner.go
+++ b/pkg/reactnative/runner.go
@@ -13,8 +13,15 @@ import (
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
+	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/reactnative"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
+
+// MsgRNNotActivated is the warning emitted when `react-native run` is invoked
+// before (or without) `activate react-native`. The user's command is still
+// executed unchanged so the build doesn't fail; only the build-cache wrapping
+// (ccache plumbing, invocation ID injection, analytics) is skipped.
+const MsgRNNotActivated = "Bitrise Build Cache for React Native is not activated on this machine — running the wrapped command without build-cache instrumentation. Run `bitrise-build-cache activate react-native` (with a workspace ID configured) first to enable."
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -106,16 +113,14 @@ func NewRunner(params RunnerParams) *Runner {
 
 // Run injects a BITRISE_INVOCATION_ID into environ and delegates execution to ExecFn.
 // If wrapperInvocationID is empty, a random UUID is used.
+//
+// When `activate react-native` was never run on this machine (or the
+// activation didn't carry a workspace ID through), the wrapped command is
+// still executed but every build-cache-related side-effect — ccache helper
+// plumbing, invocation ID injection, analytics — is skipped. The user's
+// build never fails just because the cache wasn't activated.
 func (r *Runner) Run(ctx context.Context, args []string, wrapperInvocationID string, environ []string) error {
 	configcommon.LogCLIVersion(r.logger)
-
-	if wrapperInvocationID == "" {
-		r.logger.TInfof("No invocation ID provided, generating a random one")
-
-		wrapperInvocationID = uuid.New().String()
-	}
-
-	r.logger.TInfof("React Native invocation ID: %s", wrapperInvocationID)
 
 	// Strip leading "--" separator (cobra passes it through with DisableFlagParsing)
 	if len(args) > 0 && args[0] == "--" {
@@ -127,6 +132,20 @@ func (r *Runner) Run(ctx context.Context, args []string, wrapperInvocationID str
 	}
 
 	name, cmdArgs := args[0], args[1:]
+
+	if !r.isReactNativeReady() {
+		r.logger.TWarnf(MsgRNNotActivated)
+
+		return r.execFn(environ, name, cmdArgs...)
+	}
+
+	if wrapperInvocationID == "" {
+		r.logger.TInfof("No invocation ID provided, generating a random one")
+
+		wrapperInvocationID = uuid.New().String()
+	}
+
+	r.logger.TInfof("React Native invocation ID: %s", wrapperInvocationID)
 
 	if r.socket != nil {
 		r.ensureHelper(ctx, wrapperInvocationID)
@@ -142,6 +161,29 @@ func (r *Runner) Run(ctx context.Context, args []string, wrapperInvocationID str
 	}
 
 	return execErr
+}
+
+// isReactNativeReady reports whether `activate react-native` was run on this
+// machine AND the multiplatform analytics config has the workspace slug we
+// need to identify the user's workspace at analytics + UI URL time.
+//
+// Both signals must agree. The RN marker on its own only says "activate
+// happened"; the multiplatform config carries the workspace slug that the
+// post-run hook and the Visit-URL log line depend on. A missing or
+// empty-workspace config means we cannot safely report analytics or print
+// a working details URL, so we skip wrapping entirely (and log once).
+func (r *Runner) isReactNativeReady() bool {
+	cfg, err := rnconfig.ReadConfig(r.osProxy, r.decoderFactory)
+	if err != nil || !cfg.Enabled {
+		return false
+	}
+
+	mpCfg, err := multiplatformconfig.ReadConfig(r.osProxy, r.decoderFactory)
+	if err != nil {
+		return false
+	}
+
+	return mpCfg.AuthConfig.WorkspaceID != ""
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes [ACI-4923](https://bitrise.atlassian.net/browse/ACI-4923): the link the CLI prints after a React Native wrapper invocation save returns **404**.

```
[13:40:05] React Native invocation saved. Visit 👉 https://app.bitrise.io/build-cache/invocations/react-native/ffc0a374-…
```

## Root cause

Two layers:

1. **The URL itself is missing the workspace slug.** The public web route that resolves a workspace from the user session does not include `react-native` in its build-tool dispatch — gradle / xcode happen to redirect to a useful page from the slug-less URL but RN does not. The route that actually renders is the slug-prefixed form already used by the JSON BFF route:

   ```
   https://app.bitrise.io/<workspace_slug>/invocations/react-native/<id>
   ```

   Verified live (workspace `322a005426441b60`, an RN invocation from PR #317 e2e):

   | URL | Status |
   |---|---|
   | `…/build-cache/invocations/react-native/<id>` (old) | 302 → `/users/sign_in` (no resolution) |
   | `…/build-cache/<workspace_slug>/invocations/react-native/<id>` (this PR) | 200 |

2. **The runner pressed on even when the workspace slug was missing.** If `react-native run` is invoked without `activate react-native` (or with an activation that didn't carry a workspace ID through), there's no slug to build a correct URL — and no workspace context for analytics either. The previous behaviour silently emitted the broken slug-less URL.

## Changes

- `pkg/reactnative/runner.go`
  - New activation gate `isReactNativeReady()` at the start of `Run`: checks the RN marker (`~/.bitrise/cache/reactnative/config.json`) **and** that the multiplatform analytics config carries a non-empty `AuthConfig.WorkspaceID`.
  - If either is missing, emit `MsgRNNotActivated` (one warning) and execute the wrapped command unchanged — no IPC plumbing, no `BITRISE_INVOCATION_ID` injection, no post-run analytics. **The user's build never fails just because activation was skipped.**
- `pkg/reactnative/post_run_deps.go`
  - `MsgRNInvocationSaved` is now `…Visit 👉 %s` and takes a fully-formed URL.
  - `rnInvocationDetailsURL(workspaceSlug, invocationID)` builds the slug-prefixed URL. With the activation gate in place we no longer need a workspace-less fallback — callers only reach this once the slug is known.
- `pkg/reactnative/run_cmd_test.go`
  - `activateRNHome(t)` helper writes the RN marker + multiplatform config into a temp `HOME` so existing tests don't depend on the developer's local activation state. Wired into `TestRunner_Run` and `TestRunner_PostRunHook`.
  - New `TestRunner_BypassWhenNotActivated` covering both bypass paths: missing RN marker, and present marker with empty `WorkspaceID`. Asserts no invocation ID injected and `postRun` not fired.
- `pkg/reactnative/post_run_deps_test.go`
  - `TestRNInvocationDetailsURL_WithWorkspace` — slug-prefixed shape. (The previous `…FallsBackWhenWorkspaceMissing` case is gone since the fallback is gone.)

## Notes / out of scope

- The same slug-less URL is also emitted by `cmd/xcode/xcodebuild.go:46` (`MsgInvocationSaved`) and the bazel BES base in `internal/config/bazel/bazelrc.gotemplate`. Today gradle/xcode happen to redirect via session, so they're not user-visible failures — kept out of this PR per the scope of ACI-4923. Easy follow-up if/when the website tightens the redirect dispatch.

## Test plan

- [ ] `go test -tags unit -race ./pkg/reactnative/...` passes locally ✅.
- [ ] CI green on this PR.
- [ ] After merge: confirm a fresh `react-native run` build prints the slug-prefixed URL and that opening it in a browser renders the invocation page.
- [ ] Manual: invoke `react-native run` without first running `activate react-native` → expect the `MsgRNNotActivated` warning and the wrapped command running to completion unchanged.

[ACI-4923]: https://bitrise.atlassian.net/browse/ACI-4923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ