### PR TITLE
fix: ccache IPC socket default to TempDir for EAS-CLI compat

### DIFF
--- a/cmd/ccache/activate_cpp.go
+++ b/cmd/ccache/activate_cpp.go
@@ -60,7 +60,7 @@ func init() {
 		&activateCppParams.IPCSocketPathOverride,
 		"ipc-socket-path",
 		activateCppParams.IPCSocketPathOverride,
-		"Override the IPC socket path for the ccache storage helper. Defaults to <working-dir>/ccache-ipc.sock.",
+		"Override the IPC socket path for the ccache storage helper. Defaults to $BITRISE_CCACHE_IPC_SOCKET_PATH or <temp-dir>/ccache-ipc.sock.",
 	)
 	activateCppCmd.Flags().StringVar(
 		&activateCppParams.BaseDirOverride,

--- a/internal/config/ccache/config.go
+++ b/internal/config/ccache/config.go
@@ -90,11 +90,10 @@ func NewConfig(envs map[string]string, osProxy utils.OsProxy, params Params) (Co
 
 	ipcEndpoint := params.IPCSocketPathOverride
 	if ipcEndpoint == "" {
-		wd, err := osProxy.Getwd()
-		if err != nil {
-			wd = "."
+		ipcEndpoint = envs["BITRISE_CCACHE_IPC_SOCKET_PATH"]
+		if ipcEndpoint == "" {
+			ipcEndpoint = filepath.Join(osProxy.TempDir(), "ccache-ipc.sock")
 		}
-		ipcEndpoint = filepath.Join(wd, "ccache-ipc.sock")
 	}
 
 	buildCacheEndpoint := common.SelectCacheEndpointURL(params.BuildCacheEndpoint, envs)

--- a/pkg/ccache/activator_test.go
+++ b/pkg/ccache/activator_test.go
@@ -51,6 +51,7 @@ func newOsProxyMock(t *testing.T) *mocks.OsProxyMock {
 		UserHomeDirFunc: func() (string, error) { return tmpDir, nil },
 		MkdirAllFunc:    func(_ string, _ os.FileMode) error { return nil },
 		GetwdFunc:       func() (string, error) { return "/work/dir", nil },
+		TempDirFunc:     func() string { return tmpDir },
 		CreateFunc: func(_ string) (*os.File, error) {
 			return os.CreateTemp(tmpDir, "ccache-config-*.json")
 		},


### PR DESCRIPTION
## Summary
- Move default ccache IPC socket from `<Getwd()>/ccache-ipc.sock` to `<TempDir()>/ccache-ipc.sock` so it lives outside the project workdir.
- Add `BITRISE_CCACHE_IPC_SOCKET_PATH` env fallback ahead of the new TempDir default, matching the xcelerate proxy-socket pattern (`BITRISE_XCELERATE_PROXY_SOCKET_PATH`).
- Flag override (`--ipc-socket-path`) precedence preserved; help text updated.

## Why
EAS CLI shallow-clones the project workdir before the build. The old default put the AF_UNIX socket at the RN/Expo repo root, so EAS's copy step blew up with:

```
Cannot copy a socket file: cp returned EINVAL (cannot copy a socket file: /var/folders/.../eas-cli-nodejs/<id>-shallow-clone/ccache-ipc.sock)
    Error: build command failed.
```

TempDir is outside any project tree, so EAS never touches it.

## Test plan
- [x] `go test -tags unit -race ./...` green
- [ ] Manual: `bitrise-build-cache react-native run eas build ...` no longer EINVALs on socket copy
- [ ] CI green