### PR TITLE
fix(ACI-4922): consolidate benchmark phase log into a single summary

### DIFF
--- a/cmd/gradle/activate_gradle.go
+++ b/cmd/gradle/activate_gradle.go
@@ -63,6 +63,8 @@ If the "# [start/end] generated-by-bitrise-build-cache" block is already present
 			return fmt.Errorf("activate plugins for Gradle: %w", err)
 		}
 
+		configcommon.LogBenchmarkSummary(logger, []string{configcommon.BuildToolGradle})
+
 		logger.TInfof("✅ Bitrise plugins activated")
 
 		return nil

--- a/cmd/xcode/activate_xcode.go
+++ b/cmd/xcode/activate_xcode.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
@@ -47,7 +48,7 @@ This command will:
 		activateXcodeParams.DebugLogging = common.IsDebugLogMode
 		logger.Infof("Activate Xcode params: %+v", activateXcodeParams)
 
-		return xcelerate.Activate(
+		if err := xcelerate.Activate(
 			cmd.Context(),
 			logger,
 			utils.DefaultOsProxy{},
@@ -56,7 +57,13 @@ This command will:
 			utils.DefaultDecoderFactory{},
 			activateXcodeParams,
 			utils.AllEnvs(),
-		)
+		); err != nil {
+			return err //nolint:wrapcheck // xcelerate.Activate already returns wrapped errors
+		}
+
+		configcommon.LogBenchmarkSummary(logger, []string{configcommon.BuildToolXcode})
+
+		return nil
 	},
 }
 

--- a/internal/config/common/benchmark_summary.go
+++ b/internal/config/common/benchmark_summary.go
@@ -28,10 +28,8 @@ func LogBenchmarkSummary(logger log.Logger, tools []string) {
 		phase string
 	}
 
-	var (
-		entries         []entry
-		anyCacheEnabled bool
-	)
+	entries := make([]entry, 0, len(tools))
+	anyCacheEnabled := false
 
 	for _, tool := range tools {
 		phase := ReadBenchmarkPhaseFile(tool, logger)

--- a/internal/config/common/benchmark_summary.go
+++ b/internal/config/common/benchmark_summary.go
@@ -1,0 +1,80 @@
+package common
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+)
+
+// LogBenchmarkSummary emits a single consolidated log line summarizing the
+// resolved benchmark phase for each active build tool. The previous per-tool
+// "(i) Benchmark phase: …" + "Benchmark baseline mode: …" / warmup info lines
+// were misleading on multi-tool activations (e.g. React Native, where one
+// tool can be in baseline while the other is in warmup) — they made the
+// build look like it was entirely in baseline even when the tool the build
+// actually used was caching normally.
+//
+// The summary highlights which tools have the cache enabled and only uses
+// the warning channel when *every* active tool is in baseline (= the build
+// genuinely cannot benefit from the cache). Otherwise it logs at info level.
+//
+// Tools without a resolved phase (no benchmark file present, e.g. on
+// non-Bitrise CI or when the BE returned an empty phase) are skipped. The
+// function is a no-op when none of the requested tools have a phase.
+func LogBenchmarkSummary(logger log.Logger, tools []string) {
+	type entry struct {
+		tool  string
+		phase string
+	}
+
+	var (
+		entries         []entry
+		anyCacheEnabled bool
+	)
+
+	for _, tool := range tools {
+		phase := ReadBenchmarkPhaseFile(tool, logger)
+		if phase == "" {
+			continue
+		}
+
+		entries = append(entries, entry{tool: tool, phase: phase})
+
+		if phase != BenchmarkPhaseBaseline {
+			anyCacheEnabled = true
+		}
+	}
+
+	if len(entries) == 0 {
+		return
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].tool < entries[j].tool })
+
+	parts := make([]string, 0, len(entries))
+	for _, e := range entries {
+		parts = append(parts, formatBenchmarkEntry(e.tool, e.phase))
+	}
+
+	summary := strings.Join(parts, ", ")
+
+	if anyCacheEnabled {
+		logger.Infof("(i) Benchmark phases: %s", summary)
+
+		return
+	}
+
+	logger.Warnf("All active build tools in baseline benchmark mode (%s): cache disabled, analytics only", summary)
+}
+
+func formatBenchmarkEntry(tool, phase string) string {
+	switch phase {
+	case BenchmarkPhaseBaseline:
+		return tool + "=baseline (cache disabled)"
+	case BenchmarkPhaseWarmup:
+		return tool + "=warmup (cache enabled, hit rate may not be ideal)"
+	default:
+		return tool + "=" + phase
+	}
+}

--- a/internal/config/common/benchmark_summary_test.go
+++ b/internal/config/common/benchmark_summary_test.go
@@ -1,0 +1,120 @@
+//go:build unit
+
+package common
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingLogger captures the Info / Warn lines emitted during a test.
+// Embeds log.Logger so the value satisfies the full interface; only Infof
+// and Warnf are overridden because those are the ones LogBenchmarkSummary
+// uses.
+type recordingLogger struct {
+	log.Logger
+	infoLines []string
+	warnLines []string
+}
+
+func (r *recordingLogger) Infof(format string, args ...any) {
+	r.infoLines = append(r.infoLines, fmt.Sprintf(format, args...))
+}
+
+func (r *recordingLogger) Warnf(format string, args ...any) {
+	r.warnLines = append(r.warnLines, fmt.Sprintf(format, args...))
+}
+
+func TestLogBenchmarkSummary_NoPhasesNoOp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	rl := &recordingLogger{Logger: log.NewLogger()}
+	LogBenchmarkSummary(rl, []string{BuildToolGradle, BuildToolXcode})
+
+	assert.Empty(t, rl.infoLines, "should not emit info when no phase files exist")
+	assert.Empty(t, rl.warnLines, "should not emit warn when no phase files exist")
+}
+
+func TestLogBenchmarkSummary_AnyToolNotBaselineUsesInfo(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	WriteBenchmarkPhaseFile(BuildToolGradle, BenchmarkPhaseWarmup, log.NewLogger())
+	WriteBenchmarkPhaseFile(BuildToolXcode, BenchmarkPhaseBaseline, log.NewLogger())
+
+	rl := &recordingLogger{Logger: log.NewLogger()}
+	LogBenchmarkSummary(rl, []string{BuildToolGradle, BuildToolXcode})
+
+	require.Len(t, rl.infoLines, 1)
+	assert.Empty(t, rl.warnLines)
+
+	line := rl.infoLines[0]
+	assert.Contains(t, line, "gradle=warmup (cache enabled")
+	assert.Contains(t, line, "xcode=baseline (cache disabled)")
+}
+
+func TestLogBenchmarkSummary_AllBaselineUsesWarn(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	WriteBenchmarkPhaseFile(BuildToolGradle, BenchmarkPhaseBaseline, log.NewLogger())
+	WriteBenchmarkPhaseFile(BuildToolXcode, BenchmarkPhaseBaseline, log.NewLogger())
+
+	rl := &recordingLogger{Logger: log.NewLogger()}
+	LogBenchmarkSummary(rl, []string{BuildToolGradle, BuildToolXcode})
+
+	assert.Empty(t, rl.infoLines)
+	require.Len(t, rl.warnLines, 1)
+
+	line := rl.warnLines[0]
+	assert.Contains(t, line, "All active build tools in baseline benchmark mode")
+	assert.Contains(t, line, "gradle=baseline")
+	assert.Contains(t, line, "xcode=baseline")
+}
+
+func TestLogBenchmarkSummary_SkipsToolsWithoutPhase(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	WriteBenchmarkPhaseFile(BuildToolGradle, BenchmarkPhaseWarmup, log.NewLogger())
+
+	rl := &recordingLogger{Logger: log.NewLogger()}
+	LogBenchmarkSummary(rl, []string{BuildToolGradle, BuildToolXcode})
+
+	require.Len(t, rl.infoLines, 1)
+
+	line := rl.infoLines[0]
+	assert.Contains(t, line, "gradle=warmup")
+	assert.NotContains(t, line, "xcode")
+}
+
+func TestLogBenchmarkSummary_SingleToolBaselineWarns(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	WriteBenchmarkPhaseFile(BuildToolGradle, BenchmarkPhaseBaseline, log.NewLogger())
+
+	rl := &recordingLogger{Logger: log.NewLogger()}
+	LogBenchmarkSummary(rl, []string{BuildToolGradle})
+
+	assert.Empty(t, rl.infoLines)
+	require.Len(t, rl.warnLines, 1)
+	assert.Contains(t, rl.warnLines[0], "gradle=baseline")
+}
+
+func TestLogBenchmarkSummary_OutputIsToolOrderStable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	WriteBenchmarkPhaseFile(BuildToolXcode, BenchmarkPhaseWarmup, log.NewLogger())
+	WriteBenchmarkPhaseFile(BuildToolGradle, BenchmarkPhaseWarmup, log.NewLogger())
+
+	rl := &recordingLogger{Logger: log.NewLogger()}
+	LogBenchmarkSummary(rl, []string{BuildToolXcode, BuildToolGradle})
+
+	require.Len(t, rl.infoLines, 1)
+	line := rl.infoLines[0]
+
+	// Tools sorted alphabetically: gradle before xcode.
+	assert.Less(t, strings.Index(line, "gradle="), strings.Index(line, "xcode="))
+}

--- a/internal/config/gradle/benchmark.go
+++ b/internal/config/gradle/benchmark.go
@@ -13,9 +13,11 @@ type EnvExporter interface {
 }
 
 // ApplyBenchmarkPhase queries the benchmark phase and overrides gradle params accordingly.
-// Baseline phase disables cache and enables analytics only. Warmup phase logs a warning.
-// The phase is exported as BITRISE_BUILD_CACHE_BENCHMARK_PHASE env var
-// and written to ~/.local/state/xcelerate/benchmark/benchmark-phase.json as fallback.
+// Baseline phase disables cache and enables analytics only.
+// The phase is exported as BITRISE_BUILD_CACHE_BENCHMARK_PHASE_GRADLE env var
+// and written to ~/.local/state/xcelerate/benchmark/benchmark-phase-gradle.json
+// as fallback. The user-facing log line is emitted once by
+// common.LogBenchmarkSummary at the end of activation, not from this function.
 func ApplyBenchmarkPhase(
 	params *ActivateGradleParams,
 	logger log.Logger,
@@ -37,18 +39,18 @@ func ApplyBenchmarkPhase(
 	}
 
 	envVar := common.BenchmarkPhaseEnvVar(common.BuildToolGradle)
-	logger.Infof("(i) Benchmark phase: %s", phase)
 	exporter.Export(envVar, phase)
 	exporter.ExportToShellRC("Bitrise Benchmark Phase", "export "+envVar+"="+phase)
 	common.WriteBenchmarkPhaseFile(common.BuildToolGradle, phase, logger)
 
-	switch phase {
-	case common.BenchmarkPhaseBaseline:
-		logger.Warnf("Benchmark baseline mode: disabling cache and enabling analytics only")
+	// The user-facing summary is logged once at the end of activation by
+	// common.LogBenchmarkSummary. Avoid logging per-tool here so that on
+	// multi-tool activations (React Native) the user does not see one
+	// tool's baseline mode warning and assume the whole build is in
+	// baseline when the relevant tool is actually caching normally.
+	if phase == common.BenchmarkPhaseBaseline {
 		params.Cache.Enabled = false
 		params.Cache.JustDependency = false
 		params.Analytics.Enabled = true
-	case common.BenchmarkPhaseWarmup:
-		logger.Infof("(i) Benchmark warmup phase: cache performance might not be ideal")
 	}
 }

--- a/internal/config/xcelerate/benchmark.go
+++ b/internal/config/xcelerate/benchmark.go
@@ -13,9 +13,11 @@ type EnvExporter interface {
 }
 
 // ApplyBenchmarkPhase queries the benchmark phase and overrides xcode params accordingly.
-// Baseline phase disables cache. Warmup phase logs a warning.
-// The phase is exported as BITRISE_BUILD_CACHE_BENCHMARK_PHASE env var
-// and written to ~/.local/state/xcelerate/benchmark/benchmark-phase.json as fallback.
+// Baseline phase disables cache.
+// The phase is exported as BITRISE_BUILD_CACHE_BENCHMARK_PHASE_XCODE env var
+// and written to ~/.local/state/xcelerate/benchmark/benchmark-phase-xcode.json
+// as fallback. The user-facing log line is emitted once by
+// common.LogBenchmarkSummary at the end of activation, not from this function.
 func ApplyBenchmarkPhase(
 	params *Params,
 	logger log.Logger,
@@ -37,16 +39,16 @@ func ApplyBenchmarkPhase(
 	}
 
 	envVar := common.BenchmarkPhaseEnvVar(common.BuildToolXcode)
-	logger.Infof("(i) Benchmark phase: %s", phase)
 	exporter.Export(envVar, phase)
 	exporter.ExportToShellRC("Bitrise Benchmark Phase", "export "+envVar+"="+phase)
 	common.WriteBenchmarkPhaseFile(common.BuildToolXcode, phase, logger)
 
-	switch phase {
-	case common.BenchmarkPhaseBaseline:
-		logger.Warnf("Benchmark baseline mode: disabling cache and enabling analytics only")
+	// The user-facing summary is logged once at the end of activation by
+	// common.LogBenchmarkSummary. Avoid logging per-tool here so that on
+	// multi-tool activations (React Native) the user does not see one
+	// tool's baseline mode warning and assume the whole build is in
+	// baseline when the relevant tool is actually caching normally.
+	if phase == common.BenchmarkPhaseBaseline {
 		params.BuildCacheEnabled = false
-	case common.BenchmarkPhaseWarmup:
-		logger.Infof("(i) Benchmark warmup phase: cache performance might not be ideal")
 	}
 }

--- a/pkg/reactnative/activator.go
+++ b/pkg/reactnative/activator.go
@@ -129,6 +129,20 @@ func (a *Activator) Activate(ctx context.Context) error {
 		return err
 	}
 
+	// Single consolidated benchmark phase summary across whichever sub-tools
+	// were activated. Per-tool baseline warnings used to fire individually
+	// from each ApplyBenchmarkPhase call, which made multi-tool RN runs look
+	// like the whole build was in baseline even when only the *unused* tool
+	// was (the relevant tool was caching normally).
+	tools := []string{}
+	if a.gradle != nil {
+		tools = append(tools, configcommon.BuildToolGradle)
+	}
+	if a.xcode != nil {
+		tools = append(tools, configcommon.BuildToolXcode)
+	}
+	configcommon.LogBenchmarkSummary(a.logger, tools)
+
 	a.logger.TInfof("✅ Bitrise Build Cache for React Native activated")
 
 	return nil

--- a/pkg/reactnative/activator.go
+++ b/pkg/reactnative/activator.go
@@ -69,13 +69,19 @@ func NewActivator(params ActivatorParams) *Activator {
 		a.xcode = &xcodeActivator{logger: logger, debugLogging: params.DebugLogging}
 	}
 
-	if params.CppEnabled {
+	// ccache only meaningfully wraps the Android/Gradle native build path in
+	// React Native projects — without Gradle activated there is nothing for
+	// ccache to accelerate here. Tie the two together so `--cpp=true
+	// --gradle=false` doesn't leave a stray ccache helper running.
+	if params.CppEnabled && params.GradleEnabled {
 		a.cpp = ccachepkg.NewActivator(ccachepkg.ActivatorParams{
 			PushEnabled:  ccacheconfig.DefaultParams().PushEnabled,
 			DebugLogging: params.DebugLogging,
 			Logger:       logger,
 		})
 		a.helper = &storageHelperStarter{logger: logger}
+	} else if params.CppEnabled && !params.GradleEnabled {
+		logger.Infof("(i) Skipping C++ (ccache) activation: Gradle is disabled — ccache only wraps the Android/Gradle native build path.")
 	}
 
 	return a
@@ -109,16 +115,8 @@ func (a *Activator) Activate(ctx context.Context) error {
 		}
 	}
 
-	if a.cpp != nil {
-		a.logger.TInfof("Activating C++ build cache...")
-
-		if err := a.cpp.Activate(ctx); err != nil {
-			return fmt.Errorf("activate C++ build cache: %w", err)
-		}
-
-		if err := a.helper.start(); err != nil {
-			return fmt.Errorf("start ccache storage helper: %w", err)
-		}
+	if err := a.activateCppIfApplicable(ctx); err != nil {
+		return err
 	}
 
 	if err := saveMultiplatformConfig(a.debugLogging); err != nil {
@@ -144,6 +142,36 @@ func (a *Activator) Activate(ctx context.Context) error {
 	configcommon.LogBenchmarkSummary(a.logger, tools)
 
 	a.logger.TInfof("✅ Bitrise Build Cache for React Native activated")
+
+	return nil
+}
+
+// activateCppIfApplicable activates ccache and starts the storage helper
+// when ccache was wired in NewActivator AND gradle did not end up in the
+// benchmark baseline phase. The gradle-baseline skip is a stop-gap until
+// ccache grows its own benchmark phase support (ACI-4926) so the rotation
+// stays consistent across both halves of the Android build.
+func (a *Activator) activateCppIfApplicable(ctx context.Context) error {
+	if a.cpp == nil {
+		return nil
+	}
+
+	gradlePhase := configcommon.ReadBenchmarkPhaseFile(configcommon.BuildToolGradle, a.logger)
+	if gradlePhase == configcommon.BenchmarkPhaseBaseline {
+		a.logger.Infof("(i) Skipping C++ (ccache) activation: Gradle is in benchmark baseline mode.")
+
+		return nil
+	}
+
+	a.logger.TInfof("Activating C++ build cache...")
+
+	if err := a.cpp.Activate(ctx); err != nil {
+		return fmt.Errorf("activate C++ build cache: %w", err)
+	}
+
+	if err := a.helper.start(); err != nil {
+		return fmt.Errorf("start ccache storage helper: %w", err)
+	}
 
 	return nil
 }

--- a/pkg/reactnative/activator_test.go
+++ b/pkg/reactnative/activator_test.go
@@ -30,3 +30,43 @@ func TestActivator_saveReactNativeMarker_WritesEnabledTrue(t *testing.T) {
 
 	assert.FileExists(t, filepath.Join(home, ".bitrise/cache/reactnative/config.json"))
 }
+
+func TestNewActivator_CppRequiresGradle(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cases := []struct {
+		name   string
+		params ActivatorParams
+		wantCpp bool
+	}{
+		{
+			name:    "cpp+gradle both on → cpp activated",
+			params:  ActivatorParams{GradleEnabled: true, CppEnabled: true},
+			wantCpp: true,
+		},
+		{
+			name:    "cpp on, gradle off → cpp skipped",
+			params:  ActivatorParams{GradleEnabled: false, CppEnabled: true},
+			wantCpp: false,
+		},
+		{
+			name:    "cpp off → cpp skipped regardless of gradle",
+			params:  ActivatorParams{GradleEnabled: true, CppEnabled: false},
+			wantCpp: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewActivator(tc.params)
+
+			if tc.wantCpp {
+				assert.NotNil(t, a.cpp, "cpp activator should be wired")
+				assert.NotNil(t, a.helper, "ccache storage helper starter should be wired")
+			} else {
+				assert.Nil(t, a.cpp, "cpp activator should not be wired")
+				assert.Nil(t, a.helper, "ccache storage helper starter should not be wired")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [ACI-4922](https://bitrise.atlassian.net/browse/ACI-4922): the activate step's log says \"Benchmark baseline mode: disabling cache and enabling analytics only\" but the build's gradle/xcode commands actually use the cache.

## Root cause (verified from the two repro builds)

The activator queries the BE for a benchmark phase **per build tool** (`gradle`, `xcode`). The BE rotates phases independently per `(workspace, app, workflow, build_tool)` and for the same RN workflow it returns different phases per tool:

| Workflow | gradle phase | xcode phase | Tool the workflow runs | \"baseline\" warning fired for |
|---|---|---|---|---|
| primary-android (build `5a3206fb…`) | warmup | baseline | gradle (caches normally) | xcode (irrelevant, no xcodebuild runs) |
| primary-ios (build `6c6a265a…`) | baseline | warmup | xcode (caches normally) | gradle (irrelevant, no gradle runs) |

Each per-tool `ApplyBenchmarkPhase` emitted its own warning, so the user saw \"baseline\" + \"cache being used\" and reported the contradiction. No actual cache-disable bug — the disable was applied correctly, just to the *unused* tool.

## Changes

### Consolidated benchmark phase log

- `internal/config/common/benchmark_summary.go` (new): `LogBenchmarkSummary(logger, tools)` reads each tool's phase from its phase file and emits a single line:
  ```
  (i) Benchmark phases: gradle=warmup (cache enabled, hit rate may not be ideal), xcode=baseline (cache disabled)
  ```
  Uses `Warnf` (yellow) only when *every* active tool is in baseline. Otherwise stays at `Infof` so the line doesn't make the build look degraded when the tool the build actually runs is caching normally.
- `internal/config/gradle/benchmark.go`, `internal/config/xcelerate/benchmark.go`: drop the per-tool `(i) Benchmark phase: …`, `Benchmark baseline mode: …`, `(i) Benchmark warmup phase: …` lines. Param mutation, env export, file write behaviour unchanged.
- `cmd/gradle/activate_gradle.go`, `cmd/xcode/activate_xcode.go`, `pkg/reactnative/activator.go`: call `LogBenchmarkSummary` once at the end of activation with whichever tools were active.

### Tie ccache activation to gradle in the RN flow

ccache only meaningfully wraps the Android/Gradle native build path on RN, so its activation should follow gradle's. Two ties added in `pkg/reactnative/Activator`:

1. **Hard tie at construction** — `CppEnabled=true` + `GradleEnabled=false` skips ccache wiring entirely (no helper started). Logs the reason.
2. **Phase tie at activation** — when gradle ends up in benchmark baseline this run, skip the ccache activation + storage-helper start so the baseline measurement isn't polluted by a still-warm ccache. Stop-gap until [ACI-4926](https://bitrise.atlassian.net/browse/ACI-4926) lands proper per-tool benchmark phase support for ccache (BE's `command_benchmark_status` route's `:tool` regex only accepts `gradle|xcode|bazel` today).

### Tests

- `internal/config/common/benchmark_summary_test.go` covers the no-phase / mixed / all-baseline / single-tool / sort-stable cases.
- `pkg/reactnative/activator_test.go` covers the hard tie (cpp without gradle skipped at construction).

## Verification

- `go build ./... && go test -tags unit -race ./...` clean.
- Logging-only fix for the user-perceived contradiction; param mutation behaviour and the values written to env vars / phase files are unchanged.

## Out of scope (separate follow-ups)

- **Latent gradle.properties bug**: `internal/config/gradle/activate.go:40` calls `UpdateGradleProps(params, …)` with the un-mutated outer `params`, so when `ApplyBenchmarkPhase` flips `Cache.Enabled = false` the init script picks up the disable but `gradle.properties` still gets `org.gradle.caching=true`. Doesn't manifest in either of the two repro builds (the workflow's relevant tool is in warmup in both cases) but would bite a gradle-running workflow that actually lands in baseline. Worth a separate small PR.
- **BE rotation divergence**: per-tool independent rotation for the same workflow is user-confusing even with the new log; worth a conversation with whoever owns the website rotation logic.
- **ccache benchmark phase support** — tracked in [ACI-4926](https://bitrise.atlassian.net/browse/ACI-4926).

[ACI-4922]: https://bitrise.atlassian.net/browse/ACI-4922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACI-4926]: https://bitrise.atlassian.net/browse/ACI-4926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ