### PR TITLE
chore: QoL — --version flag, stdout version, skip baseline ccache stats

### DIFF
--- a/cmd/common/root.go
+++ b/cmd/common/root.go
@@ -11,8 +11,9 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{ //nolint:gochecknoglobals
-	Use:   "bitrise-build-cache-cli",
-	Short: "Bitrise Build Cache CLI - to enable/configure Gradle or Bazel build cache on the machine where you run this CLI.",
+	Use:     "bitrise-build-cache-cli",
+	Version: configcommon.GetCLIVersion(log.NewLogger()),
+	Short:   "Bitrise Build Cache CLI - to enable/configure Gradle or Bazel build cache on the machine where you run this CLI.",
 	Long: `Bitrise Build Cache CLI - to enable/configure Gradle or Bazel build cache on the machine where you run this CLI.
 
 What does the CLI do on a high level?

--- a/cmd/common/version.go
+++ b/cmd/common/version.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"fmt"
+
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
@@ -12,7 +14,7 @@ var VersionCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Short: "Show the version number of bitrise-build-cache-cli",
 	Long:  `Show the version number of bitrise-build-cache-cli`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Println(common.GetCLIVersion(log.NewLogger()))
+		fmt.Fprintln(cmd.OutOrStdout(), common.GetCLIVersion(log.NewLogger()))
 	},
 }
 

--- a/pkg/reactnative/post_run_deps.go
+++ b/pkg/reactnative/post_run_deps.go
@@ -82,13 +82,22 @@ func (d *postRunDeps) run(ctx context.Context, wrapperInvocationID string, args 
 		fullCommand = strings.Join(args, " ")
 	}
 
-	helper, helperErr := ccachepkg.NewStorageHelper(ccachepkg.StorageHelperParams{
-		ParentInvocationID: wrapperInvocationID,
-	})
-	if helperErr != nil {
-		d.logger.TWarnf("Failed to create storage helper for ccache stats collection: %v", helperErr)
+	// Mirror the activate-side skip: when Gradle is in benchmark baseline,
+	// activate-react-native deliberately does not write ccache config (see
+	// Activator.activateCppIfApplicable). Attempting to load the helper here
+	// would fail with a scary ENOENT WARN even though the skip is intentional.
+	// Stop-gap until ccache grows its own benchmark phase support (ACI-4926).
+	if common.ReadBenchmarkPhaseFile(common.BuildToolGradle, d.logger) == common.BenchmarkPhaseBaseline {
+		d.logger.Debugf("Skipping ccache stats collection: Gradle is in benchmark baseline mode.")
 	} else {
-		helper.CollectAndSendStats(ctx, "", "")
+		helper, helperErr := ccachepkg.NewStorageHelper(ccachepkg.StorageHelperParams{
+			ParentInvocationID: wrapperInvocationID,
+		})
+		if helperErr != nil {
+			d.logger.TWarnf("Failed to create storage helper for ccache stats collection: %v", helperErr)
+		} else {
+			helper.CollectAndSendStats(ctx, "", "")
+		}
 	}
 
 	agg := childstats.NewAggregator(wrapperInvocationID)


### PR DESCRIPTION
## Summary

Three small QoL fixes bundled together — surfaced while debugging the v2.7.3 RN-features step `signal: killed` regression (root cause: step's `isCorrectVersion` check + new ccache TempDir socket; PR: bitrise-steplib/bitrise-step-activate-react-native-features#25).

- **`--version` flag on RootCmd.** Setting `Version:` makes cobra wire the canonical `--version` flag. Any consumer probing the binary with `--version` (the usual cross-CLI convention) now works without falling through to "unknown flag" + error. The `version` subcommand stays as-is.

- **`version` subcommand writes to stdout.** Cobra's `cmd.Println` defaults to `OutOrStderr()`, so `exec.Command(bin, "version").Output()` returns an empty string and breaks naive version checks (e.g. the activate-react-native-features step's `isCorrectVersion`, which we just patched in the step repo). Switch to `fmt.Fprintln(cmd.OutOrStdout(), ...)`.

- **Skip ccache stats collection when Gradle is in benchmark baseline.** Mirrors the activate-side skip in `Activator.activateCppIfApplicable`: when Gradle ran in baseline we don't write the ccache config, so the post-run hook trying to load the helper prints a scary ENOENT WARN even though the skip is intentional. Stop-gap until ccache grows its own benchmark phase support (ACI-4926).

## Test plan
- [x] `make test-unit` green
- [x] `make lint` clean
- [x] Local smoke: `bitrise-build-cache --version` → `bitrise-build-cache-cli version <v>` (stdout); `bitrise-build-cache version` → `<v>` (stdout)
- [ ] CI green on this PR