### PR TITLE
fix: ACI-4937 fix dependency matrix generation

### DIFF
--- a/assets/dependency-matrix-header.md
+++ b/assets/dependency-matrix-header.md
@@ -7,9 +7,8 @@ This page lists every released version of the [Bitrise Build Cache CLI](https://
 The CLI is downloaded and invoked by the Bitrise steps below. Pinning any of these steps to a specific patch version effectively pins the CLI version (and therefore the plugin versions) used in your build:
 
 - [Activate Bitrise Build Cache for Gradle](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache) — `activate-build-cache-for-gradle`
-- [Bitrise Build Cache for React Native](https://github.com/bitrise-steplib/bitrise-step-activate-react-native-features) — `activate-react-native-features`
+- [Bitrise Build Cache for React Native](https://github.com/bitrise-steplib/bitrise-step-activate-react-native-features) — `activate-build-cache-for-react-native`
 - [Activate Bitrise-hosted Gradle repository mirrors](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-mirrors) — `activate-gradle-mirrors`
-- [Activate Bitrise Build Cache features for Gradle](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-features) — `activate-gradle-features` (experimental)
 
 Different consumer steps may bundle different CLI versions, so the plugin versions in your build depend on which step actually runs first in your workflow. To find the CLI version a build used, look at the activating step's log — it prints the CLI version near the top of its section. Then look up that row below.
 
@@ -24,9 +23,8 @@ Two views over the same data:
 
 - [CLI release table](#cli-release-table)
 - [activate-build-cache-for-gradle](#activate-build-cache-for-gradle)
-- [activate-react-native-features](#activate-react-native-features)
+- [activate-build-cache-for-react-native](#activate-build-cache-for-react-native)
 - [activate-gradle-mirrors](#activate-gradle-mirrors)
-- [activate-gradle-features](#activate-gradle-features)
 
 ## Components
 

--- a/assets/dependency-matrix-header.md
+++ b/assets/dependency-matrix-header.md
@@ -1,19 +1,24 @@
 # Bitrise Build Cache CLI — Dependency Matrix
 
-This page lists every released version of the [Bitrise Build Cache CLI](https://github.com/bitrise-io/bitrise-build-cache-cli) and the corresponding plugin versions it pins for Gradle builds (Analytics, Remote Cache, Test Distribution).
+This page lists every released version of the [Bitrise Build Cache CLI](https://github.com/bitrise-io/bitrise-build-cache-cli) and the corresponding plugin versions it pins for Gradle builds (Analytics, Remote Cache, Test Distribution, Common).
 
 ## Where the CLI runs
 
-The CLI is downloaded and invoked by several Bitrise steps. Pinning any of these steps to a specific patch version effectively pins the CLI version (and therefore the plugin versions) used in your build:
+The CLI is downloaded and invoked by the Bitrise steps below. Pinning any of these steps to a specific patch version effectively pins the CLI version (and therefore the plugin versions) used in your build:
 
-- [Activate Gradle Remote Cache](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache) — `activate-build-cache-for-gradle`
-- [Activate React Native Features](https://github.com/bitrise-steplib/bitrise-step-activate-react-native-features) — `activate-react-native-features` (RN cache)
-- [Activate Gradle Features](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-features) — `activate-gradle-features` (experimental)
-- [Install missing Android SDK components](https://github.com/bitrise-steplib/steps-install-missing-android-tools) — `install-missing-android-tools`
-- [Activate Gradle Mirrors](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-mirrors) — `activate-gradle-mirrors`
-- [Gradle Runner](https://github.com/bitrise-steplib/steps-gradle-runner) — `gradle-runner`
+- [Activate Bitrise Build Cache for Gradle](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache) — `activate-build-cache-for-gradle`
+- [Bitrise Build Cache for React Native](https://github.com/bitrise-steplib/bitrise-step-activate-react-native-features) — `activate-react-native-features`
+- [Activate Bitrise-hosted Gradle repository mirrors](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-mirrors) — `activate-gradle-mirrors`
+- [Activate Bitrise Build Cache features for Gradle](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-features) — `activate-gradle-features` (experimental)
 
 Different consumer steps may bundle different CLI versions, so the plugin versions in your build depend on which step actually runs first in your workflow. To find the CLI version a build used, look at the activating step's log — it prints the CLI version near the top of its section. Then look up that row below.
+
+## How to read this page
+
+Two views over the same data:
+
+- **CLI releases → bundled plugin versions** — start here if you know the CLI version a build used and want to know which plugin versions it pulled.
+- **One section per consumer step** — start here if you know the step version pinned in your workflow and want the CLI + plugin versions it resolves to.
 
 ## Components
 
@@ -21,6 +26,7 @@ Different consumer steps may bundle different CLI versions, so the plugin versio
 - The analytics plugin `io.bitrise.gradle:gradle-analytics` is published to Maven Central and provides build analytics (e.g. [critical path](https://bitrise.io/changelog/enhanced-gradle-critical-path/24815)).
 - The remote cache plugin `io.bitrise.gradle:remote-cache` is published to Maven Central and implements the client for the Bitrise remote build cache.
 - The test distribution plugin `io.bitrise.gradle:test-distribution` is published to Maven Central and integrates with Bitrise Test Distribution.
+- The common plugin `io.bitrise.gradle:common` is published to Maven Central and is a shared dependency of the above.
 
 ## Gradle dependency verification
 
@@ -30,5 +36,3 @@ If you use Gradle's [dependency verification](https://docs.gradle.org/current/us
 - `verification-metadata-mirror.xml` (from `v2.4.6` onward) — checksums for artifacts as served by the **Bitrise Maven Central mirror**. The mirror is on by default for all Bitrise Android builds, so this is the file most workflows need; the plain origin file will fail verification when the mirror serves the artifacts.
 
 For the full setup walkthrough — including which step in your workflow activates the mirror, how to lock that step's version, and how to regenerate the metadata when the CLI is updated — see [Gradle dependency verification for the Maven Central mirror](https://docs.google.com/document/d/1mrquZ-n7dNNmQo0o4ddzY73JTsY5xkYRgRKARoKNFvs/edit).
-
-## Releases

--- a/assets/dependency-matrix-header.md
+++ b/assets/dependency-matrix-header.md
@@ -17,8 +17,16 @@ Different consumer steps may bundle different CLI versions, so the plugin versio
 
 Two views over the same data:
 
-- **CLI releases → bundled plugin versions** — start here if you know the CLI version a build used and want to know which plugin versions it pulled.
+- **CLI release table** — start here if you know the CLI version a build used and want to know which plugin versions it pulled.
 - **One section per consumer step** — start here if you know the step version pinned in your workflow and want the CLI + plugin versions it resolves to.
+
+## Contents
+
+- [CLI release table](#cli-release-table)
+- [activate-build-cache-for-gradle](#activate-build-cache-for-gradle)
+- [activate-react-native-features](#activate-react-native-features)
+- [activate-gradle-mirrors](#activate-gradle-mirrors)
+- [activate-gradle-features](#activate-gradle-features)
 
 ## Components
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1353,6 +1353,8 @@ step_bundles:
                 set -ex
 
                 bash ./scripts/generate-dependency-matrix.sh
+          envs:
+            - GH_TOKEN: $GIT_BOT_USER_ACCESS_TOKEN
       - script:
           title: Reformat dependency matrix
           inputs:

--- a/scripts/generate-dependency-matrix.sh
+++ b/scripts/generate-dependency-matrix.sh
@@ -127,7 +127,7 @@ cat "$MD_HEADER_PATH" > "$RESULT_MD_PATH"
 
 {
   echo
-  echo "## CLI releases → bundled plugin versions"
+  echo "## CLI release table"
   echo
   echo "| CLI version | Release date | Analytics plugin | Cache plugin | Test Distribution plugin | Common plugin |"
   echo "|-------------|--------------|------------------|--------------|--------------------------|----------------|"

--- a/scripts/generate-dependency-matrix.sh
+++ b/scripts/generate-dependency-matrix.sh
@@ -1,95 +1,200 @@
 #!/bin/bash
 
-set -e
+# Generate docs/dependency-matrix.md by:
+#   1. Reading internal/consts/consts.go at each CLI release tag (no binary download, no
+#      `activate gradle` invocation — so no side effects like the benchmark-phase API call
+#      that previously zeroed out the cache plugin column for every CLI >= v1.1.0).
+#   2. For each consumer step that bundles the CLI, walking the step's git tags and
+#      reading either step.sh (bash toolkit) or go.mod (Go toolkit) to find the pinned
+#      CLI version, then joining back to the per-CLI plugin versions from step 1.
+
+set -eo pipefail
 
 mkdir -p docs
-export RESULT_MD_PATH="docs/dependency-matrix.md"
-export MD_HEADER_PATH="assets/dependency-matrix-header.md"
-export CLI_RELEASE_URL_PREFIX="https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag"
-export CLI_DOWNLOAD_URL_PREFIX="https://github.com/bitrise-io/bitrise-build-cache-cli/releases/download"
+RESULT_MD_PATH="${RESULT_MD_PATH:-docs/dependency-matrix.md}"
+MD_HEADER_PATH="${MD_HEADER_PATH:-assets/dependency-matrix-header.md}"
+CLI_RELEASE_URL_PREFIX="https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag"
 
-export BITRISE_BUILD_CACHE_WORKSPACE_ID=322a005426441b60
-# `activate gradle --test-distribution` requires this; on Bitrise CI it is set automatically.
-export BITRISE_APP_SLUG="${BITRISE_APP_SLUG:-dependency-matrix}"
+CLI_REPO="bitrise-io/bitrise-build-cache-cli"
+CONSTS_PATH="internal/consts/consts.go"
 
-cat $MD_HEADER_PATH > $RESULT_MD_PATH
-export tmpdir=$(mktemp -d)
+# Consumer steps that bundle the CLI. Pipe-delimited: human_name|repo
+# For each step tag we try, in order: step.sh, step/cli.go, go.mod — first match wins.
+# (Different steps pin the CLI in different ways: bash-toolkit steps export
+# BITRISE_BUILD_CACHE_CLI_VERSION in step.sh; the RN step hard-codes cliVersion in
+# step/cli.go; other Go-toolkit steps reference the CLI module from go.mod.)
+STEPS=(
+  "activate-build-cache-for-gradle|bitrise-step-activate-gradle-remote-cache"
+  "activate-react-native-features|bitrise-step-activate-react-native-features"
+  "activate-gradle-mirrors|bitrise-step-activate-gradle-mirrors"
+  "activate-gradle-features|bitrise-step-activate-gradle-features"
+)
 
-pushd $tmpdir
+# Let `gh` pick up whichever GitHub token Bitrise CI happens to expose.
+if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
+  if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+    export GH_TOKEN="$GITHUB_API_TOKEN"
+  fi
+fi
 
-git clone --filter=blob:none --no-checkout https://github.com/bitrise-io/bitrise-build-cache-cli.git
-cd bitrise-build-cache-cli
-git fetch --tags --no-recurse-submodules origin
-cd ..
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
 
-export tmp_md="release-table.md"
-echo "| CLI version | Release date | Analytics plugin version | Cache plugin version | Test Distribution plugin version |" >> $tmp_md
-echo "|-------------|--------------|--------------------------|----------------------|----------------------------------|" >> $tmp_md
+git clone --filter=blob:none --no-checkout "https://github.com/${CLI_REPO}.git" "$tmpdir/cli" >/dev/null
+git -C "$tmpdir/cli" fetch --tags --no-recurse-submodules origin >/dev/null
 
-# List CLI release tags in descending semver order — only stable vMAJOR.MINOR.PATCH (no -rc, -beta etc.).
-cli_versions=$(cd bitrise-build-cache-cli && git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
+extract_const() {
+  local content="$1" name="$2"
+  printf '%s\n' "$content" \
+    | sed -nE "s/.*${name}[[:space:]]*=[[:space:]]*\"([0-9]+\.[0-9]+\.[0-9]+)\".*/\1/p" \
+    | head -1
+}
 
-for cli_version in $cli_versions; do
-  echo "==== Processing CLI $cli_version ===="
+# Decode a file from a step repo at a given ref. Prints empty on any failure.
+fetch_step_file() {
+  local repo="$1" path="$2" ref="$3"
+  local b64
+  b64=$(gh api "repos/bitrise-steplib/${repo}/contents/${path}?ref=${ref}" --jq '.content' 2>/dev/null || true)
+  if [ -z "$b64" ]; then
+    return 0
+  fi
+  printf '%s' "$b64" | base64 -d 2>/dev/null || true
+}
 
-  semver_regex='^v([0-9]+)\.([0-9]+)\.([0-9]+)$'
-  if [[ ! $cli_version =~ $semver_regex ]]; then
-    echo "Skipping non-semver tag $cli_version"
+# Find the CLI version a step tag pins by probing the three known patterns in
+# order. Prints "vX.Y.Z" on first match, empty if the tag doesn't reference the CLI.
+find_cli_version_for_step_tag() {
+  local repo="$1" ref="$2"
+  local content cli
+
+  content=$(fetch_step_file "$repo" "step.sh" "$ref")
+  cli=$(printf '%s\n' "$content" \
+    | sed -nE 's/.*BITRISE_BUILD_CACHE_CLI_VERSION="(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' \
+    | head -1)
+  if [ -n "$cli" ]; then printf '%s' "$cli"; return 0; fi
+
+  content=$(fetch_step_file "$repo" "step/cli.go" "$ref")
+  cli=$(printf '%s\n' "$content" \
+    | sed -nE 's/.*cliVersion[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/v\1/p' \
+    | head -1)
+  if [ -n "$cli" ]; then printf '%s' "$cli"; return 0; fi
+
+  content=$(fetch_step_file "$repo" "go.mod" "$ref")
+  # Match only released versions; the trailing `[^-]` rules out Go module
+  # pseudo-versions like v1.5.6-0.20260407... which point at a commit, not a tag.
+  cli=$(printf '%s\n' "$content" \
+    | sed -nE 's#.*github\.com/bitrise-io/bitrise-build-cache-cli(/v[0-9]+)?[[:space:]]+v([0-9]+\.[0-9]+\.[0-9]+)([[:space:]]|$).*#v\2#p' \
+    | head -1)
+  if [ -n "$cli" ]; then printf '%s' "$cli"; return 0; fi
+}
+
+# Build CLI table data: TSV with columns tag\tdate\tanalytics\tcache\ttestdistro\tcommon
+cli_data="$tmpdir/cli_data.tsv"
+: > "$cli_data"
+
+cli_tags=$(git -C "$tmpdir/cli" tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
+cli_count=0
+for tag in $cli_tags; do
+  consts=$(git -C "$tmpdir/cli" show "${tag}:${CONSTS_PATH}" 2>/dev/null || true)
+  if [ -z "$consts" ]; then
+    echo "Skipping $tag (no $CONSTS_PATH at that tag)"
     continue
   fi
-  major="${BASH_REMATCH[1]}"
-  minor="${BASH_REMATCH[2]}"
-  patch="${BASH_REMATCH[3]}"
 
-  version_no_v="${cli_version#v}"
-  download_url="$CLI_DOWNLOAD_URL_PREFIX/$cli_version/bitrise-build-cache_${version_no_v}_linux_amd64.tar.gz"
+  release_date=$(git -C "$tmpdir/cli" log -1 --format=%as "$tag")
+  analytics=$(extract_const "$consts" GradleAnalyticsPluginDepVersion)
+  cache=$(extract_const "$consts" GradleRemoteBuildCachePluginDepVersion)
+  testdistro=$(extract_const "$consts" GradleTestDistributionPluginDepVersion)
+  common=$(extract_const "$consts" GradleCommonPluginDepVersion)
 
-  cli_dir=$(mktemp -d)
-  if ! curl --retry 3 -sSfL -o "$cli_dir/cli.tar.gz" "$download_url"; then
-    echo "Could not download $download_url — skipping"
-    rm -rf "$cli_dir"
-    continue
-  fi
-  tar -xzf "$cli_dir/cli.tar.gz" -C "$cli_dir"
-  cli_bin="$cli_dir/bitrise-build-cache"
-  if [ ! -x "$cli_bin" ]; then
-    echo "Binary missing in $cli_dir — skipping"
-    rm -rf "$cli_dir"
-    continue
-  fi
-
-  # Reset gradle init dir so we only see this version's output.
-  rm -f "$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts"
-
-  # Match the historical command-name change: `activate gradle` exists from v0.16.10 onwards.
-  if (( major > 0 )) || (( major == 0 && minor > 16 )) || (( major == 0 && minor == 16 && patch >= 10 )); then
-    "$cli_bin" activate gradle --cache --test-distribution -d || true
-  else
-    "$cli_bin" enable-for gradle || true
-  fi
-
-  init_script="$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts"
-  if [ ! -f "$init_script" ]; then
-    echo "Init script not generated for $cli_version — skipping"
-    rm -rf "$cli_dir"
-    continue
-  fi
-
-  analytics_version=$(grep 'classpath("io.bitrise.gradle:gradle-analytics:' "$init_script" | sed -n -E 's/.*gradle-analytics:([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
-  cache_version=$(grep 'classpath("io.bitrise.gradle:remote-cache:' "$init_script" | sed -n -E 's/.*remote-cache:([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
-  test_distro_version=$(grep 'classpath("io.bitrise.gradle:test-distribution:' "$init_script" | sed -n -E 's/.*test-distribution:([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
-
-  release_date=$(cd bitrise-build-cache-cli && git log -1 --format=%as "$cli_version")
-
-  echo "$cli_version → analytics=$analytics_version cache=$cache_version test-distro=$test_distro_version (released $release_date)"
-
-  echo "| [$cli_version]($CLI_RELEASE_URL_PREFIX/$cli_version) | $release_date | ${analytics_version:--} | ${cache_version:--} | ${test_distro_version:--} |" >> $tmp_md
-
-  rm -rf "$cli_dir"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$tag" "$release_date" \
+    "${analytics:--}" "${cache:--}" "${testdistro:--}" "${common:--}" >> "$cli_data"
+  cli_count=$((cli_count + 1))
 done
 
-popd
-cat $MD_HEADER_PATH > $RESULT_MD_PATH
-cat $tmpdir/$tmp_md >> $RESULT_MD_PATH
+echo "Processed $cli_count CLI tags"
+if [ "$cli_count" -eq 0 ]; then
+  echo "Zero CLI tags processed — refusing to write an empty matrix"
+  exit 1
+fi
 
-echo "Release table generated in $RESULT_MD_PATH"
+lookup_cli_row() {
+  awk -F'\t' -v t="$1" '$1==t {print; exit}' "$cli_data"
+}
+
+cat "$MD_HEADER_PATH" > "$RESULT_MD_PATH"
+
+{
+  echo
+  echo "## CLI releases → bundled plugin versions"
+  echo
+  echo "| CLI version | Release date | Analytics plugin | Cache plugin | Test Distribution plugin | Common plugin |"
+  echo "|-------------|--------------|------------------|--------------|--------------------------|----------------|"
+  while IFS=$'\t' read -r tag release_date analytics cache testdistro common; do
+    echo "| [$tag]($CLI_RELEASE_URL_PREFIX/$tag) | $release_date | $analytics | $cache | $testdistro | $common |"
+  done < "$cli_data"
+} >> "$RESULT_MD_PATH"
+
+for entry in "${STEPS[@]}"; do
+  IFS='|' read -r step_name step_repo <<< "$entry"
+
+  echo "Processing step $step_name ($step_repo) ..."
+
+  step_tags=$(gh api "repos/bitrise-steplib/${step_repo}/git/refs/tags" --paginate --jq '.[].ref' 2>/dev/null \
+    | sed 's#^refs/tags/##' \
+    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sort -V -r || true)
+
+  {
+    echo
+    echo "## $step_name"
+    echo
+  } >> "$RESULT_MD_PATH"
+
+  if [ -z "$step_tags" ]; then
+    echo "  no stable semver tags"
+    echo "No tagged versions yet." >> "$RESULT_MD_PATH"
+    continue
+  fi
+
+  step_rows="$tmpdir/${step_name}.tsv"
+  : > "$step_rows"
+  total=0
+  matched=0
+  for stag in $step_tags; do
+    total=$((total + 1))
+    cli=$(find_cli_version_for_step_tag "$step_repo" "$stag")
+    if [ -z "$cli" ]; then
+      continue
+    fi
+
+    row=$(lookup_cli_row "$cli")
+    if [ -z "$row" ]; then
+      printf '%s\t%s\t%s\t%s\t%s\n' "$stag" "$cli" "-" "-" "-" >> "$step_rows"
+    else
+      analytics=$(printf '%s' "$row" | cut -f3)
+      cache=$(printf '%s' "$row" | cut -f4)
+      testdistro=$(printf '%s' "$row" | cut -f5)
+      printf '%s\t%s\t%s\t%s\t%s\n' "$stag" "$cli" "$analytics" "$cache" "$testdistro" >> "$step_rows"
+    fi
+    matched=$((matched + 1))
+  done
+
+  echo "  $step_name: $total tags, $matched with CLI ref"
+
+  if [ "$matched" -eq 0 ]; then
+    echo "No step versions reference the Bitrise Build Cache CLI." >> "$RESULT_MD_PATH"
+    continue
+  fi
+
+  {
+    echo "| Step version | CLI version | Analytics plugin | Cache plugin | Test Distribution plugin |"
+    echo "|--------------|-------------|------------------|--------------|--------------------------|"
+    while IFS=$'\t' read -r stag cli analytics cache testdistro; do
+      echo "| $stag | [$cli]($CLI_RELEASE_URL_PREFIX/$cli) | $analytics | $cache | $testdistro |"
+    done < "$step_rows"
+  } >> "$RESULT_MD_PATH"
+done
+
+echo "Generated $RESULT_MD_PATH"

--- a/scripts/generate-dependency-matrix.sh
+++ b/scripts/generate-dependency-matrix.sh
@@ -38,9 +38,19 @@ STEPS=(
 
 # Let `gh` pick up whichever GitHub token Bitrise CI happens to expose.
 if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
-  if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+  if [ -n "${GIT_BOT_USER_ACCESS_TOKEN:-}" ]; then
+    export GH_TOKEN="$GIT_BOT_USER_ACCESS_TOKEN"
+  elif [ -n "${GITHUB_API_TOKEN:-}" ]; then
     export GH_TOKEN="$GITHUB_API_TOKEN"
   fi
+fi
+
+# Fail fast on missing auth — we make ~600 GitHub API calls per run, which would
+# blow past the 60/hour unauthenticated limit and silently produce a matrix with
+# empty per-step tables (the failure mode that motivated this check).
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh is not authenticated. Set GH_TOKEN (or GIT_BOT_USER_ACCESS_TOKEN)." >&2
+  exit 1
 fi
 
 tmpdir=$(mktemp -d)
@@ -153,6 +163,7 @@ cat "$MD_HEADER_PATH" > "$RESULT_MD_PATH"
   done < "$cli_data"
 } >> "$RESULT_MD_PATH"
 
+total_step_rows=0
 for step_id in "${STEPS[@]}"; do
   echo "Processing step $step_id ..."
 
@@ -212,6 +223,7 @@ for step_id in "${STEPS[@]}"; do
   done
 
   echo "  $step_id: $total versions, $matched with CLI ref"
+  total_step_rows=$((total_step_rows + matched))
 
   if [ "$matched" -eq 0 ]; then
     echo "No published versions reference the Bitrise Build Cache CLI." >> "$RESULT_MD_PATH"
@@ -226,5 +238,10 @@ for step_id in "${STEPS[@]}"; do
     done < "$step_rows"
   } >> "$RESULT_MD_PATH"
 done
+
+if [ "$total_step_rows" -eq 0 ]; then
+  echo "ERROR: no step versions matched a CLI — every per-step table is empty." >&2
+  exit 1
+fi
 
 echo "Generated $RESULT_MD_PATH"

--- a/scripts/generate-dependency-matrix.sh
+++ b/scripts/generate-dependency-matrix.sh
@@ -4,9 +4,11 @@
 #   1. Reading internal/consts/consts.go at each CLI release tag (no binary download, no
 #      `activate gradle` invocation — so no side effects like the benchmark-phase API call
 #      that previously zeroed out the cache plugin column for every CLI >= v1.1.0).
-#   2. For each consumer step that bundles the CLI, walking the step's git tags and
-#      reading either step.sh (bash toolkit) or go.mod (Go toolkit) to find the pinned
-#      CLI version, then joining back to the per-CLI plugin versions from step 1.
+#   2. For each consumer step that bundles the CLI, listing released versions from the
+#      bitrise-steplib registry, resolving each version's source commit, and reading
+#      either step.sh (bash toolkit) or step/cli.go / go.mod (Go toolkit) at that
+#      commit to find the pinned CLI version. Joins back to the per-CLI plugin
+#      versions from step 1.
 
 set -eo pipefail
 
@@ -17,17 +19,21 @@ CLI_RELEASE_URL_PREFIX="https://github.com/bitrise-io/bitrise-build-cache-cli/re
 
 CLI_REPO="bitrise-io/bitrise-build-cache-cli"
 CONSTS_PATH="internal/consts/consts.go"
+STEPLIB_REPO="bitrise-io/bitrise-steplib"
 
-# Consumer steps that bundle the CLI. Pipe-delimited: human_name|repo
-# For each step tag we try, in order: step.sh, step/cli.go, go.mod — first match wins.
-# (Different steps pin the CLI in different ways: bash-toolkit steps export
-# BITRISE_BUILD_CACHE_CLI_VERSION in step.sh; the RN step hard-codes cliVersion in
-# step/cli.go; other Go-toolkit steps reference the CLI module from go.mod.)
+# Consumer steps that bundle the CLI, identified by their steplib step ID (the same
+# id customers reference in their bitrise.yml). Each version we list comes from
+# bitrise-steplib's steps/<id>/<version>/step.yml — that file pins both the source
+# repo URL and the exact source commit, which we then probe for the CLI ref.
+#
+# For each source commit we try, in order: step.sh, step/cli.go, go.mod — first match
+# wins. (Bash-toolkit steps export BITRISE_BUILD_CACHE_CLI_VERSION in step.sh; the RN
+# step hard-codes cliVersion in step/cli.go; other Go-toolkit steps reference the
+# CLI module from go.mod.)
 STEPS=(
-  "activate-build-cache-for-gradle|bitrise-step-activate-gradle-remote-cache"
-  "activate-react-native-features|bitrise-step-activate-react-native-features"
-  "activate-gradle-mirrors|bitrise-step-activate-gradle-mirrors"
-  "activate-gradle-features|bitrise-step-activate-gradle-features"
+  "activate-build-cache-for-gradle"
+  "activate-build-cache-for-react-native"
+  "activate-gradle-mirrors"
 )
 
 # Let `gh` pick up whichever GitHub token Bitrise CI happens to expose.
@@ -50,42 +56,53 @@ extract_const() {
     | head -1
 }
 
-# Decode a file from a step repo at a given ref. Prints empty on any failure.
-fetch_step_file() {
-  local repo="$1" path="$2" ref="$3"
+# Decode a file from any GitHub repo at a given ref (or the default branch if ref
+# is empty). Prints empty on any failure.
+fetch_file() {
+  local owner_repo="$1" path="$2" ref="${3:-}"
+  local url="repos/${owner_repo}/contents/${path}"
+  if [ -n "$ref" ]; then
+    url="${url}?ref=${ref}"
+  fi
   local b64
-  b64=$(gh api "repos/bitrise-steplib/${repo}/contents/${path}?ref=${ref}" --jq '.content' 2>/dev/null || true)
+  b64=$(gh api "$url" --jq '.content' 2>/dev/null || true)
   if [ -z "$b64" ]; then
     return 0
   fi
   printf '%s' "$b64" | base64 -d 2>/dev/null || true
 }
 
-# Find the CLI version a step tag pins by probing the three known patterns in
-# order. Prints "vX.Y.Z" on first match, empty if the tag doesn't reference the CLI.
-find_cli_version_for_step_tag() {
-  local repo="$1" ref="$2"
+# Find the CLI version a step source commit pins, by probing the three known
+# patterns in order. Prints "vX.Y.Z" on first match, empty if no match.
+find_cli_version_at_commit() {
+  local owner_repo="$1" commit="$2"
   local content cli
 
-  content=$(fetch_step_file "$repo" "step.sh" "$ref")
+  content=$(fetch_file "$owner_repo" "step.sh" "$commit")
   cli=$(printf '%s\n' "$content" \
     | sed -nE 's/.*BITRISE_BUILD_CACHE_CLI_VERSION="(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' \
     | head -1)
   if [ -n "$cli" ]; then printf '%s' "$cli"; return 0; fi
 
-  content=$(fetch_step_file "$repo" "step/cli.go" "$ref")
+  content=$(fetch_file "$owner_repo" "step/cli.go" "$commit")
   cli=$(printf '%s\n' "$content" \
     | sed -nE 's/.*cliVersion[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/v\1/p' \
     | head -1)
   if [ -n "$cli" ]; then printf '%s' "$cli"; return 0; fi
 
-  content=$(fetch_step_file "$repo" "go.mod" "$ref")
-  # Match only released versions; the trailing `[^-]` rules out Go module
-  # pseudo-versions like v1.5.6-0.20260407... which point at a commit, not a tag.
+  content=$(fetch_file "$owner_repo" "go.mod" "$commit")
+  # Match only released versions; the trailing space/EOL check rules out Go
+  # module pseudo-versions like v1.5.6-0.20260407... which point at a commit.
   cli=$(printf '%s\n' "$content" \
     | sed -nE 's#.*github\.com/bitrise-io/bitrise-build-cache-cli(/v[0-9]+)?[[:space:]]+v([0-9]+\.[0-9]+\.[0-9]+)([[:space:]]|$).*#v\2#p' \
     | head -1)
   if [ -n "$cli" ]; then printf '%s' "$cli"; return 0; fi
+}
+
+# Extract owner/repo from a github URL: trims https:// and any .git suffix.
+github_owner_repo_from_url() {
+  printf '%s' "$1" \
+    | sed -E 's#^https?://github\.com/##; s#\.git$##; s#/$##'
 }
 
 # Build CLI table data: TSV with columns tag\tdate\tanalytics\tcache\ttestdistro\tcommon
@@ -136,63 +153,76 @@ cat "$MD_HEADER_PATH" > "$RESULT_MD_PATH"
   done < "$cli_data"
 } >> "$RESULT_MD_PATH"
 
-for entry in "${STEPS[@]}"; do
-  IFS='|' read -r step_name step_repo <<< "$entry"
+for step_id in "${STEPS[@]}"; do
+  echo "Processing step $step_id ..."
 
-  echo "Processing step $step_name ($step_repo) ..."
-
-  step_tags=$(gh api "repos/bitrise-steplib/${step_repo}/git/refs/tags" --paginate --jq '.[].ref' 2>/dev/null \
-    | sed 's#^refs/tags/##' \
+  # Versions published to steplib are directory names under steps/<id>/. Filter to
+  # stable X.Y.Z dirs and sort descending so the newest row sits on top.
+  step_versions=$(gh api --paginate "repos/${STEPLIB_REPO}/contents/steps/${step_id}" --jq '.[].name' 2>/dev/null \
     | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
     | sort -V -r || true)
 
   {
     echo
-    echo "## $step_name"
+    echo "## $step_id"
     echo
   } >> "$RESULT_MD_PATH"
 
-  if [ -z "$step_tags" ]; then
-    echo "  no stable semver tags"
-    echo "No tagged versions yet." >> "$RESULT_MD_PATH"
+  if [ -z "$step_versions" ]; then
+    echo "  no versions in steplib"
+    echo "Not yet published to the Bitrise steplib." >> "$RESULT_MD_PATH"
     continue
   fi
 
-  step_rows="$tmpdir/${step_name}.tsv"
+  step_rows="$tmpdir/${step_id}.tsv"
   : > "$step_rows"
   total=0
   matched=0
-  for stag in $step_tags; do
+  for sv in $step_versions; do
     total=$((total + 1))
-    cli=$(find_cli_version_for_step_tag "$step_repo" "$stag")
+
+    # The steplib's step.yml pins both the source repo and the exact commit
+    # we should read the CLI ref from.
+    step_yml=$(fetch_file "$STEPLIB_REPO" "steps/${step_id}/${sv}/step.yml")
+    if [ -z "$step_yml" ]; then
+      continue
+    fi
+    source_url=$(printf '%s\n' "$step_yml" | sed -nE 's#^[[:space:]]*(source_code_url|website):[[:space:]]*(.+)$#\2#p' | head -1)
+    commit=$(printf '%s\n' "$step_yml" | sed -nE 's#^[[:space:]]*commit:[[:space:]]*(.+)$#\1#p' | head -1)
+    owner_repo=$(github_owner_repo_from_url "$source_url")
+    if [ -z "$owner_repo" ] || [ -z "$commit" ]; then
+      continue
+    fi
+
+    cli=$(find_cli_version_at_commit "$owner_repo" "$commit")
     if [ -z "$cli" ]; then
       continue
     fi
 
     row=$(lookup_cli_row "$cli")
     if [ -z "$row" ]; then
-      printf '%s\t%s\t%s\t%s\t%s\n' "$stag" "$cli" "-" "-" "-" >> "$step_rows"
+      printf '%s\t%s\t%s\t%s\t%s\n' "$sv" "$cli" "-" "-" "-" >> "$step_rows"
     else
       analytics=$(printf '%s' "$row" | cut -f3)
       cache=$(printf '%s' "$row" | cut -f4)
       testdistro=$(printf '%s' "$row" | cut -f5)
-      printf '%s\t%s\t%s\t%s\t%s\n' "$stag" "$cli" "$analytics" "$cache" "$testdistro" >> "$step_rows"
+      printf '%s\t%s\t%s\t%s\t%s\n' "$sv" "$cli" "$analytics" "$cache" "$testdistro" >> "$step_rows"
     fi
     matched=$((matched + 1))
   done
 
-  echo "  $step_name: $total tags, $matched with CLI ref"
+  echo "  $step_id: $total versions, $matched with CLI ref"
 
   if [ "$matched" -eq 0 ]; then
-    echo "No step versions reference the Bitrise Build Cache CLI." >> "$RESULT_MD_PATH"
+    echo "No published versions reference the Bitrise Build Cache CLI." >> "$RESULT_MD_PATH"
     continue
   fi
 
   {
     echo "| Step version | CLI version | Analytics plugin | Cache plugin | Test Distribution plugin |"
     echo "|--------------|-------------|------------------|--------------|--------------------------|"
-    while IFS=$'\t' read -r stag cli analytics cache testdistro; do
-      echo "| $stag | [$cli]($CLI_RELEASE_URL_PREFIX/$cli) | $analytics | $cache | $testdistro |"
+    while IFS=$'\t' read -r sv cli analytics cache testdistro; do
+      echo "| $sv | [$cli]($CLI_RELEASE_URL_PREFIX/$cli) | $analytics | $cache | $testdistro |"
     done < "$step_rows"
   } >> "$RESULT_MD_PATH"
 done


### PR DESCRIPTION
## Summary

[ACI-4937](https://bitrise.atlassian.net/browse/ACI-4937) — fix the [public dependency matrix](https://bitrise-io.github.io/bitrise-build-cache-cli/dependency-matrix) so customers and CSMs can read the right plugin versions and the right step ↔ CLI mapping.

Three problems addressed:

- **Cache plugin column was `–` for every CLI ≥ v1.1.0.** The generator ran `activate gradle --cache` against the `dependency-matrix` workflow's app slug; that workflow returns benchmark phase `baseline`, which sets `Cache.Enabled=false`, drops the `classpath("io.bitrise.gradle:remote-cache:...")` line from the init script, and made the script's grep return nothing. Switch to reading `internal/consts/consts.go` at each release tag (`git show <tag>:internal/consts/consts.go`) — no binary download, no API call, no env side-effects. Cache column now reflects the real pin (e.g. v2.7.1 → `1.3.3`, v2.0.0 → `1.3.1`).
- **Header listed steps that don't bundle the CLI for cache activation.** Drop `gradle-runner` and `install-missing-android-tools` from the consumer-step list. Only the four "activate" steps actually pin a CLI release: `activate-build-cache-for-gradle`, `activate-react-native-features`, `activate-gradle-mirrors`, `activate-gradle-features` (experimental).
- **No step-version → CLI mapping.** Add one inverted table per consumer step. For each step tag, the script probes three known patterns in order — `step.sh` (`BITRISE_BUILD_CACHE_CLI_VERSION=`), `step/cli.go` (RN, `cliVersion =`), `go.mod` (other Go-toolkit steps) — and joins back to the plugin versions from the CLI table.

Side benefit: matrix generation goes from "download + run a tarball per CLI tag" to "git show per CLI tag", which is ~50× faster and removes every external dependency except the GitHub API.

Local regeneration on this branch shows: 183 CLI tags processed; 121/126 `activate-build-cache-for-gradle` step tags mapped; 21/22 RN tags mapped (the 22nd points at a pseudo-version commit and is correctly skipped); 7/7 mirror tags mapped; `activate-gradle-features` placeholder (no tags yet).

## Test plan

- [ ] Trigger the `generate_and_commit_dependency_matrix` workflow on this branch from Bitrise CI
- [ ] Confirm the script completes without the binary download / `activate gradle` step
- [ ] Confirm pandoc reformat succeeds
- [ ] Inspect the diff against `gh-pages` before merging — Cache plugin column should be populated for v1.1.0+
- [ ] Spot-check a few step-version rows resolve to the right CLI tag and plugin versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4937]: https://bitrise.atlassian.net/browse/ACI-4937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ