### PR TITLE
fix(release): make Homebrew tap publish non-fatal

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -23,6 +23,17 @@ Concrete rules:
 - **Treat any failure of the CLI `release` workflow as a drop-everything-and-fix incident.** Don't move on to step releases until the CLI release workflow is green AND the v2.6.x release has all 8 expected assets (6 platform tarballs, checksums.txt, both verification XMLs).
 - **Smoke-test installer.sh edits on a real Bitrise build before merging.** The release flow does not regenerate this file, and there is no automated test that exercises it under `/bin/sh`.
 
+### Brew tap is best-effort, NOT critical path
+
+`bitrise-io/homebrew-bitrise-build-cache` is a nice-to-have publication target, not part of the install flow used by Bitrise builds. The "Publish Homebrew formula" step in `bitrise.yml`'s `release` workflow runs goreleaser with only the brew publisher and is marked `is_skippable: true`, so a tap-permission failure (e.g. 404 from `PUT /Formula/bitrise-build-cache.rb`) won't break the release.
+
+If the brew step fails:
+
+- Confirm the release workflow's overall status is still green.
+- Verify the GitHub release has all 8 expected assets and the GAR mirror upload succeeded — these are critical.
+- Fix the tap separately. The most common cause is the bot user behind `GIT_BOT_USER_ACCESS_TOKEN` not being a collaborator with push access on `bitrise-io/homebrew-bitrise-build-cache`. Add them in the tap repo's settings.
+- Do NOT block other step releases on this — re-running the brew publish is a separate concern.
+
 ## Two Entry Points
 
 A release can be triggered by:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -64,7 +64,12 @@ workflows:
             #!/usr/bin/env bash
             set -ex
 
-            goreleaser release
+            # Skip homebrew here — that step writes to a separate tap repo and
+            # has historically failed independently (404 when the bot user
+            # lacks push on the tap). We do not want it to block the critical
+            # path: binaries on GH + mirror to GAR. Homebrew is published
+            # in a dedicated, non-fatal step further down.
+            goreleaser release --skip=homebrew
     - script:
         title: Authenticate to GCP
         inputs:
@@ -177,6 +182,29 @@ workflows:
         is_always_run: true
         inputs:
           - deploy_path: "$GRADLE_VERIFICATION_REF_MIRROR_TARGET_PATH"
+    - script:
+        title: Publish Homebrew formula (non-fatal)
+        is_skippable: true
+        deps:
+          brew:
+          - name: goreleaser
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+            # Re-run goreleaser publishing only the homebrew step. Reuses
+            # the dist/ artefacts produced by the earlier release step so
+            # the formula embeds the correct SHA256 sums (no rebuild). We
+            # skip every other phase: the GH release and the binaries are
+            # already published.
+            #
+            # Homebrew is "nice to have" — installer.sh + GH release
+            # binaries + GAR mirror are the critical path for every Bitrise
+            # build. is_skippable=true ensures a tap-permission failure
+            # here does not fail the release workflow.
+            set -e
+
+            goreleaser release \
+              --skip=announce,archive,before,build,release,sign
     - bundle::update-step:
         envs:
         - STEP_NAME: bitrise-step-activate-gradle-remote-cache


### PR DESCRIPTION
## Summary

Last CLI release tripped on goreleaser's homebrew step (`404 PUT /Formula/bitrise-build-cache.rb` against `bitrise-io/homebrew-bitrise-build-cache`) and that fatal exit blocked the rest of the workflow — including the GAR mirror upload and downstream steplib auto-updates. The GH release binaries (the critical path used by every Bitrise build via `installer.sh`) had already landed before the failure, so the user-facing impact was limited, but the workflow status was red and the steplib promotion didn't run.

## Critical-path ordering

| Channel | Critical? |
|---|---|
| GH release tarballs + checksums (`installer.sh` consumes these) | **Yes** — every Bitrise build |
| GAR mirror of the same tarballs (installer fallback) | **Yes** — every Bitrise build when GH is degraded |
| Homebrew tap (`bitrise-io/homebrew-bitrise-build-cache`) | No — nice-to-have, not in the install path |

## Changes

- `bitrise.yml` — split the release script:
  - **"Goreleaser (create binaries + publish to GH)"** now runs `goreleaser release --skip=homebrew`. Binaries + GH release publish without touching the tap.
  - **GAR mirror steps** unchanged (now guaranteed to run even when the tap is broken).
  - **New "Publish Homebrew formula (non-fatal)"** step re-runs goreleaser with every other phase skipped so only the brew publisher executes, reusing the `dist/` artefacts from the first run. `is_skippable: true` ensures a tap-permission failure here can't fail the workflow.
- `.claude/skills/release/SKILL.md` — document the rule under the existing "Critical path" section so future releases don't treat a brew failure as a drop-everything incident.

## Follow-up (out of scope for this PR)

Root-cause the 404: the bot user behind `GIT_BOT_USER_ACCESS_TOKEN` is not a collaborator with push access on `bitrise-io/homebrew-bitrise-build-cache`. Once added, the brew step should succeed again — but the defensive split above means failures from here on are recoverable instead of release-blocking.

## Test plan

- [ ] Next CLI tag triggers the release workflow; verify the "Goreleaser (create binaries + publish to GH)" step succeeds without touching the tap.
- [ ] Verify GAR upload completes.
- [ ] Verify "Publish Homebrew formula (non-fatal)" runs and either succeeds (once the bot has tap access) or fails without failing the workflow.