### PR TITLE
fix: ACI-4938 unblock installer.sh GAR fallback under set -e

### DIFF
--- a/install/installer.sh
+++ b/install/installer.sh
@@ -338,7 +338,11 @@ github_release() {
   version=$2
   test -z "$version" && version="latest"
   giturl="https://github.com/${owner_repo}/releases/${version}"
-  json=$(http_copy "$giturl" "Accept:application/json")
+  # `|| true` inside the substitution: without it, set -e (active for the
+  # whole script) kills this function the moment http_copy returns non-zero,
+  # before we can check $json and fall through to the GAR fallback below.
+  # This previously rendered the entire fallback path dead code.
+  json=$(http_copy "$giturl" "Accept:application/json" || true)
   if [ -n "$json" ]; then
     parsed=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
     if [ -n "$parsed" ]; then


### PR DESCRIPTION
## Summary

[ACI-4938](https://bitrise.atlassian.net/browse/ACI-4938)

Caught by the new `verify-release` workflow on the v2.6.4 release (build #4334, Section 4 — forced-GAR install with github.com blocked via /etc/hosts). The fallback code added in #329 was dead under `set -e`.

## Root cause

`install/installer.sh` runs with `set -e` at the top. Inside `github_release()`:

```sh
json=$(http_copy "$giturl" "Accept:application/json")
```

When `github.com` is unreachable (curl returns HTTP 000 → `http_download_curl` returns 1 → `http_copy` returns 1), `set -e` kills the command-substitution subshell **before** the rest of `github_release()` runs. The new "fall back to GAR's latest-pointer:VERSION" branch never gets a chance. The caller's `REALTAG=$(github_release ...) && true` swallows the nonzero exit and gets an empty REALTAG; `tag_to_version()` then aborts with `unable to find ''`.

This bug was latent in the old installer.sh too — the old `test -z "$json" && return 1` line was equally unreachable. Nobody noticed because no CI exercised the "github.com fully unreachable" path before. The new `verify-release` Section 4 (which blocks github.com via /etc/hosts) is what surfaced it.

## Fix

```sh
json=$(http_copy "$giturl" "Accept:application/json" || true)
```

`|| true` inside the substitution makes the subshell's last command always succeed, regardless of `http_copy`'s return code. `json` gets the (possibly empty) body without triggering errexit. The downstream `if [ -n "\$json" ]; then ...` check + fallback branch now run as designed.

One-line change in `install/installer.sh`. Comment in the source flags the gotcha for future readers.

## Local verification (end-to-end)

Reproduced the failure first with a patched `http_download_curl` that returns 1 for `*.github.com` / `*.githubusercontent.com` URLs only (mirroring the /etc/hosts trick on the Mac VM). Without the fix: `crit unable to find ''`, exit 1, no binary installed — exactly matching build #4334's Section 4 failure log.

With the fix:

```
info checking GitHub for latest tag
debug http_download https://github.com/bitrise-io/.../releases/latest
info GitHub tag resolution failed; falling back to GAR for latest version
debug http_download https://artifactregistry.googleapis.com/.../installer.sh:latest-pointer:VERSION:download?alt=media
info found version: 2.6.4 for v2.6.4/darwin/arm64
debug http_download https://github.com/.../bitrise-build-cache_2.6.4_darwin_arm64.tar.gz
info primary download failed for ..., falling back to https://artifactregistry.googleapis.com/.../bitrise-build-cache_darwin_arm64.tar.gz:2.6.4:...:download?alt=media
debug http_download https://github.com/.../bitrise-build-cache_2.6.4_checksums.txt
info primary download failed for ..., falling back to https://artifactregistry.googleapis.com/.../bitrise-build-cache_checksums.txt:2.6.4:...:download?alt=media
info installed /tmp/realsim-bin/bitrise-build-cache

/tmp/realsim-bin/bitrise-build-cache version
2.6.4
```

GAR-only end-to-end install works with all of github.com unreachable.

## Sequencing

Verify-release for v2.6.4 has already failed. After this lands:
1. Cut a new release (v2.6.5) from main.
2. The new release's tag-triggered pipeline runs `release` → `verify-release`. The fixed installer.sh is mirrored to GAR via `gar_mirror_installer.sh`, and `verify_release.sh`'s Section 4 uses the fixed installer.sh from the just-tagged checkout. Both paths now exercise the working fallback. Section 4 should pass.

## Test plan

- [x] `make lint` clean
- [x] `make test-unit` clean
- [x] Reproduced original failure locally (matches build #4334 Section 4 log byte-for-byte: `crit unable to find ''`)
- [x] End-to-end GAR-only install validated locally with the fix
- [ ] After merge, cut v2.6.5; verify-release Section 4 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4938]: https://bitrise.atlassian.net/browse/ACI-4938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ