### PR TITLE
fix(release): decouple Homebrew publish from goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,24 +41,12 @@ builds:
 archives:
   - name_template: 'bitrise-build-cache_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 
-brews:
-  - name: bitrise-build-cache
-    homepage: https://bitrise.io
-    description: Bitrise Build Cache CLI — configure remote build cache for Gradle, Bazel, Xcode, and React Native.
-    license: MIT
-    repository:
-      owner: bitrise-io
-      name: homebrew-bitrise-build-cache
-      branch: main
-    commit_author:
-      name: bitbot
-      email: letsbuild@bitrise.io
-    commit_msg_template: 'brew formula update for {{ .ProjectName }} version {{ .Tag }}'
-    directory: Formula
-    test: |
-      system "#{bin}/bitrise-build-cache", "--help"
-    install: |
-      bin.install "bitrise-build-cache"
+# Homebrew formula generation is intentionally NOT handled by goreleaser.
+# It is published by a separate, idempotent shell step in bitrise.yml
+# (`Publish Homebrew formula (non-fatal)`) that reads dist/checksums.txt
+# and pushes Formula/bitrise-build-cache.rb to the tap repo. This avoids
+# a second goreleaser invocation that would rebuild + re-upload binaries
+# to the existing GH release just to push the formula.
 
 changelog:
   sort: asc

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -64,12 +64,12 @@ workflows:
             #!/usr/bin/env bash
             set -ex
 
-            # Skip homebrew here — that step writes to a separate tap repo and
-            # has historically failed independently (404 when the bot user
-            # lacks push on the tap). We do not want it to block the critical
-            # path: binaries on GH + mirror to GAR. Homebrew is published
-            # in a dedicated, non-fatal step further down.
-            goreleaser release --skip=homebrew
+            # Homebrew formula generation has been removed from .goreleaser.yaml
+            # and moved to a dedicated, non-fatal shell step further down that
+            # writes Formula/bitrise-build-cache.rb directly to the tap repo
+            # from dist/checksums.txt. This keeps the GH release + GAR mirror
+            # (the critical path) free of any brew-related work.
+            goreleaser release
     - script:
         title: Authenticate to GCP
         inputs:
@@ -185,26 +185,11 @@ workflows:
     - script:
         title: Publish Homebrew formula (non-fatal)
         is_skippable: true
-        deps:
-          brew:
-          - name: goreleaser
         inputs:
         - content: |
             #!/usr/bin/env bash
-            # Re-run goreleaser publishing only the homebrew step. Reuses
-            # the dist/ artefacts produced by the earlier release step so
-            # the formula embeds the correct SHA256 sums (no rebuild). We
-            # skip every other phase: the GH release and the binaries are
-            # already published.
-            #
-            # Homebrew is "nice to have" — installer.sh + GH release
-            # binaries + GAR mirror are the critical path for every Bitrise
-            # build. is_skippable=true ensures a tap-permission failure
-            # here does not fail the release workflow.
             set -e
-
-            goreleaser release \
-              --skip=announce,archive,before,build,release,sign
+            ./scripts/publish_homebrew_formula.sh
     - bundle::update-step:
         envs:
         - STEP_NAME: bitrise-step-activate-gradle-remote-cache

--- a/scripts/publish_homebrew_formula.sh
+++ b/scripts/publish_homebrew_formula.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Publish the Homebrew formula to bitrise-io/homebrew-bitrise-build-cache.
+#
+# Decoupled from goreleaser: reads SHA256s from dist/checksums.txt (already
+# written by the goreleaser step earlier in the release workflow) and
+# templates Formula/bitrise-build-cache.rb directly, then pushes to the tap.
+# This avoids a second goreleaser invocation that would rebuild + re-upload
+# all binaries to the existing GH release.
+#
+# Inputs (env):
+#   BITRISE_GIT_TAG   release tag, e.g. v2.6.2 (or pass TAG to override)
+#   GITHUB_TOKEN      PAT with push access to bitrise-io/homebrew-bitrise-build-cache
+#
+# Optional (env):
+#   DIST_DIR          directory containing checksums.txt (default: dist)
+#   TAP_REMOTE        tap repo URL (default: bitrise-io/homebrew-bitrise-build-cache)
+#   TAP_BRANCH        tap branch to push to (default: main)
+#   DRY_RUN           if "1", template the formula and print it; do not push
+
+set -euo pipefail
+
+TAG="${TAG:-${BITRISE_GIT_TAG:-}}"
+[ -n "$TAG" ] || { echo "TAG / BITRISE_GIT_TAG is not set" >&2; exit 1; }
+VER="${TAG#v}"
+
+DIST_DIR="${DIST_DIR:-dist}"
+TAP_BRANCH="${TAP_BRANCH:-main}"
+TAP_REMOTE_DEFAULT="bitrise-io/homebrew-bitrise-build-cache"
+DRY_RUN="${DRY_RUN:-0}"
+
+CHECKSUMS="${DIST_DIR}/bitrise-build-cache_${VER}_checksums.txt"
+[ -f "$CHECKSUMS" ] || { echo "missing $CHECKSUMS" >&2; exit 1; }
+
+sha_for() {
+  local name="bitrise-build-cache_${VER}_$1.tar.gz"
+  local sha
+  sha=$(awk -v n="$name" '$2==n {print $1}' "$CHECKSUMS")
+  [ -n "$sha" ] || { echo "no sha for $name in $CHECKSUMS" >&2; exit 1; }
+  echo "$sha"
+}
+
+SHA_DARWIN_AMD64=$(sha_for darwin_amd64)
+SHA_DARWIN_ARM64=$(sha_for darwin_arm64)
+SHA_LINUX_AMD64=$(sha_for linux_amd64)
+SHA_LINUX_ARM64=$(sha_for linux_arm64)
+
+URL_BASE="https://github.com/bitrise-io/bitrise-build-cache-cli/releases/download/${TAG}"
+
+render_formula() {
+  cat <<RUBY
+class BitriseBuildCache < Formula
+  desc "Bitrise Build Cache CLI — configure remote build cache for Gradle, Bazel, Xcode, and React Native"
+  homepage "https://bitrise.io"
+  version "${VER}"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "${URL_BASE}/bitrise-build-cache_${VER}_darwin_arm64.tar.gz"
+      sha256 "${SHA_DARWIN_ARM64}"
+    end
+    on_intel do
+      url "${URL_BASE}/bitrise-build-cache_${VER}_darwin_amd64.tar.gz"
+      sha256 "${SHA_DARWIN_AMD64}"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "${URL_BASE}/bitrise-build-cache_${VER}_linux_arm64.tar.gz"
+      sha256 "${SHA_LINUX_ARM64}"
+    end
+    on_intel do
+      url "${URL_BASE}/bitrise-build-cache_${VER}_linux_amd64.tar.gz"
+      sha256 "${SHA_LINUX_AMD64}"
+    end
+  end
+
+  def install
+    bin.install "bitrise-build-cache"
+  end
+
+  test do
+    system "#{bin}/bitrise-build-cache", "--help"
+  end
+end
+RUBY
+}
+
+if [ "$DRY_RUN" = "1" ]; then
+  render_formula
+  exit 0
+fi
+
+[ -n "${GITHUB_TOKEN:-}" ] || { echo "GITHUB_TOKEN is not set" >&2; exit 1; }
+TAP_REMOTE="${TAP_REMOTE:-https://x-access-token:${GITHUB_TOKEN}@github.com/${TAP_REMOTE_DEFAULT}.git}"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+git clone --depth 1 --branch "$TAP_BRANCH" "$TAP_REMOTE" "$WORK"
+cd "$WORK"
+git config user.name "bitbot"
+git config user.email "letsbuild@bitrise.io"
+
+mkdir -p Formula
+render_formula > Formula/bitrise-build-cache.rb
+
+git add Formula/bitrise-build-cache.rb
+if git diff --cached --quiet; then
+  echo "Formula content unchanged; nothing to commit"
+  exit 0
+fi
+git commit -m "brew formula update for bitrise-build-cache ${TAG}"
+git push origin "HEAD:${TAP_BRANCH}"


### PR DESCRIPTION
## Summary

- The brew-publish step shipped in v2.6.2 (#323) was a second goreleaser invocation. It failed v2.6.2 outright (goreleaser v2 dropped `build` / `release` from `--skip`), and even if the syntax had been right, the design double-uploaded all binaries to the existing GH release on every run just to push the formula.
- Drop the `brews:` block from `.goreleaser.yaml` entirely. Goreleaser no longer touches Homebrew.
- Drop `--skip=homebrew` from the first goreleaser call (no-op now).
- Move the formula-publish logic into `scripts/publish_homebrew_formula.sh`. The bitrise.yml step is now a 2-line shim that calls the script. The script reads SHA256s from `dist/checksums.txt` (already on disk from the earlier goreleaser run), templates `Formula/bitrise-build-cache.rb` (`on_macos` / `on_linux` × `on_arm` / `on_intel`, pointing at GH release tarballs), and pushes to `bitrise-io/homebrew-bitrise-build-cache` via `$GIT_BOT_USER_ACCESS_TOKEN`.
- `is_skippable: true` preserved — `installer.sh` + GH release binaries + GAR mirror remain the critical path; a brew tap push failure must not fail the release workflow.

## Why

v2.6.2 (#323) shipped the goreleaser-based brew step but it never actually executed (build #4184 step `Publish Homebrew formula (non-fatal)` exited 1 with `error=--skip=build is not allowed`). The tap repo still contains only its initial commit (`7de9610c`, 2026-05-08).

Beyond the syntax bug, the original design re-ran goreleaser end-to-end — rebuild + re-archive + re-upload all binaries to the existing GH release — purely to push a formula file. Simpler to template the formula and `git push` directly.

Picked up alongside the upcoming gradle-plugins-driven CLI release.

## Local test

```bash
mkdir -p /tmp/brew-test-dist
curl -sSL "https://github.com/bitrise-io/bitrise-build-cache-cli/releases/download/v2.6.2/bitrise-build-cache_2.6.2_checksums.txt" \
  -o /tmp/brew-test-dist/bitrise-build-cache_2.6.2_checksums.txt
TAG=v2.6.2 DIST_DIR=/tmp/brew-test-dist DRY_RUN=1 ./scripts/publish_homebrew_formula.sh
```

Renders a valid Homebrew formula against real v2.6.2 release checksums. Error paths (`TAG` unset, checksums file missing, sha missing for a platform) all exit `1` with a clear message.

## Test plan

- [ ] Next CLI release tag triggers the `release` workflow.
- [ ] `Goreleaser (create binaries + publish to GH)` step still publishes the GH release with all 8 assets (no behavioural change from removing `--skip=homebrew`).
- [ ] `Publish Homebrew formula (non-fatal)` step succeeds and produces a `brew formula update for bitrise-build-cache v<NEW>` commit on `bitrise-io/homebrew-bitrise-build-cache@main`.
- [ ] The committed `Formula/bitrise-build-cache.rb` validates: `brew tap bitrise-io/bitrise-build-cache && brew install bitrise-build-cache && bitrise-build-cache --version` resolves to the new version.
- [ ] If the tap push still fails (bot user push permissions on the tap repo), `is_skippable: true` keeps the rest of the release flow green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)