### PR TITLE
docs: release skill + installer.sh + README — critical-path warnings

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -10,6 +10,19 @@ Releasing a new version is a multi-step process across several repositories.
 
 **IMPORTANT: Drive the ENTIRE process end-to-end in a single conversation.** Use the Bitrise MCP server to monitor build statuses (poll every 30s), check for triggered workflows in downstream repos, and move to the next step as soon as the previous one completes. Do not stop and wait for the user between steps.
 
+## ⚠ Critical path — read before doing anything
+
+The `install/installer.sh` script and the binaries attached to every CLI GitHub release are **on the critical path of every Bitrise build — not just builds that opt into the build cache**. The Bitrise default workflow runs the gradle-mirrors activation step (and other CLI-driven steps) unconditionally, and each of those pipes `installer.sh` to `sh` and fetches the platform tarball + checksum from the latest non-prerelease GitHub release. If any of these break — installer script, binaries, checksum file, the wrong release marked as latest — the CLI install fails, the mirror activation soft-fails, and Maven Central requests bypass the Bitrise proxy on the entire fleet.
+
+That failure mode caused the [2026-04-28 Maven Central rate-limit incident](https://bitrise.atlassian.net/wiki/spaces/INCIDENT/pages/4980998155/2026-04-28+-+Postmortem+for+incident-2026-04-28-mavencentral-too-many-requests-5238).
+
+Concrete rules:
+
+- **Always create the CLI GitHub release as `--prerelease`** (see step 6). The installer ignores prereleases when resolving `latest`, so an empty / half-uploaded release cannot poison builds.
+- **Never let an empty release be marked `latest`.** If goreleaser fails midway, leave the release as prerelease until you have manually verified the assets list is complete.
+- **Treat any failure of the CLI `release` workflow as a drop-everything-and-fix incident.** Don't move on to step releases until the CLI release workflow is green AND the v2.6.x release has all 8 expected assets (6 platform tarballs, checksums.txt, both verification XMLs).
+- **Smoke-test installer.sh edits on a real Bitrise build before merging.** The release flow does not regenerate this file, and there is no automated test that exercises it under `/bin/sh`.
+
 ## Two Entry Points
 
 A release can be triggered by:

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -62,7 +62,9 @@ gh pr merge --merge --auto --repo bitrise-io/bitrise-build-cache-cli <PR_NUMBER>
 
 Create a GitHub release in `bitrise-build-cache-cli`.
 
-- **Do NOT mark it as "latest"** — another CI job handles that
+- **MUST mark it as `--prerelease`.** The release workflow uploads the binaries asynchronously; until those land, the release is empty. Marking it as latest (or as a regular release) at create-time makes a binary-less release "current," which breaks any consumer that downloads the latest asset. A separate CI job promotes the release out of prerelease once the binaries are appended.
+- **Do NOT pass `--latest`.** Without `--latest`, GitHub will not auto-promote a prerelease; with `--latest` it would, defeating the prerelease gate.
+- Example: `gh release create vX.Y.Z --repo bitrise-io/bitrise-build-cache-cli --title vX.Y.Z --prerelease --notes "..."`
 - Follow the format of existing releases for release notes
 - **Version numbering — always ask the user** which semver bump to apply (patch, minor, or major). Use these guidelines as defaults:
   - **Patch** bump: dependency-only updates (e.g., plugin version bumps) or bug fixes

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Bitrise Build Cache CLI - to enable/configure Gradle or Bazel build cache on the machine where you run this CLI.
 
+> [!IMPORTANT]
+> **`install/installer.sh` and the assets attached to every CLI GitHub release are on the critical path of every Bitrise build — not just builds that opt into the build cache.**
+>
+> The Bitrise default workflow runs the gradle-mirrors activation step (and other CLI-driven steps) unconditionally, and each of those installs the CLI by piping `install/installer.sh` to `sh` and fetching the platform tarball + checksum from the latest non-prerelease GitHub release. If any of those (the installer script, the binaries, the checksum file) is broken or missing, the CLI install fails, the mirror activation soft-fails, and Maven Central requests stop going through the Bitrise proxy on the entire fleet — exactly the failure mode behind the [2026-04-28 Maven Central rate-limit incident](https://bitrise.atlassian.net/wiki/spaces/INCIDENT/pages/4980998155/2026-04-28+-+Postmortem+for+incident-2026-04-28-mavencentral-too-many-requests-5238).
+>
+> When changing the installer script, the goreleaser config, the release flow, or anything that affects the GitHub release's asset list:
+> - Smoke-test end-to-end on a real Bitrise build before merging.
+> - Never publish a CLI GitHub release as anything other than `--prerelease` until the binaries have been verified attached.
+> - Treat any failure of the `release` workflow as a critical, drop-everything-and-fix incident.
+
 
 ## Install
 

--- a/install/installer.sh
+++ b/install/installer.sh
@@ -1,9 +1,39 @@
 #!/bin/sh
 set -e
-# Originally scaffolded by godownloader on 2024-01-15 and untouched
-# afterwards until 2026-05. The release flow (`bitrise.yml` cli-release
-# + `.goreleaser.yaml`) does NOT regenerate this script — there is no
-# godownloader step anywhere in the repo, so edits made here stick.
+# ============================================================================
+# CRITICAL — DO NOT MODIFY THIS FILE WITHOUT EXTREME CARE
+# ============================================================================
+#
+# This script is fetched and piped to `sh` by EVERY Bitrise build — not just
+# builds that opt into the build cache. The Bitrise default workflow runs the
+# gradle-mirrors activation step (and other CLI-driven steps) unconditionally,
+# and each of those steps installs the CLI through this script.
+#
+# If installer.sh breaks, or if the GitHub release it fetches is missing the
+# platform tarball / checksum, the CLI cannot be installed, the gradle-mirrors
+# activation step fails open, and Maven Central requests stop going through
+# the Bitrise proxy on the entire fleet.
+#
+# That exact failure mode caused the 2026-04-28 Maven Central rate-limit
+# incident, post-mortem at:
+#   https://bitrise.atlassian.net/wiki/spaces/INCIDENT/pages/4980998155/2026-04-28+-+Postmortem+for+incident-2026-04-28-mavencentral-too-many-requests-5238
+#
+# Before changing this file, OR before publishing a CLI release that this
+# script will download, verify:
+#   1. The new flow has been smoke-tested end-to-end on a real Bitrise build.
+#   2. Both primary (GitHub) and fallback (GAR) download URLs resolve for
+#      every supported (OS, arch) combination — see get_binaries() below.
+#   3. The shell syntax stays POSIX-portable (this script runs under /bin/sh
+#      on every Bitrise stack — alpine /bin/sh included on some images).
+#   4. The release on GitHub actually has the binaries attached. Empty
+#      releases (e.g. while goreleaser is still uploading) MUST be marked as
+#      prerelease so this script's `releases/latest` lookup ignores them.
+#
+# Originally scaffolded by godownloader on 2024-01-15 and untouched until
+# 2026-05. The release flow (`bitrise.yml` cli-release + `.goreleaser.yaml`)
+# does NOT regenerate this script — there is no godownloader step anywhere
+# in the repo, so edits made here stick.
+# ============================================================================
 #
 
 usage() {


### PR DESCRIPTION
## Summary

Two related changes:

### 1. Release skill — mandate `--prerelease` for CLI releases

The release workflow uploads CLI binaries to the GitHub release asynchronously (goreleaser, after the tag push). Until those land — or if goreleaser fails, as happened today with the v2.6.1 / v1 → v2 schema break (#321) — the release is empty. If GitHub treats an empty release as latest, every consumer that downloads the latest asset (Homebrew tap, install script, step auto-updaters) breaks.

`.claude/skills/release/SKILL.md` step 6 now mandates `--prerelease`, forbids `--latest`, and includes the exact `gh release create` invocation. A downstream CI job (or a manual promotion once we verify binaries landed) flips the release out of prerelease.

### 2. Surface installer.sh + GH release binaries as critical-path

`install/installer.sh` is fetched and piped to `sh` by **every** Bitrise build — the gradle-mirrors activation step (and other CLI-driven steps) runs in the default workflow regardless of whether build cache is enabled. If installer.sh breaks, or if the latest non-prerelease GitHub release is missing assets, the CLI install fails fleet-wide, the Maven Central mirror activation soft-fails, and Maven Central traffic bypasses the Bitrise proxy.

That is exactly the failure mode behind the [2026-04-28 Maven Central rate-limit incident](https://bitrise.atlassian.net/wiki/spaces/INCIDENT/pages/4980998155/2026-04-28+-+Postmortem+for+incident-2026-04-28-mavencentral-too-many-requests-5238).

Prominent warnings added in three places:

- `install/installer.sh` top-of-file banner — blast radius + pre-merge checklist (smoke test, dual-URL resolution, POSIX `sh` portability, attached binaries).
- `README.md` install section — IMPORTANT callout with the incident link.
- `.claude/skills/release/SKILL.md` — new "Critical path" section at the top with concrete rules (always `--prerelease` until binaries are verified, never let an empty release be latest, treat a CLI release workflow failure as a drop-everything incident).

## Test plan

- [x] No code changes; docs/comments + skill only.
- [x] `make lint` (unchanged Go code) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)