### PR TITLE
ACI-4939: runtime opt-out for Gradle mirrors init script

### DIFF
--- a/cmd/gradle/activate_gradle_mirrors.go
+++ b/cmd/gradle/activate_gradle_mirrors.go
@@ -20,7 +20,11 @@ When no flags are provided, all known mirrors are enabled.
 
 The command checks the BITRISE_MAVENCENTRAL_PROXY_ENABLED environment variable
 and only installs the init script when it is set to "true".
-The mirror URL is determined by the BITRISE_DEN_VM_DATACENTER environment variable.`,
+The mirror URL is determined by the BITRISE_DEN_VM_DATACENTER environment variable.
+
+The installed init script re-reads BITRISE_MAVENCENTRAL_PROXY_ENABLED at Gradle
+build time: setting it to "false" (via Secrets, step inputs, or app config)
+disables the mirrors per workflow / per workspace without removing the file.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		activator := mirrorspkg.NewActivator(mirrorspkg.ActivatorParams{

--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -68,6 +68,8 @@ func TestActivate(t *testing.T) {
 				"https://repository-manager-ams.services.bitrise.io:8090/maven/gradle-plugins",
 				`r.getUrl().toString().trimEnd('/').equals("https://plugins.gradle.org/m2")`,
 				`"[Bitrise Gradle Mirrors] [$ts] $message"`,
+				`if (System.getenv("BITRISE_MAVENCENTRAL_PROXY_ENABLED") == "false") {`,
+				`log("BITRISE_MAVENCENTRAL_PROXY_ENABLED=false, skipping Bitrise Gradle mirror activation")`,
 				`log("beforeSettings fired,`,
 				`log("settingsEvaluated fired,`,
 				`if (getParent() == null) {

--- a/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -7,6 +7,13 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
             val ts = java.text.SimpleDateFormat("HH:mm:ss").format(System.currentTimeMillis())
             println("[Bitrise Gradle Mirrors] [$ts] $message")
         }
+        // Runtime opt-out: customers can set BITRISE_MAVENCENTRAL_PROXY_ENABLED=false via
+        // Secrets / step inputs / app config to disable the mirrors without removing this
+        // file. Any other value (unset, "true", etc.) leaves the mirrors active.
+        if (System.getenv("BITRISE_MAVENCENTRAL_PROXY_ENABLED") == "false") {
+            log("BITRISE_MAVENCENTRAL_PROXY_ENABLED=false, skipping Bitrise Gradle mirror activation")
+            return
+        }
         // Tracks (repoName|oldUrl|mirrorUrl) tuples we've already logged so the same
         // replacement isn't logged once per subproject in multi-project builds.
         val loggedReplacements = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()

--- a/pkg/gradle/mirrors/activator.go
+++ b/pkg/gradle/mirrors/activator.go
@@ -124,6 +124,11 @@ func NewActivator(params ActivatorParams) *Activator {
 // When disabled (via the Enabled param or the BITRISE_MAVENCENTRAL_PROXY_ENABLED
 // env var), or when no datacenter is available, Activate logs the reason and
 // returns nil.
+//
+// The installed init script also re-reads BITRISE_MAVENCENTRAL_PROXY_ENABLED at
+// Gradle build time: an explicit "false" disables the mirrors at runtime, so a
+// customer can opt out per workflow / per workspace via Secrets, step inputs,
+// or app config without having to remove the file.
 func (a *Activator) Activate(_ context.Context) error {
 	configcommon.LogCLIVersion(a.logger)
 	a.logger.TInfof("Activate Bitrise mirrors for Gradle")


### PR DESCRIPTION
## Summary

Follow-up from the [Maven Central rate-limit postmortem](https://bitrise.atlassian.net/wiki/spaces/INCIDENT/pages/4980998155) ([ACI-4939](https://bitrise.atlassian.net/browse/ACI-4939), parent epic ACI-4935).

Today's customer opt-out is a shared script step that customers paste at the start of their workflow: it `export`s `BITRISE_MAVENCENTRAL_PROXY_ENABLED=false`, calls `envman add` for the same key, and `rm`s `~/.gradle/init.d/bitrise-gradle-mirrors.init.gradle.kts`. Raw shell pasted into a workflow is fragile, doesn't survive workflow rewrites, and forces every opt-out request through CSM 1-on-1.

This change makes the installed init script re-read `BITRISE_MAVENCENTRAL_PROXY_ENABLED` inside the Gradle JVM. When the env var is explicitly `"false"`, the script logs and returns early — no replacements are wired up. Customers can now disable the mirrors per workflow / per workspace by setting the env var via:

- Secrets (workspace or app-level)
- Step inputs (`envs:` on the relevant step)
- App-level env vars
- An inline script step (`envman add --key BITRISE_MAVENCENTRAL_PROXY_ENABLED --value false`)

No more `rm` of the init file. The activation-time semantics are unchanged — the file is still only written when `BITRISE_MAVENCENTRAL_PROXY_ENABLED == "true"` at activate time — so the runtime guard is a *override layer* on top, satisfying the postmortem agreement that "workflow-level overrides take precedence over the monolith's LD-based default".

### Runtime semantics

Only the literal `"false"` disables. Unset, `"true"`, or anything else leaves the mirrors active. Rationale: the file's existence already encodes "the operator decided to enable" at activate time; the runtime check is just an explicit opt-out hatch.

### Changes

- `internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate` — early-return guard at the top of `InternalRepositoryPlugin.apply()`.
- `internal/config/gradle/mirrors/activate_test.go` — asserts the guard renders into the AMS1-all-mirrors fixture.
- `cmd/gradle/activate_gradle_mirrors.go` — cobra `Long` help mentions the runtime opt-out.
- `pkg/gradle/mirrors/activator.go` — `Activate` godoc mentions the runtime opt-out.

### Out of scope

- Devcenter page documenting the opt-out (item 2 of the postmortem plan) — separate work, outside this repo.

## Test plan

- [x] `make test-unit` — passes locally
- [x] `make lint` — clean
- [ ] CI: verify `cache-gradle-test` workflow still picks up the MavenCentral and Google mirrors with `BITRISE_MAVENCENTRAL_PROXY_ENABLED=true` (the existing e2e checks at `bitrise.yml:1046` cover this — the guard's early-return only fires for `"false"`).
- [ ] Manual: in a sandbox app, install the init script, set `BITRISE_MAVENCENTRAL_PROXY_ENABLED=false` via Secrets, run a Gradle build, confirm the `[Bitrise Gradle Mirrors] ... skipping ... activation` log line appears and that no mirror URLs are substituted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4939]: https://bitrise.atlassian.net/browse/ACI-4939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ