### PR TITLE
feat: ACI-4938 PR CI check for installer.sh + goreleaser

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -254,6 +254,26 @@ workflows:
         machine_type_id: g2.mac.medium
         stack: osx-xcode-edge
 
+  pr-release-check-linux:
+    description: |
+      PR dry-run of the release flow on Linux. See bundle::release-flow-check.
+    meta:
+      bitrise.io:
+        machine_type_id: g2.linux.medium
+        stack: linux-docker-android-22.04
+    steps:
+    - bundle::release-flow-check: {}
+
+  pr-release-check-mac:
+    description: |
+      PR dry-run of the release flow on macOS. See bundle::release-flow-check.
+    meta:
+      bitrise.io:
+        machine_type_id: g2.mac.medium
+        stack: osx-xcode-edge
+    steps:
+    - bundle::release-flow-check: {}
+
   generate_gradle_verification:
     steps:
     - bundle::generate_gradle_verification_reference: { }
@@ -1181,6 +1201,96 @@ workflows:
             - UPDATE_SCRIPT_PATH: ../scripts/update_activate_react_native_features.sh
 
 step_bundles:
+  release-flow-check:
+    description: |
+      Dry-run of the release flow. Verifies install/installer.sh still works
+      against the current GitHub `latest` release and that goreleaser can
+      produce a full snapshot build with the current .goreleaser.yaml. Then
+      runs `version` on the just-built binary for the host platform.
+      Nothing is published. Used by pr-release-check-linux and -mac.
+    steps:
+    - activate-ssh-key@4:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@8: {}
+    - script@1:
+        title: asdf use latest go
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            asdf install golang 1.24.3
+            asdf global golang 1.24.3
+    - script:
+        title: Syntax-check installer.sh (POSIX sh)
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            # installer.sh runs under /bin/sh on every Bitrise stack (alpine
+            # included). Catch non-POSIX syntax before it ships.
+            sh -n install/installer.sh
+    - script:
+        title: Run installer.sh end-to-end (latest GH release)
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            # Exercise the same code path every Bitrise build hits: resolve
+            # `latest`, download from GH (with GAR fallback), verify checksum,
+            # extract, install. Then smoke-test the resulting binary.
+            rm -rf ./bin-installer-check
+            sh install/installer.sh -b ./bin-installer-check
+            ./bin-installer-check/bitrise-build-cache version
+    - script:
+        title: Install Goreleaser
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            GOBIN=/usr/local/bin/ go install github.com/goreleaser/goreleaser/v2@latest
+    - script:
+        title: goreleaser check (config validation)
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            goreleaser check
+    - script:
+        title: goreleaser snapshot (dry-run, no publish)
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            # --snapshot:     no tag required
+            # --clean:        wipe ./dist between runs
+            # --skip=publish: never touch GitHub / Homebrew / GAR
+            goreleaser release --snapshot --clean --skip=publish
+            ls -laR dist
+
+            # Smoke-test the just-built binary for the current platform.
+            # goreleaser snapshot lays binaries out at:
+            #   dist/<project>_<os>_<arch>[_v<variant>]/<binary>
+            host_os=$(uname -s | tr '[:upper:]' '[:lower:]')
+            host_arch=$(uname -m)
+            case "$host_arch" in
+              x86_64) host_arch=amd64 ;;
+              aarch64) host_arch=arm64 ;;
+            esac
+            built_binary=$(find dist -type f -name bitrise-build-cache \
+              -path "*_${host_os}_${host_arch}*/*" | head -n1)
+            if [ -z "$built_binary" ]; then
+              echo "Could not locate built binary for ${host_os}/${host_arch} in dist/"
+              exit 1
+            fi
+            echo "Running snapshot binary: $built_binary"
+            "$built_binary" version
+
   generate_gradle_verification_reference:
     steps:
     - script:
@@ -1405,6 +1515,8 @@ pipelines:
   features-e2e:
     workflows:
       test: {}
+      pr-release-check-linux: {}
+      pr-release-check-mac: {}
       feature-e2e-bazel-bitrisedc-no-rbe: {}
       feature-e2e-bazel-public-no-rbe: {}
       feature-e2e-gradle-duckduck: {}


### PR DESCRIPTION
## Summary

[ACI-4938](https://bitrise.atlassian.net/browse/ACI-4938)

Adds a PR-time dry-run of the release flow so regressions in `install/installer.sh` or `.goreleaser.yaml` are caught on the PR, not at tag-time.

A new step bundle `release-flow-check`:
- Syntax-checks `install/installer.sh` under POSIX `sh -n` (per the file's CRITICAL banner — it runs on every Bitrise stack including alpine `/bin/sh`).
- Runs the installer end-to-end against the current GitHub `latest` release (exercises GH download → GAR fallback → checksum verify → extract → install), then smoke-tests the installed binary with `bitrise-build-cache version`.
- Runs `goreleaser check` to validate `.goreleaser.yaml`.
- Builds a full snapshot with `goreleaser release --snapshot --clean --skip=publish` — no GitHub / Homebrew / GAR side effects.
- Finally runs `version` on the just-built binary matching the runner's `uname -s` / `uname -m` (with `x86_64→amd64`, `aarch64→arm64` normalization), so a goreleaser dist-layout change won't pass silently.

The bundle is invoked by two thin platform workflows that the `features-e2e` pipeline runs on every PR:

| Workflow | Stack | Machine |
|---|---|---|
| `pr-release-check-linux` | `linux-docker-android-22.04` | `g2.linux.medium` |
| `pr-release-check-mac` | `osx-xcode-edge` | `g2.mac.medium` |

This way both platform toolchains are exercised on every PR (goreleaser builds linux+darwin × amd64+arm64 in both, but the host-binary smoke test runs the actual binary on each platform).

## Test plan

- [ ] `make lint` clean
- [ ] `make test-unit` clean
- [ ] On this PR, the `features-e2e` pipeline runs `pr-release-check-linux` and `pr-release-check-mac` and both pass
- [ ] Confirm no GitHub release / Homebrew formula / GAR upload happened from the PR build (only the `release` workflow is tag-triggered and unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4938]: https://bitrise.atlassian.net/browse/ACI-4938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ