### PR TITLE
ACI-4998 - Use canonical un-suffixed repository-manager hostname in mirror URLs

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1066,7 +1066,7 @@ workflows:
         - content: |-
             set -exo pipefail
 
-            MIRROR_URL="repository-manager-[a-z]*\.services\.bitrise\.io:8090/maven/central"
+            MIRROR_URL="repository-manager(-[a-z]+)?\.services\.bitrise\.io:8090/maven/central"
             MATCH_COUNT=$(grep -cE "$MIRROR_URL" "$BITRISE_DEPLOY_DIR/logs.txt" || true)
 
             echo "Found $MATCH_COUNT log lines referencing the MavenCentral mirror"
@@ -1084,7 +1084,7 @@ workflows:
         - content: |-
             set -exo pipefail
 
-            MIRROR_URL="repository-manager-[a-z]*\.services\.bitrise\.io:8090/maven/google"
+            MIRROR_URL="repository-manager(-[a-z]+)?\.services\.bitrise\.io:8090/maven/google"
             MATCH_COUNT=$(grep -cE "$MIRROR_URL" "$BITRISE_DEPLOY_DIR/logs.txt" || true)
 
             echo "Found $MATCH_COUNT log lines referencing the Google mirror"

--- a/internal/config/gradle/mirror_url.go
+++ b/internal/config/gradle/mirror_url.go
@@ -12,7 +12,7 @@ const (
 	// MirrorDatacenterEnvKey identifies the datacenter, used to build the mirror region slug.
 	MirrorDatacenterEnvKey = "BITRISE_DEN_VM_DATACENTER"
 
-	mirrorURLPattern           = "https://repository-manager-%s.services.bitrise.io:8090/maven/%s"
+	mirrorURLPattern           = "https://repository-manager.services.bitrise.io:8090/maven/%s"
 	mirrorSegmentGradlePlugins = "gradle-plugins"
 )
 
@@ -36,5 +36,5 @@ func GradlePluginsMirrorURL(envs map[string]string) string {
 		return ""
 	}
 
-	return fmt.Sprintf(mirrorURLPattern, region, mirrorSegmentGradlePlugins)
+	return fmt.Sprintf(mirrorURLPattern, mirrorSegmentGradlePlugins)
 }

--- a/internal/config/gradle/mirror_url_test.go
+++ b/internal/config/gradle/mirror_url_test.go
@@ -21,11 +21,11 @@ func TestGradlePluginsMirrorURL(t *testing.T) {
 		},
 		"AMS1": {
 			envs: map[string]string{MirrorEnabledEnvKey: "true", MirrorDatacenterEnvKey: "AMS1"},
-			want: "https://repository-manager-ams.services.bitrise.io:8090/maven/gradle-plugins",
+			want: "https://repository-manager.services.bitrise.io:8090/maven/gradle-plugins",
 		},
 		"IAD1": {
 			envs: map[string]string{MirrorEnabledEnvKey: "true", MirrorDatacenterEnvKey: "IAD1"},
-			want: "https://repository-manager-iad.services.bitrise.io:8090/maven/gradle-plugins",
+			want: "https://repository-manager.services.bitrise.io:8090/maven/gradle-plugins",
 		},
 		"unsupported ATL1": {
 			envs: map[string]string{MirrorEnabledEnvKey: "true", MirrorDatacenterEnvKey: "ATL1"},

--- a/internal/config/gradle/mirrors/activate.go
+++ b/internal/config/gradle/mirrors/activate.go
@@ -82,7 +82,7 @@ func Activate(logger log.Logger, osProxy utils.OsProxy, params Params) error {
 
 	entries := make([]templateEntry, 0, len(params.Mirrors))
 	for _, m := range params.Mirrors {
-		url := fmt.Sprintf(URLPattern, region, m.URLSegment)
+		url := fmt.Sprintf(URLPattern, m.URLSegment)
 		entries = append(entries, templateEntry{
 			ID:                      m.TemplateID,
 			GradleMatch:             m.GradleMatch,

--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -63,9 +63,9 @@ func TestActivate(t *testing.T) {
 			params:        mirrors.Params{Enabled: true, Datacenter: "AMS1", Mirrors: allMirrors},
 			expectCreated: true,
 			expectContains: []string{
-				"https://repository-manager-ams.services.bitrise.io:8090/maven/central",
-				"https://repository-manager-ams.services.bitrise.io:8090/maven/google",
-				"https://repository-manager-ams.services.bitrise.io:8090/maven/gradle-plugins",
+				"https://repository-manager.services.bitrise.io:8090/maven/central",
+				"https://repository-manager.services.bitrise.io:8090/maven/google",
+				"https://repository-manager.services.bitrise.io:8090/maven/gradle-plugins",
 				`r.getUrl().toString().trimEnd('/').equals("https://plugins.gradle.org/m2")`,
 				`"[Bitrise Gradle Mirrors] [$ts] $message"`,
 				`if (System.getenv("BITRISE_MAVENCENTRAL_PROXY_ENABLED") == "false") {`,
@@ -78,14 +78,14 @@ func TestActivate(t *testing.T) {
                 log("afterProject(${getPath()}) fired,`,
 				`if (getProject().getParent() == null) {
                     log("setting robolectric.dependency.repo.url=`,
-				`log("prepending pluginManagement mirror https://repository-manager-ams.services.bitrise.io:8090/maven/apache-central")`,
-				`log("prepending pluginManagement mirror https://repository-manager-ams.services.bitrise.io:8090/maven/gradle-plugins")`,
+				`log("prepending pluginManagement mirror https://repository-manager.services.bitrise.io:8090/maven/apache-central")`,
+				`log("prepending pluginManagement mirror https://repository-manager.services.bitrise.io:8090/maven/gradle-plugins")`,
 				`val loggedReplacements = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()`,
 				`if (loggedReplacements.add("${getName()}|${getUrl()}|$mirrorUrl"))`,
-				`log("setting robolectric.dependency.repo.url=\"https://repository-manager-ams.services.bitrise.io:8090/maven/central\" on ${getPath()}")`,
+				`log("setting robolectric.dependency.repo.url=\"https://repository-manager.services.bitrise.io:8090/maven/central\" on ${getPath()}")`,
 			},
 			expectNotContain: []string{
-				"https://repository-manager-ams.services.bitrise.io:8090/maven/jitpack",
+				"https://repository-manager.services.bitrise.io:8090/maven/jitpack",
 				`"https://jitpack.io"`,
 				"mirrorBaseUrl",
 				"java.time.Instant.now()",
@@ -96,11 +96,11 @@ func TestActivate(t *testing.T) {
 			params:        mirrors.Params{Enabled: true, Datacenter: "IAD1", Mirrors: centralOnly},
 			expectCreated: true,
 			expectContains: []string{
-				"https://repository-manager-iad.services.bitrise.io:8090/maven/central",
+				"https://repository-manager.services.bitrise.io:8090/maven/central",
 				`"[Bitrise Gradle Mirrors] [$ts] $message"`,
 			},
 			expectNotContain: []string{
-				"https://repository-manager-iad.services.bitrise.io:8090/maven/google",
+				"https://repository-manager.services.bitrise.io:8090/maven/google",
 				"mirrorBaseUrl",
 			},
 		},
@@ -109,11 +109,11 @@ func TestActivate(t *testing.T) {
 			params:        mirrors.Params{Enabled: true, Datacenter: "ORD1", Mirrors: googleOnly},
 			expectCreated: true,
 			expectContains: []string{
-				"https://repository-manager-ord.services.bitrise.io:8090/maven/google",
+				"https://repository-manager.services.bitrise.io:8090/maven/google",
 				`"[Bitrise Gradle Mirrors] [$ts] $message"`,
 			},
 			expectNotContain: []string{
-				"https://repository-manager-ord.services.bitrise.io:8090/maven/central",
+				"https://repository-manager.services.bitrise.io:8090/maven/central",
 				"mirrorBaseUrl",
 				// google is not flagged ApplyToPluginManagement, so no PM mirror prepend log
 				"prepending pluginManagement mirror",
@@ -201,7 +201,7 @@ func TestActivate_ExportsMirrorURLs(t *testing.T) {
 
 	for _, m := range mirrors.KnownMirrors {
 		key := mirrors.MirrorURLEnvKeyPrefix + m.TemplateID
-		want := "https://repository-manager-ams.services.bitrise.io:8090/maven/" + m.URLSegment
+		want := "https://repository-manager.services.bitrise.io:8090/maven/" + m.URLSegment
 		assert.Equal(t, want, exp.exported[key], "exported value for %s", key)
 	}
 }

--- a/internal/config/gradle/mirrors/mirror.go
+++ b/internal/config/gradle/mirrors/mirror.go
@@ -39,8 +39,10 @@ func InitTemplate() string {
 // InitFileName is the filename written under ~/.gradle/init.d.
 const InitFileName = "bitrise-gradle-mirrors.init.gradle.kts"
 
-// URLPattern is the format string for mirror URLs: region + URL segment.
-const URLPattern = "https://repository-manager-%s.services.bitrise.io:8090/maven/%s"
+// URLPattern is the format string for mirror URLs: URL segment.
+// The canonical un-suffixed hostname is redirected to DC-internal proxy IPs
+// via /etc/hosts entries written by the preboot reconciler (see ACI-4611).
+const URLPattern = "https://repository-manager.services.bitrise.io:8090/maven/%s"
 
 // FilterByFlagNames returns the subset of KnownMirrors whose FlagName matches
 // any of names. If names is empty, KnownMirrors is returned unchanged. Order

--- a/pkg/gradle/mirrors/activator_test.go
+++ b/pkg/gradle/mirrors/activator_test.go
@@ -40,7 +40,7 @@ func TestActivator_Activate_ExplicitParamsWin(t *testing.T) {
 	content, err := os.ReadFile(initFile)
 	require.NoError(t, err)
 
-	assert.Contains(t, string(content), "https://repository-manager-ams.services.bitrise.io:8090/maven/central")
+	assert.Contains(t, string(content), "https://repository-manager.services.bitrise.io:8090/maven/central")
 	assert.NotContains(t, string(content), "zzz")
 }
 
@@ -62,8 +62,8 @@ func TestActivator_Activate_FallsBackToEnv(t *testing.T) {
 	content, err := os.ReadFile(initFile)
 	require.NoError(t, err)
 
-	assert.Contains(t, string(content), "https://repository-manager-iad.services.bitrise.io:8090/maven/central")
-	assert.Contains(t, string(content), "https://repository-manager-iad.services.bitrise.io:8090/maven/google")
+	assert.Contains(t, string(content), "https://repository-manager.services.bitrise.io:8090/maven/central")
+	assert.Contains(t, string(content), "https://repository-manager.services.bitrise.io:8090/maven/google")
 }
 
 func TestActivator_Activate_DisabledNoOp(t *testing.T) {


### PR DESCRIPTION
## Summary

[ACI-4998](https://bitrise.atlassian.net/browse/ACI-4998). Drop the per-DC region (`-ams`/`-iad`/`-ord`) from the mirror URL pattern so the CLI emits the canonical `repository-manager.services.bitrise.io` hostname. Build VMs resolve it to the local DC's proxy IPs via the `/etc/hosts` entries written by the preboot reconciler.

The DC-supported-region gate (`AMS1`/`IAD1`/`ORD1`) is kept as-is: activation still only runs in DCs where the hosts override is set up.

Also widens the E2E `MIRROR_URL` regex in `bitrise.yml` to match either the old suffixed form or the new canonical form, so older fleet snapshots remain matchable during rollout.

## Related deployments

- Preboot `/etc/hosts` override (ACI-4611): [build-prebooting-deployments#1548](https://github.com/bitrise-io/build-prebooting-deployments/pull/1548) (production, **merged**) and [#1549](https://github.com/bitrise-io/build-prebooting-deployments/pull/1549) (staging, **merged**).
- TLS cert: already covered by the existing `*.services.bitrise.io` wildcard issued via `repository-manager-deployments/repository-manager-central/templates/certificate.yaml`. No cert change required.

## Test plan

- [x] `make test-unit` — green
- [x] `make lint` — 0 issues
- [x] Alpha release `v2.7.4-alpha.1` cut from this branch — binaries on GH release + GAR + R2.
- [x] Release pipeline succeeded end-to-end after preboot rollout (build #7483).
- [ ] **End-to-end "can fetch artifacts via the new URL"** — needs a build on a fresh post-#1548 VM template; the release-pipeline second gradle run is cache-hit only and doesn't actually exercise the network path. Sanity check kicked off via staging-DEN test-cli builds on the DuckDuckGo E2E app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4998]: https://bitrise.atlassian.net/browse/ACI-4998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ