### PR TITLE
feat: ACI-4966 include scheme/testPlan/configuration in xcode short command

### DIFF
--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -106,6 +106,19 @@ func (p Default) Command() string {
 }
 
 func (p Default) ShortCommand() string {
+	base := p.shortCommandBase()
+	suffix := p.shapingSuffix()
+	if suffix == "" {
+		return base
+	}
+	if base == "" {
+		return suffix
+	}
+
+	return base + " " + suffix
+}
+
+func (p Default) shortCommandBase() string {
 	nonCommands := p.nonCommands()
 	if len(nonCommands) == 0 {
 		return ""
@@ -121,9 +134,88 @@ func (p Default) ShortCommand() string {
 		}
 	}
 
-	p.logger.Infof("No short command found, defaulting to all: %s", strings.Join(p.nonCommands(), " "))
+	p.logger.Infof("No short command found, defaulting to all: %s", strings.Join(nonCommands, " "))
 
-	return strings.TrimSpace(strings.Join(p.nonCommands(), " "))
+	return strings.TrimSpace(strings.Join(nonCommands, " "))
+}
+
+// shapingSuffix returns the bracketed "[scheme / testPlan / configuration]"
+// suffix appended to the short command for analytics. Missing values are
+// skipped (no placeholder). Returns "" if none of the three are present.
+func (p Default) shapingSuffix() string {
+	scheme, testPlan, configuration := p.extractShapingFlagValues()
+
+	parts := make([]string, 0, 3)
+	if scheme != "" {
+		parts = append(parts, scheme)
+	}
+	if testPlan != "" {
+		parts = append(parts, testPlan)
+	}
+	if configuration != "" {
+		parts = append(parts, configuration)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return "[" + strings.Join(parts, " / ") + "]"
+}
+
+// extractShapingFlagValues scans OriginalArgs for `-scheme`, `-testPlan`, and
+// `-configuration` values. Supports both `-flag value` and `-flag=value` forms
+// (single- or double-dash). Last occurrence wins. A value that begins with `-`
+// is treated as the next flag, not as the current flag's value.
+func (p Default) extractShapingFlagValues() (string, string, string) {
+	var scheme, testPlan, configuration string
+
+	args := p.OriginalArgs
+	for i := 0; i < len(args); i++ {
+		name, value, hasInlineValue := splitShapingFlag(args[i])
+		if name != "scheme" && name != "testPlan" && name != "configuration" {
+			continue
+		}
+
+		if !hasInlineValue {
+			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
+				continue
+			}
+			value = args[i+1]
+			i++
+		}
+
+		if value == "" {
+			continue
+		}
+
+		switch name {
+		case "scheme":
+			scheme = value
+		case "testPlan":
+			testPlan = value
+		case "configuration":
+			configuration = value
+		}
+	}
+
+	return scheme, testPlan, configuration
+}
+
+// splitShapingFlag parses a single argv entry as a flag. Returns the flag name
+// (without leading dashes), the inline value (if a `=` was present), and a
+// boolean indicating whether the inline value form was used. Non-flag args
+// return an empty name.
+func splitShapingFlag(arg string) (string, string, bool) {
+	if !strings.HasPrefix(arg, "-") {
+		return "", "", false
+	}
+
+	trimmed := strings.TrimLeft(arg, "-")
+	if eq := strings.IndexByte(trimmed, '='); eq >= 0 {
+		return trimmed[:eq], trimmed[eq+1:], true
+	}
+
+	return trimmed, "", false
 }
 
 func (p Default) Args(additional map[string]string) []string {

--- a/internal/xcelerate/xcodeargs/args_test.go
+++ b/internal/xcelerate/xcodeargs/args_test.go
@@ -161,7 +161,7 @@ func Test_ShortCommand(t *testing.T) {
 		{
 			name:     "with command at the end",
 			args:     "xcodebuild -destination 'platform=iOS Simulator,OS=18.1,name=iPhone 16 Pro' -scheme WordPress -workspace WordPress.xcworkspace  CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO -showBuildTimingSummary test\n",
-			expected: "test",
+			expected: "test [WordPress]",
 		},
 		{
 			name:     "with command in the middle",
@@ -176,7 +176,7 @@ func Test_ShortCommand(t *testing.T) {
 		{
 			name:     "clean followed by archive returns archive",
 			args:     "xcodebuild clean archive -workspace /Users/vagrant/git/GuestSelfService.xcworkspace -scheme HyattApp -configuration Release -xcconfig /var/folders/f6/wf2hj3cj75qdwmt5rn814r_00000gn/T/2300449354/temp.xcconfig -archivePath /var/folders/f6/wf2hj3cj75qdwmt5rn814r_00000gn/T/xcodeArchive2352012375/HyattApp.xcarchive -destination generic/platform=iOS -skipPackagePluginValidation -disableAutomaticPackageResolution PROVISIONING_PROFILE= PROVISIONING_PROFILE_SPECIFIER=HyattApp_InHouse_Kermit",
-			expected: "archive",
+			expected: "archive [HyattApp / Release]",
 		},
 		{
 			name:     "clean alone returns clean",
@@ -196,6 +196,116 @@ func Test_ShortCommand(t *testing.T) {
 			args := strings.Split(tc.args, " ")
 			cmd := &cobra.Command{Use: "xcodebuild"}
 			SUT := xcodeargs.NewDefault(cmd, args, mockLogger)
+
+			// when
+			result := SUT.ShortCommand()
+
+			// then
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func Test_ShortCommand_ShapingFlags(t *testing.T) {
+	type testCase struct {
+		name     string
+		args     []string
+		expected string
+	}
+
+	tcs := []testCase{
+		{
+			name:     "scheme only",
+			args:     []string{"xcodebuild", "test", "-scheme", "StockTwits(Production)"},
+			expected: "test [StockTwits(Production)]",
+		},
+		{
+			name:     "scheme and testPlan",
+			args:     []string{"xcodebuild", "test", "-scheme", "StockTwits(Production)", "-testPlan", "StockTwits(Develop)_bitrise"},
+			expected: "test [StockTwits(Production) / StockTwits(Develop)_bitrise]",
+		},
+		{
+			name:     "scheme and configuration without testPlan (no double slash)",
+			args:     []string{"xcodebuild", "archive", "-scheme", "AccorHotelsApp", "-configuration", "SandboxDevelopmentRelease"},
+			expected: "archive [AccorHotelsApp / SandboxDevelopmentRelease]",
+		},
+		{
+			name:     "all three flags",
+			args:     []string{"xcodebuild", "test-without-building", "-scheme", "Substack", "-testPlan", "SubstackUITests", "-configuration", "Debug"},
+			expected: "test-without-building [Substack / SubstackUITests / Debug]",
+		},
+		{
+			name:     "testPlan without scheme still renders brackets",
+			args:     []string{"xcodebuild", "test", "-testPlan", "SubstackUITests"},
+			expected: "test [SubstackUITests]",
+		},
+		{
+			name:     "configuration without scheme still renders brackets",
+			args:     []string{"xcodebuild", "build", "-configuration", "Debug"},
+			expected: "build [Debug]",
+		},
+		{
+			name:     "testPlan and configuration without scheme",
+			args:     []string{"xcodebuild", "test", "-testPlan", "Smoke", "-configuration", "Debug"},
+			expected: "test [Smoke / Debug]",
+		},
+		{
+			name:     "scheme value with spaces",
+			args:     []string{"xcodebuild", "test", "-scheme", "DysonLink UI Tests"},
+			expected: "test [DysonLink UI Tests]",
+		},
+		{
+			name:     "scheme value containing hyphen segment",
+			args:     []string{"xcodebuild", "archive", "-scheme", "Terminal - Certifications"},
+			expected: "archive [Terminal - Certifications]",
+		},
+		{
+			name:     "non-action base showBuildSettings with no shaping flags is unchanged",
+			args:     []string{"xcodebuild", "-showBuildSettings", "-workspace", "Foo.xcworkspace"},
+			expected: "-showBuildSettings",
+		},
+		{
+			name:     "non-action base showBuildSettings with scheme still gets brackets",
+			args:     []string{"xcodebuild", "-showBuildSettings", "-scheme", "Foo"},
+			expected: "-showBuildSettings [Foo]",
+		},
+		{
+			name:     "equals form: -scheme=Value",
+			args:     []string{"xcodebuild", "test", "-scheme=WordPress"},
+			expected: "test [WordPress]",
+		},
+		{
+			name:     "equals form: all three with =",
+			args:     []string{"xcodebuild", "test", "-scheme=Substack", "-testPlan=SubstackUITests", "-configuration=Debug"},
+			expected: "test [Substack / SubstackUITests / Debug]",
+		},
+		{
+			name:     "double-dash form",
+			args:     []string{"xcodebuild", "test", "--scheme", "WordPress", "--configuration", "Release"},
+			expected: "test [WordPress / Release]",
+		},
+		{
+			name:     "empty scheme value is treated as absent",
+			args:     []string{"xcodebuild", "test", "-scheme", "", "-configuration", "Debug"},
+			expected: "test [Debug]",
+		},
+		{
+			name:     "scheme followed by another flag has no value",
+			args:     []string{"xcodebuild", "test", "-scheme", "-workspace", "Foo.xcworkspace"},
+			expected: "test",
+		},
+		{
+			name:     "last occurrence of scheme wins",
+			args:     []string{"xcodebuild", "test", "-scheme", "First", "-scheme", "Second"},
+			expected: "test [Second]",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			cmd := &cobra.Command{Use: "xcodebuild"}
+			SUT := xcodeargs.NewDefault(cmd, tc.args, mockLogger)
 
 			// when
 			result := SUT.ShortCommand()


### PR DESCRIPTION
## Summary
- Extend `ShortCommand()` in `internal/xcelerate/xcodeargs/args.go` to append a `[scheme / testPlan / configuration]` suffix when any of those `xcodebuild` flags are present, so semantically-different invocations stop collapsing to the same identifier (`test`, `build`, `archive`, …) in the analytics UI.
- `FullCommand` is unchanged. The `Invocation.Command` field name stays the same; only the value rendered into it gets richer.
- The argv parser supports both `-flag value` and `-flag=value`, both single- and double-dash prefixes, takes the last occurrence when a flag is repeated, and treats a value that starts with `-` as the next flag (no value).

Format (rules):
- `<base>` — no shaping flags present (unchanged from today)
- `<base> [<scheme>]`
- `<base> [<scheme> / <testPlan>]`
- `<base> [<scheme> / <testPlan> / <configuration>]`
- `<base> [<scheme> / <configuration>]` — testPlan missing
- Missing values are skipped entirely (no dash placeholder, no double slash).
- Order is always scheme → testPlan → configuration.

Parent ticket: ACI-4951.
Subtask: ACI-4966.

## Known limitation: defaults are not resolved

This change only reads what's in argv. When `-scheme` / `-testPlan` / `-configuration` are **not** passed explicitly, `xcodebuild` resolves them from the project (`.xcworkspace`/`.xcodeproj`) — default scheme, `-configuration Release` if omitted, etc. We don't extract those implicit defaults here. Doing so end-to-end would require a coordinated backend migration as well (the analytics backend would need to be migrated to store/render those resolved values), so it's intentionally out of scope for this CLI-side change. Invocations without explicit flags will continue to render as the bare `<base>`, same as today.

## Scope justification (variance analysis)

90 days of production data (xcode-analytics-service DB, 431K invocations, 173K successful canonical-action invocations). Law of total variance on `duration_ms`:

| Key | Distinct values | Within-group runtime SD | Total-variance reduction |
|---|---|---|---|
| command only (today) | 43 | 504s | 11.7% |
| + scheme | ~820 | 311s | 66.4% |
| + scheme + configuration | ~983 | 283s | 72.1% |
| + scheme + testPlan + configuration | ~1,017 | 226s | 82.2% |
| + scheme + testPlan + cfg + dest_platform | ~1,028 | 226s | 82.2% (no gain) |
| + scheme + bundle (workspace/project) | — | 332s | +0.1pp marginal (collinear with scheme) |

`-destination platform`, `-sdk`, `-workspace`/`-project`, `-xcconfig`, `-only-testing`/`-skip-testing` add ~zero marginal variance reduction on top of scheme. They are intentionally out of scope for this change; the parent ACI-4951 description still lists them as candidates — ignore that, this subtask narrows scope to the 3 high-signal flags.

Worst-case rendered length with the 3 chosen flags is ~60 characters (fits the UI).

## Example rendered values

- `test [StockTwits(Production) / StockTwits(Develop)_bitrise]`
- `archive [AccorHotelsApp / SandboxDevelopmentRelease]`
- `test-without-building [Substack / SubstackUITests / Debug]`
- `-showBuildSettings` (unchanged — no shaping flags present)

## Test plan
- [x] `go test -tags unit -race ./internal/xcelerate/xcodeargs/...` passes (table-driven cases covering: no flags, scheme only, scheme+testPlan, scheme+config (no double slash), all three, testPlan/config without scheme, scheme with spaces, scheme with hyphen segment, non-action base `-showBuildSettings`, `-flag=value` form, double-dash form, empty value, value-starts-with-`-`, last occurrence wins).
- [x] `make lint` — clean.
- [x] `make test-unit` — full repo green.
- [x] CI green on this PR (e2e `e2e-xcode-comp-cache` invocation rendered as `"command":"build [ComposableArchitecture]"` with `fullCommand` unchanged).

## Follow-ups (not in this PR)
- Server-side backfill: re-parse historical `FullCommand` to update old rows. Tracked separately.
- Resolving implicit defaults from the project (default scheme / `Release` configuration / …) — needs coordinated backend changes; see the "Known limitation" section above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
