### PR TITLE
feat(ci): add post-release RN e2e workflows + share via step_bundles

### DIFF
--- a/bitrise_rn_config/bitrise.yml
+++ b/bitrise_rn_config/bitrise.yml
@@ -478,57 +478,8 @@ workflows:
     steps:
     - activate-ssh-key@4: {}
     - git-clone@8: {}
-    - script:
-        title: Build and install CLI
-        inputs:
-        - content: |-
-            go build
-            cp bitrise-build-cache-cli /usr/local/bin/bitrise-build-cache
-    - script:
-        title: Clone Seek app
-        inputs:
-        - content: git clone --depth 1 "$SEEK_URL" --branch "$SEEK_TAG" _seek
-    - script:
-        title: Configure and install dependencies
-        inputs:
-        - content: bash $BITRISE_SOURCE_DIR/scripts/react_e2e_setup_seek_android.sh
-    - script:
-        title: Install ccache 4.13.2
-        inputs:
-        - content: |-
-            CCACHE_VERSION="4.13.2"
-            curl -fsSL "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}-darwin.tar.gz" \
-              | tar -xz --strip-components=1 -C /usr/local/bin "ccache-${CCACHE_VERSION}-darwin/ccache"
-            ccache --version
-    - script:
-        title: Activate react-native (Gradle + C++)
-        inputs:
-        - content: ./bitrise-build-cache-cli --debug activate react-native --gradle=true --xcode=false --cpp=true
-    - script:
-        title: Build
-        inputs:
-        - content: |-
-            export RN_CLI_LOG="$BITRISE_DEPLOY_DIR/rn-cli.log"
-            envman add --key RN_CLI_LOG --value "$RN_CLI_LOG"
-            cd _seek
-            ../bitrise-build-cache-cli react-native run npx react-native build-android 2>&1 | tee -a "$RN_CLI_LOG"
-    - script:
-        title: Assert ccache GET calls via storage helper logs
-        inputs:
-        - content: |-
-            # Stop the storage helper so logs are fully flushed before asserting
-            ./bitrise-build-cache-cli ccache storage-helper stop || true
-            LOG_DIR="$HOME/.local/state/ccache/logs"
-            if ! grep -rl '\[Get - [0-9a-f]\+\]' "$LOG_DIR" 2>/dev/null | grep -q .; then
-              echo "No remote GET calls found in storage helper logs ❌"
-              ls -la "$LOG_DIR" 2>/dev/null || echo "Log dir not found"
-              exit 1
-            fi
-            echo "Remote GET calls confirmed in storage helper logs ✅"
-    - script:
-        title: Assert analytics were sent
-        inputs:
-        - content: bash $BITRISE_SOURCE_DIR/scripts/react_e2e_assert_analytics.sh
+    - bundle::rn-cli-install-from-source: {}
+    - bundle::rn-seek-android-e2e-body: {}
 
   react-seek-ios-e2e:
     title: Seek iOS - assert react-native CLI invocation analytics
@@ -539,36 +490,32 @@ workflows:
     steps:
     - activate-ssh-key@4: {}
     - git-clone@8: {}
-    - script:
-        title: Build and install CLI
-        inputs:
-        - content: |-
-            go build
-            cp bitrise-build-cache-cli /usr/local/bin/bitrise-build-cache
-    - script:
-        title: Clone Seek app
-        inputs:
-        - content: git clone --depth 1 "$SEEK_URL" --branch "$SEEK_TAG" _seek
-    - script:
-        title: Configure and install dependencies
-        inputs:
-        - content: bash $BITRISE_SOURCE_DIR/scripts/react_e2e_setup_seek_ios.sh
-    - script:
-        title: Activate react-native (Xcode)
-        inputs:
-        - content: ./bitrise-build-cache-cli activate react-native --gradle=false --xcode=true --cpp=false
-    - script:
-        title: Build
-        inputs:
-        - content: |-
-            export RN_CLI_LOG="$BITRISE_DEPLOY_DIR/rn-cli.log"
-            envman add --key RN_CLI_LOG --value "$RN_CLI_LOG"
-            cd _seek
-            ../bitrise-build-cache-cli react-native run npx react-native build-ios 2>&1 | tee -a "$RN_CLI_LOG"
-    - script:
-        title: Assert CLI invocation analytics were sent
-        inputs:
-        - content: bash $BITRISE_SOURCE_DIR/scripts/react_e2e_assert_analytics.sh
+    - bundle::rn-cli-install-from-source: {}
+    - bundle::rn-seek-ios-e2e-body: {}
+
+  react-seek-android-post-release-e2e:
+    title: Seek Android (post-release) - assert analytics and ccache remote cache hit using latest released CLI
+    meta:
+      bitrise.io:
+        machine_type_id: g2.mac.large
+        stack: osx-xcode-26.3.x
+    steps:
+    - activate-ssh-key@4: {}
+    - git-clone@8: {}
+    - bundle::rn-cli-install-from-release: {}
+    - bundle::rn-seek-android-e2e-body: {}
+
+  react-seek-ios-post-release-e2e:
+    title: Seek iOS (post-release) - assert react-native CLI invocation analytics using latest released CLI
+    meta:
+      bitrise.io:
+        machine_type_id: g2.mac.large
+        stack: osx-xcode-26.3.x
+    steps:
+    - activate-ssh-key@4: {}
+    - git-clone@8: {}
+    - bundle::rn-cli-install-from-release: {}
+    - bundle::rn-seek-ios-e2e-body: {}
 
 
   ccache-storage-helper-test:
@@ -937,6 +884,106 @@ step_bundles:
         run_if: '{{getenv "BENCHMARK_APP_NAME" | ne ""}}'
     inputs:
     - BENCHMARK_APP_NAME: $BENCHMARK_APP_NAME
+
+  # -------------------------------------------------------------------------------
+  # Seek RN feature-e2e shared bundles (used by react-seek-{android,ios}{,-post-release}-e2e)
+  # -------------------------------------------------------------------------------
+  rn-cli-install-from-source:
+    steps:
+    - script:
+        title: Build and install CLI
+        inputs:
+        - content: |-
+            go build
+            cp bitrise-build-cache-cli /usr/local/bin/bitrise-build-cache
+
+  rn-cli-install-from-release:
+    steps:
+    - script:
+        title: Install latest released CLI
+        inputs:
+        - content: |-
+            set -exo pipefail
+            curl --retry 5 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' \
+              | sh -s -- -b /usr/local/bin
+            cp /usr/local/bin/bitrise-build-cache ./bitrise-build-cache-cli
+            ./bitrise-build-cache-cli version
+
+  rn-seek-android-e2e-body:
+    steps:
+    - script:
+        title: Clone Seek app
+        inputs:
+        - content: git clone --depth 1 "$SEEK_URL" --branch "$SEEK_TAG" _seek
+    - script:
+        title: Configure and install dependencies
+        inputs:
+        - content: bash $BITRISE_SOURCE_DIR/scripts/react_e2e_setup_seek_android.sh
+    - script:
+        title: Install ccache 4.13.2
+        inputs:
+        - content: |-
+            CCACHE_VERSION="4.13.2"
+            curl -fsSL "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}-darwin.tar.gz" \
+              | tar -xz --strip-components=1 -C /usr/local/bin "ccache-${CCACHE_VERSION}-darwin/ccache"
+            ccache --version
+    - script:
+        title: Activate react-native (Gradle + C++)
+        inputs:
+        - content: ./bitrise-build-cache-cli --debug activate react-native --gradle=true --xcode=false --cpp=true
+    - script:
+        title: Build
+        inputs:
+        - content: |-
+            export RN_CLI_LOG="$BITRISE_DEPLOY_DIR/rn-cli.log"
+            envman add --key RN_CLI_LOG --value "$RN_CLI_LOG"
+            cd _seek
+            ../bitrise-build-cache-cli react-native run npx react-native build-android 2>&1 | tee -a "$RN_CLI_LOG"
+    - script:
+        title: Assert ccache GET calls via storage helper logs
+        inputs:
+        - content: |-
+            # Stop the storage helper so logs are fully flushed before asserting
+            ./bitrise-build-cache-cli ccache storage-helper stop || true
+            LOG_DIR="$HOME/.local/state/ccache/logs"
+            if ! grep -rl '\[Get - [0-9a-f]\+\]' "$LOG_DIR" 2>/dev/null | grep -q .; then
+              echo "No remote GET calls found in storage helper logs ❌"
+              ls -la "$LOG_DIR" 2>/dev/null || echo "Log dir not found"
+              exit 1
+            fi
+            echo "Remote GET calls confirmed in storage helper logs ✅"
+    - script:
+        title: Assert analytics were sent
+        inputs:
+        - content: bash $BITRISE_SOURCE_DIR/scripts/react_e2e_assert_analytics.sh
+
+  rn-seek-ios-e2e-body:
+    steps:
+    - script:
+        title: Clone Seek app
+        inputs:
+        - content: git clone --depth 1 "$SEEK_URL" --branch "$SEEK_TAG" _seek
+    - script:
+        title: Configure and install dependencies
+        inputs:
+        - content: bash $BITRISE_SOURCE_DIR/scripts/react_e2e_setup_seek_ios.sh
+    - script:
+        title: Activate react-native (Xcode)
+        inputs:
+        - content: ./bitrise-build-cache-cli activate react-native --gradle=false --xcode=true --cpp=false
+    - script:
+        title: Build
+        inputs:
+        - content: |-
+            export RN_CLI_LOG="$BITRISE_DEPLOY_DIR/rn-cli.log"
+            envman add --key RN_CLI_LOG --value "$RN_CLI_LOG"
+            cd _seek
+            ../bitrise-build-cache-cli react-native run npx react-native build-ios 2>&1 | tee -a "$RN_CLI_LOG"
+    - script:
+        title: Assert CLI invocation analytics were sent
+        inputs:
+        - content: bash $BITRISE_SOURCE_DIR/scripts/react_e2e_assert_analytics.sh
+
 # -------------------------------------------------------------------------------
 # Pipelines
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds post-release variants of the Seek RN e2e workflows and dedups the shared body via step_bundles.

New workflows in `bitrise_rn_config/bitrise.yml`:
- `react-seek-android-post-release-e2e`
- `react-seek-ios-post-release-e2e`

These install the latest released CLI via `installer.sh` instead of `go build`. Existing `react-seek-{android,ios}-e2e` workflows still build from source for PR/main triggers that test unreleased CLI changes.

New step_bundles to share the common parts:
- `rn-cli-install-from-source` — `go build` + `cp`
- `rn-cli-install-from-release` — `installer.sh` + `cp`
- `rn-seek-android-e2e-body` — clone Seek, deps, ccache, activate, build, asserts
- `rn-seek-ios-e2e-body` — clone Seek, deps, activate, build, asserts

Each of the four workflows now reduces to four lines:

```yaml
react-seek-android-e2e:
  steps:
  - activate-ssh-key@4: {}
  - git-clone@8: {}
  - bundle::rn-cli-install-from-source: {}
  - bundle::rn-seek-android-e2e-body: {}
```

## Why

The `build-cache-e2e-testing` repo's pipeline is **post-release** — it should exercise the released binary, not whatever is on `main`. Today it triggers `react-seek-{android,ios}-e2e` on this app, which `go build`s the CLI from source. That produces flakiness when `go mod download` times out (e.g. `klauspost/compress` GAR signed URL fetch) and also tests a `main`-SHA build instead of the released tag.

Companion change: `bitrise-io/build-cache-e2e-testing` PR repoints `RN_APP_WORKFLOW_ANDROID` / `RN_APP_WORKFLOW_IOS` envs at these new workflows. **Merge this PR first** — the e2e PR will trigger missing workflows otherwise.

## Test plan

- [x] `bitrise validate --config bitrise_rn_config/bitrise.yml`
- [x] `installer.sh` runs locally, fetches `v2.6.2` (latest non-prerelease)
- [x] Verified subcommands used by the workflows exist in v2.6.2: `activate react-native --gradle/--xcode/--cpp`, `ccache storage-helper stop`, `react-native run`, `version`
- [ ] Trigger `react-seek-android-post-release-e2e` on this branch via Bitrise UI and confirm green
- [ ] Trigger `react-seek-ios-post-release-e2e` on this branch via Bitrise UI and confirm green
- [ ] Re-run `react-seek-android-e2e` (source build) on this branch and confirm unchanged behavior after the bundle refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)