### PR TITLE
fix: ACI-4966 default xcode short command base to "build" when no action in argv

### DIFF
--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -36,6 +36,7 @@ var actions = []string{
 	"test-without-building",
 	"docbuild",
 	"installsrc",
+	"installhdrs",
 	"install",
 	"clean",
 	"-showsdks",
@@ -118,11 +119,14 @@ func (p Default) ShortCommand() string {
 	return base + " " + suffix
 }
 
+// shortCommandBase resolves the action keyword for the analytics short
+// command. Per xcodebuild(1), `build` is the default action and is used if no
+// action is given — so when argv contains no recognized action keyword we
+// return the literal "build" rather than the joined arg-string, which keeps
+// the rendered short command human-readable for invocations like
+// `xcodebuild -workspace Foo.xcworkspace -scheme Foo -configuration Debug`.
 func (p Default) shortCommandBase() string {
 	nonCommands := p.nonCommands()
-	if len(nonCommands) == 0 {
-		return ""
-	}
 
 	for _, action := range actions {
 		for _, cmd := range nonCommands {
@@ -134,9 +138,9 @@ func (p Default) shortCommandBase() string {
 		}
 	}
 
-	p.logger.Infof("No short command found, defaulting to all: %s", strings.Join(nonCommands, " "))
+	p.logger.Debugf("No action keyword in argv; defaulting to %q per xcodebuild(1)", "build")
 
-	return strings.TrimSpace(strings.Join(nonCommands, " "))
+	return "build"
 }
 
 // shapingSuffix returns the bracketed "[scheme / testPlan / configuration]"

--- a/internal/xcelerate/xcodeargs/args_test.go
+++ b/internal/xcelerate/xcodeargs/args_test.go
@@ -184,9 +184,9 @@ func Test_ShortCommand(t *testing.T) {
 			expected: "clean",
 		},
 		{
-			name:     "with no action",
+			name:     "with no action defaults to build per xcodebuild(1)",
 			args:     "-destination mars 'platform=iOS Simulator,OS=18' CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO",
-			expected: "-destination mars 'platform=iOS Simulator,OS=18' CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO",
+			expected: "build",
 		},
 	}
 
@@ -298,6 +298,41 @@ func Test_ShortCommand_ShapingFlags(t *testing.T) {
 			name:     "last occurrence of scheme wins",
 			args:     []string{"xcodebuild", "test", "-scheme", "First", "-scheme", "Second"},
 			expected: "test [Second]",
+		},
+		{
+			name:     "no action keyword + workspace + scheme defaults base to build",
+			args:     []string{"xcodebuild", "-workspace", "Seek.xcworkspace", "-scheme", "Seek", "-destination", "generic/platform=iOS Simulator"},
+			expected: "build [Seek]",
+		},
+		{
+			name:     "no action keyword + workspace + scheme + configuration defaults base to build",
+			args:     []string{"xcodebuild", "-workspace", "Seek.xcworkspace", "-configuration", "Debug", "-scheme", "Seek", "-destination", "generic/platform=iOS Simulator"},
+			expected: "build [Seek / Debug]",
+		},
+		{
+			name:     "no action keyword + project + scheme + configuration defaults base to build",
+			args:     []string{"xcodebuild", "-project", "Pods.xcodeproj", "-scheme", "AppAuth", "-destination", "generic/platform=iOS", "-configuration", "Debug"},
+			expected: "build [AppAuth / Debug]",
+		},
+		{
+			name:     "no action keyword and no shaping flags renders bare build",
+			args:     []string{"xcodebuild", "-destination", "mars", "CODE_SIGN_IDENTITY=", "CODE_SIGNING_REQUIRED=NO"},
+			expected: "build",
+		},
+		{
+			name:     "scheme value with spaces, no action keyword",
+			args:     []string{"xcodebuild", "-workspace", "ios/mobile.xcworkspace", "-configuration", "ReleaseHimsStaging", "-scheme", "hims (staging)", "-sdk", "iphonesimulator"},
+			expected: "build [hims (staging) / ReleaseHimsStaging]",
+		},
+		{
+			name:     "explicit build action keyword is unchanged when also using shaping flags",
+			args:     []string{"xcodebuild", "build", "-workspace", "Foo.xcworkspace", "-scheme", "Foo", "-configuration", "Release"},
+			expected: "build [Foo / Release]",
+		},
+		{
+			name:     "installhdrs is recognized as an action keyword",
+			args:     []string{"xcodebuild", "installhdrs", "-scheme", "Foo"},
+			expected: "installhdrs [Foo]",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to ACI-4966 (the work that introduced the `<base> [<scheme> / <testPlan> / <configuration>]` short-command format, shipped in v2.7.0). The new format is otherwise working correctly in the wild — confirmed against ~3,800 production rows — but one class of inputs still produces unreadable output.

When `xcodebuild` is invoked **without an action keyword** in argv (e.g. `xcodebuild -workspace Seek.xcworkspace -configuration Debug -scheme Seek -destination "generic/platform=iOS Simulator"`), `ShortCommand()` previously fell back to the joined arg-string as the base, and the new bracket suffix got appended on top. Real production output today:

```
-workspace Seek.xcworkspace -configuration Debug -scheme Seek -destination generic/platform=iOS Simulator [Seek / Debug]
```

That's 115 chars of arg-soup. `xcodebuild(1)` documents `build` as the default action when none is given:

> **build** — Build the target in the build root (`SYMROOT`). This is the default action, and is used if no action is given.

So this PR changes the fallback in `shortCommandBase()` to return the literal string `"build"` when no action keyword is found. The example above becomes:

```
build [Seek / Debug]
```

## Scope

Only the "no action found" branch in `internal/xcelerate/xcodeargs/args.go` changes:

- **Action keyword present** (`test`, `build`, `archive`, `build-for-testing`, `test-without-building`, `analyze`, `clean`, `docbuild`, `install`, `installsrc`, `installhdrs`) → use it as the base. **Unchanged.**
- **`-`-prefixed auxiliary command** (`-showBuildSettings`, `-resolvePackageDependencies`, `-list`, `-showsdks`, `-exportArchive`, `-create-xcframework`, …) → use that. **Unchanged.** (Spot-checked rows like `-showBuildSettings [Internal]` and `-resolvePackageDependencies [Grindr]` are already correct in production and stay correct.)
- **Neither** → return `"build"`. **Changed** (was: joined arg-string).

Drive-by: added `installhdrs` to the `actions` list — it sits next to `installsrc` in xcodebuild(1) but was missing here.

## Production-data verification (post-fix)

Three of the ~500 affected rows from the last 14 days, with the rendered short command this PR will produce:

| `fullCommand` (truncated) | Before (today) | After this PR |
|---|---|---|
| `-workspace Seek.xcworkspace -configuration Debug -scheme Seek -destination …` | `-workspace Seek.xcworkspace -configuration Debug -scheme Seek -destination generic/platform=iOS Simulator [Seek / Debug]` | `build [Seek / Debug]` |
| `-workspace ios/mobile.xcworkspace -configuration ReleaseHimsStaging -scheme hims (staging) -sdk iphonesimulator …` | (long arg-soup) `[hims (staging) / ReleaseHimsStaging]` | `build [hims (staging) / ReleaseHimsStaging]` |
| `-project Pods.xcodeproj -scheme AppAuth -destination generic/platform=iOS -configuration Debug` | (long arg-soup) `[AppAuth / Debug]` | `build [AppAuth / Debug]` |

## Why both ends must agree

The server-side migration in [xcode-analytics-service#42](https://github.com/bitrise-io/xcode-analytics-service/pull/42) does the same normalization on legacy rows. The migration is idempotent by value comparison — if the CLI keeps writing the unreadable form, every dry-run will report those rows as "would update" and every real run will overwrite them. Both ends need to converge on `build` as the default; this PR is the CLI half.

## Test plan
- [x] `go test -tags unit -race ./internal/xcelerate/xcodeargs/...` — new table cases:
  - no action keyword + `-workspace` + `-scheme` → `build [Seek]`
  - no action keyword + `-workspace` + `-scheme` + `-configuration` → `build [Seek / Debug]`
  - no action keyword + `-project` + `-scheme` + `-configuration` → `build [AppAuth / Debug]`
  - no action keyword + no shaping flags → bare `build`
  - scheme value with spaces, no action keyword → `build [hims (staging) / ReleaseHimsStaging]`
  - explicit `build` keyword + shaping flags — unchanged
  - `installhdrs` — newly recognized as an action keyword
- [x] Existing `-showBuildSettings` / `-resolvePackageDependencies` / `-exportArchive` cases — unchanged (auxiliary-command branch not touched).
- [x] `make lint` clean.
- [x] `make test-unit` full repo green.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)