### PR TITLE
fix: ACI-5007 drop gh pr checks watch from prebooting bump script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,9 @@ Idempotency follows the same describe-or-upload rule (`aws s3api head-object` sk
 
 The `bump-prebooting` workflow (chained after `verify-release` in the `release-and-verify` pipeline) opens an auto-merging PR against `bitrise-io/build-prebooting-deployments`, bumping `BITRISE_BUILD_CACHE_CLI_VERSION` and the per-arch sha256 in both startup-script extensions (`preboot-reconciler/startup_script_extension_{linux,macos}_bitvirt.sh`). Only `linux_amd64` and `darwin_arm64` are bumped — those are the only preboot VM architectures.
 
-Script: `scripts/prebooting_pr_bump.sh`. After pushing the branch, the script waits on `gh pr checks --watch --fail-fast` until the deployments repo's `_unit-test` workflow turns green, then explicitly merges the PR with `gh pr merge --squash --delete-branch`. The Bitrise Infrabot is a bypass actor on the `production` rule, so the explicit merge clears required-review gates at merge time. GitHub's `--auto` merge mode is intentionally NOT used — auto-merge is a background process that does not honour bypass actors and would block on any required reviewer.
+Script: `scripts/prebooting_pr_bump.sh`. After pushing the branch, the script explicitly merges the PR with `gh pr merge --squash --delete-branch`. The Bitrise Infrabot is a bypass actor on the `production` rule, so the explicit merge clears required-review gates at merge time. GitHub's `--auto` merge mode is intentionally NOT used — auto-merge is a background process that does not honour bypass actors and would block on any required reviewer.
+
+The deployments repo has **no CI on PRs** (no GitHub Actions workflows; the Bitrise GitHub app's check-suites stay `queued` forever with zero check-runs). Any `gh pr checks --watch` would either block on phantom queued suites or exit non-zero on "no checks reported", so the script does not wait for CI. Bypass-merge is the only gate.
 
 After sed-bumping the constants, the script asserts the working tree shows **exactly** `+2/-2` per startup script and no other files modified — defensive check against a loose regex matching unintended lines.
 

--- a/scripts/prebooting_pr_bump.sh
+++ b/scripts/prebooting_pr_bump.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # Open a PR against bitrise-io/build-prebooting-deployments to bump the
 # bitrise-build-cache CLI version + sha256 in the preboot startup-script
-# extensions (linux_amd64 + darwin_arm64). Watches the PR's CI checks,
-# then explicitly merges as the Bitrise Infrabot. The bot is a bypass
-# actor on `production` so the explicit merge clears required-review
-# rules (ACI-5007). GitHub's `--auto` merge mode is intentionally NOT
-# used — it doesn't honour bypass actors and would block on any
-# required reviewer.
+# extensions (linux_amd64 + darwin_arm64), then explicitly merges as
+# the Bitrise Infrabot. The bot is a bypass actor on `production` so
+# the explicit merge clears required-review rules (ACI-5007).
+# GitHub's `--auto` merge mode is intentionally NOT used — it doesn't
+# honour bypass actors and would block on any required reviewer.
+#
+# Note: the deployments repo has NO CI on PRs (no GitHub Actions
+# workflows, no Bitrise commit-status hook). Check-suites stay
+# `queued` forever with zero check-runs, so any `gh pr checks --watch`
+# would block on phantom CI. We rely purely on the bot's bypass
+# perms — there is no other gate.
 #
 # Run AFTER verify-release so we never ship a bump pointing at a broken
 # release.
@@ -142,15 +147,15 @@ gh pr create \
   --title "chore: bump bitrise-build-cache CLI to ${tag_v}" \
   --body "$pr_body"
 
-# Block until the prebooting repo's CI finishes. Exits non-zero on any
-# failed check, which fails this Bitrise step (Slack-alerted, retry-safe).
-echo "Watching prebooting CI checks on ${BRANCH}..."
-gh pr checks "$BRANCH" --repo "$REPO" --watch --fail-fast
-
 # Explicit merge by the bot. Because the bot is a bypass actor on
 # `production`, this clears required-review rules at merge time.
 # `--auto` is deliberately avoided: auto-merge runs as a background
 # process that does NOT apply bypass.
+#
+# No `gh pr checks --watch` here: the deployments repo has no CI on
+# PRs, so any wait would either hang on phantom queued check-suites
+# or exit non-zero on "no checks reported". Bypass-merge is the only
+# gate.
 gh pr merge "$BRANCH" --repo "$REPO" --squash --delete-branch
 
 popd >/dev/null


### PR DESCRIPTION
## Summary

`bump-prebooting` workflow for v2.8.3 errored on `gh pr checks "$BRANCH" --watch --fail-fast` with `no checks reported on the 'chore/bump-bitrise-build-cache-cli-2.8.3' branch`. Verified the deployments repo (`bitrise-io/build-prebooting-deployments`) has no CI on PRs at all:

- `gh api repos/bitrise-io/build-prebooting-deployments/actions/workflows` → `total_count: 0`.
- Bitrise GitHub app's check-suites on PR head stay `status: queued`, `latest_check_runs_count: 0` forever.
- Past merged PR #1555 (most recent before ours) also had zero check-runs and zero commit statuses — confirms steady state, not transient.

`gh pr checks --watch` therefore either hangs on the phantom queued suites or exits non-zero immediately on "no checks reported". CLAUDE.md's reference to a `_unit-test` workflow was stale.

Drop the wait. Bot's bypass on `production` branch rule is the only gate this flow ever had.

## Test plan
- [ ] Merge.
- [ ] Re-trigger `bump-prebooting` workflow on v2.8.3 — script should open a fresh PR against deployments, then bypass-merge it via Infrabot PAT.
- [ ] Confirm bump commit lands on `production` in deployments repo.
- [ ] Validate next CLI release runs `bump-prebooting` end-to-end without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)