### PR TITLE
fix(release): check-then-upload to GAR instead of delete-then-upload

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -111,16 +111,18 @@ workflows:
                 echo "File $DIST_DIR/$filename does not exist."
                 exit 1
               fi
-              echo "Uploading $filename to GAR..."
-
               package_name="${filename/_${tag}/}" # Files will be versioned
 
-              gcloud artifacts files delete "$package_name:$tag:$filename" \
-                --project=ip-build-cache-prod \
-                --location=us-central1 \
-                --repository=build-cache-cli-releases \
-                --quiet || true
+              if gcloud artifacts files describe "$package_name:$tag:$filename" \
+                   --project=ip-build-cache-prod \
+                   --location=us-central1 \
+                   --repository=build-cache-cli-releases \
+                   >/dev/null 2>&1; then
+                echo "Already uploaded, skipping: $filename"
+                continue
+              fi
 
+              echo "Uploading $filename to GAR..."
               gcloud artifacts generic upload \
                 --project=ip-build-cache-prod \
                 --source="$DIST_DIR/$filename" \
@@ -153,16 +155,19 @@ workflows:
             for suffix in darwin linux-x86_64-glibc linux-aarch64-glibc; do
               filename="ccache-${CCACHE_VERSION}-${suffix}.tar.gz"
               package="ccache-${suffix}.tar.gz"
-              src_url="https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/${filename}"
 
+              if gcloud artifacts files describe "$package:$CCACHE_VERSION:$filename" \
+                   --project=ip-build-cache-prod \
+                   --location=us-central1 \
+                   --repository=build-cache-cli-releases \
+                   >/dev/null 2>&1; then
+                echo "ccache ${CCACHE_VERSION} ${suffix} already mirrored, skipping"
+                continue
+              fi
+
+              src_url="https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/${filename}"
               echo "Downloading $src_url"
               curl --retry 5 -sSfL -o "$TMPDIR/$filename" "$src_url"
-
-              gcloud artifacts files delete "$package:$CCACHE_VERSION:$filename" \
-                --project=ip-build-cache-prod \
-                --location=us-central1 \
-                --repository=build-cache-cli-releases \
-                --quiet || true
 
               gcloud artifacts generic upload \
                 --project=ip-build-cache-prod \


### PR DESCRIPTION
## Summary

- v2.6.3 release workflow (build #4243) failed at `Mirror ccache binaries to GAR`. Failure chain: `gcloud artifacts files delete` returned `PERMISSION_DENIED` (SA `build-cache-cli-release-sa` lacks `artifactregistry.files.delete`), `|| true` swallowed it, then `gcloud artifacts generic upload` exited 1 with `Requested entity already exists` because ccache v4.13.2 was already mirrored by the v2.6.2 release.
- The delete-then-upload pattern is the wrong shape for immutable artifacts at versioned paths. Bytes don't change across CLI releases when the underlying version (CLI tag for CLI binaries, ccache upstream version for ccache mirror) is unchanged. We don't need to delete — we need to skip.
- Replace both GAR-upload steps with describe-then-upload-if-missing: call `gcloud artifacts files describe`, `continue` if it succeeds, upload otherwise.

## Why both steps?

- `Mirror ccache binaries to GAR` is where the bug actually bites (versioned by ccache upstream, same across CLI releases).
- `Upload release artifacts to GAR` is versioned per CLI tag, so it normally won't skip — but symmetry beats two different idioms, and it makes idempotent workflow reruns on the same tag work.

## Downstream cleanup

The release SA no longer needs `artifactregistry.files.delete`. Permission can be removed in a follow-up infra change (out of scope here).

## Test plan

- [ ] Next CLI release tag triggers the `release` workflow.
- [ ] `Upload release artifacts to GAR` step uploads 5 CLI binary artifacts (none pre-exist for a new tag).
- [ ] `Mirror ccache binaries to GAR` step finds the existing ccache 4.13.2 artifacts and logs `already mirrored, skipping` for each of the 3 platform suffixes.
- [ ] Workflow proceeds to `Publish Homebrew formula (non-fatal)` and the 4 `Create PR for step update` steps (no longer blocked by the failed ccache mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)