### PR TITLE
fix: ACI-4793 enrich downloaded file hash mismatch error with diagnostic context

### DIFF
--- a/internal/build_cache/kv/download.go
+++ b/internal/build_cache/kv/download.go
@@ -88,12 +88,15 @@ func (c *Client) DownloadFile(ctx context.Context, filePath, key string, fileMod
 
 func (c *Client) DownloadStream(ctx context.Context, destination io.Writer, key string) error {
 	var offset int64
+	var totalBytes int64
+	var attempts uint
 
 	hasher := sha256.New()
 	multiWriter := io.MultiWriter(hasher, destination)
 	expectedHash := ""
 
 	downloadErr := retry.Times(c.downloadRetry).Wait(c.downloadRetryWait).TryWithAbort(func(attempt uint) (error, bool) {
+		attempts = attempt + 1
 		if attempt == 0 {
 			c.logger.TDebugf("Downloading %s", key)
 		} else {
@@ -111,8 +114,10 @@ func (c *Client) DownloadStream(ctx context.Context, destination io.Writer, key 
 		}
 		defer kvReader.Close()
 
-		if n, err := io.Copy(multiWriter, kvReader); err != nil {
-			st, ok := status.FromError(err)
+		n, copyErr := io.Copy(multiWriter, kvReader)
+		totalBytes += n
+		if copyErr != nil {
+			st, ok := status.FromError(copyErr)
 			if ok && st.Code() == codes.NotFound {
 				return ErrCacheNotFound, true
 			}
@@ -122,9 +127,9 @@ func (c *Client) DownloadStream(ctx context.Context, destination io.Writer, key 
 
 			offset += n
 
-			c.logger.Warnf("Failed to download stream: attempt %d: %s", attempt+1, err)
+			c.logger.Warnf("Failed to download stream: attempt %d: %s", attempt+1, copyErr)
 
-			return fmt.Errorf("download archive: %w", err), false
+			return fmt.Errorf("download archive: %w", copyErr), false
 		}
 
 		expectedHash = kvReader.Metadata()["x-flare-blob-validation-sha256"]
@@ -140,10 +145,15 @@ func (c *Client) DownloadStream(ctx context.Context, destination io.Writer, key 
 	if expectedHash != "" {
 		fileHash := hex.EncodeToString(hasher.Sum(nil))
 		if expectedHash != fileHash {
-			return fmt.Errorf("downloaded file hash mismatch: expected %s, got %s", expectedHash, fileHash)
-		} else {
-			c.logger.TDebugf("Downloaded %s hash matches expected: %s", key, expectedHash)
+			return fmt.Errorf(
+				"downloaded file hash mismatch for key %q: expected %s, got %s (received %d bytes across %d attempt(s), retried offset %d, cache-operation-id=%q, invocation-id=%q)",
+				key, expectedHash, fileHash,
+				totalBytes, attempts, offset,
+				c.cacheOperationID, c.invocationID,
+			)
 		}
+
+		c.logger.TDebugf("Downloaded %s hash matches expected: %s", key, expectedHash)
 	}
 
 	return nil

--- a/internal/build_cache/kv/download_test.go
+++ b/internal/build_cache/kv/download_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -180,4 +181,10 @@ func TestClient_DownloadStream_MismatchValidation(t *testing.T) {
 
 	err = client.DownloadStream(context.Background(), destination, "test-key")
 	require.Error(t, err)
+
+	msg := err.Error()
+	assert.Contains(t, msg, `"test-key"`, "error should identify the key")
+	assert.Contains(t, msg, "expected 3fc6540b6002f7622d978ea8c6fcb6a661089de0f4952f42390a694107269893")
+	assert.Contains(t, msg, fmt.Sprintf("received %d bytes", len(downloadTestData)))
+	assert.Contains(t, msg, "1 attempt(s)")
 }


### PR DESCRIPTION
## Summary

When `DownloadStream` (`internal/build_cache/kv/download.go`) detects a SHA256 divergence between the bytes it streamed and the server-supplied `x-flare-blob-validation-sha256`, the error currently reads:

```
downloaded file hash mismatch: expected <hex>, got <hex>
```

That's enough to know a hash diverged, but nothing else — not the key, not how much was received, not whether the wire was re-stitched across retries, and no IDs to grep on the server side.

This change enriches the error with cheap, already-in-scope context:

```
downloaded file hash mismatch for key "<key>": expected <hex>, got <hex> (received N bytes across M attempt(s), retried offset O, cache-operation-id="<id>", invocation-id="<id>")
```

Fields added:
- **key** — most important, especially for `DownloadStream` callers (xcelerate proxy, metadata JSON fetches) that don't otherwise log the key on failure
- **received N bytes** — distinguishes "got 0", "got partial", "got full size but corrupt"
- **M attempt(s)** + **retried offset** — flags retry-boundary stitching as a possible corruption source (the hasher continues across retries with `offset += n` on partial reads)
- **cache-operation-id** / **invocation-id** — already on `Client`, sent up as request headers; echoing them in the error lets ops correlate across client and server logs

### Explicitly not added
- Server response metadata (`kvReader.Metadata()` dump) — gRPC response headers can carry tokens or other sensitive values; an allowlist by prefix is brittle.
- `x-flare-blob-validation-level` — we send this as a *request* header on PUT, but the GET path doesn't send it and we have no evidence the server echoes it on GET responses.

## Test plan

- [x] `go test -tags unit -race ./internal/build_cache/kv/...` — passes
- [x] `make lint` — 0 issues
- [x] `TestClient_DownloadStream_MismatchValidation` extended to assert the new substrings (key, expected hash, byte count, attempt count) appear in the error

The error remains a plain `fmt.Errorf` (no sentinel wrapping), so existing `errors.Is(err, ErrCacheNotFound)` / `errors.Is(err, ErrCacheUnauthenticated)` checks at call sites are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)