### PR TITLE
fix: bump .goreleaser.yaml to version 2 schema

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 1
+version: 2
 
 project_name: bitrise-build-cache
 
@@ -46,7 +46,7 @@ brews:
     homepage: https://bitrise.io
     description: Bitrise Build Cache CLI — configure remote build cache for Gradle, Bazel, Xcode, and React Native.
     license: MIT
-    tap:
+    repository:
       owner: bitrise-io
       name: homebrew-bitrise-build-cache
       branch: main
@@ -54,7 +54,7 @@ brews:
       name: bitbot
       email: letsbuild@bitrise.io
     commit_msg_template: 'brew formula update for {{ .ProjectName }} version {{ .Tag }}'
-    folder: Formula
+    directory: Formula
     test: |
       system "#{bin}/bitrise-build-cache", "--help"
     install: |


### PR DESCRIPTION
## Summary

The release workflow for tag `v2.6.1` failed at the Goreleaser step with:

> only \`version: 2\` configuration files are supported, yours is \`version: 1\`, please update your configuration

goreleaser v2.13 dropped support for the v1 schema. Bump `.goreleaser.yaml` to `version: 2` and apply the v2 field renames in `brews`:

- `tap` → `repository`
- `folder` → `directory`

After merge, a follow-up `v2.6.2` tag will produce a release with binaries (v2.6.1 has no binaries because of this failure).

## Test plan

- [x] `make lint`
- [x] `make test-unit`
- [ ] Release workflow goreleaser step succeeds on the next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)