### PR TITLE
tmp: point base URL to app-staging.bitrise.io for staging testing

### DIFF
--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -43,7 +43,7 @@ const (
 	MsgArgsPassedToXcodebuild   = "Arguments passed to xcodebuild: %v"
 	MsgInvocationSuccess        = "Invocation succeeded ✅ after %s"
 	MsgInvocationFailed         = "Invocation failed ❌ after %s: %s"
-	MsgInvocationSaved          = "Invocation saved. Visit 👉 https://app.bitrise.io/build-cache/invocations/xcode/%s"
+	MsgInvocationSaved          = "Invocation saved. Visit 👉 https://app-staging.bitrise.io/build-cache/invocations/xcode/%s"
 
 	ErrExecutingXcode = "Error executing xcodebuild: %v"
 	ErrReadConfig     = "Error reading config: %v"

--- a/docs/dependency-matrix.md
+++ b/docs/dependency-matrix.md
@@ -1,0 +1,392 @@
+# Bitrise Build Cache CLI — Dependency Matrix
+
+This page lists every released version of the [Bitrise Build Cache CLI](https://github.com/bitrise-io/bitrise-build-cache-cli) and the corresponding plugin versions it pins for Gradle builds (Analytics, Remote Cache, Test Distribution, Common).
+
+## Where the CLI runs
+
+The CLI is downloaded and invoked by the Bitrise steps below. Pinning any of these steps to a specific patch version effectively pins the CLI version (and therefore the plugin versions) used in your build:
+
+- [Activate Bitrise Build Cache for Gradle](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache) — `activate-build-cache-for-gradle`
+- [Bitrise Build Cache for React Native](https://github.com/bitrise-steplib/bitrise-step-activate-react-native-features) — `activate-build-cache-for-react-native`
+- [Activate Bitrise-hosted Gradle repository mirrors](https://github.com/bitrise-steplib/bitrise-step-activate-gradle-mirrors) — `activate-gradle-mirrors`
+
+Different consumer steps may bundle different CLI versions, so the plugin versions in your build depend on which step actually runs first in your workflow. To find the CLI version a build used, look at the activating step's log — it prints the CLI version near the top of its section. Then look up that row below.
+
+## How to read this page
+
+Two views over the same data:
+
+- **CLI release table** — start here if you know the CLI version a build used and want to know which plugin versions it pulled.
+- **One section per consumer step** — start here if you know the step version pinned in your workflow and want the CLI + plugin versions it resolves to.
+
+## Contents
+
+- [CLI release table](#cli-release-table)
+- [activate-build-cache-for-gradle](#activate-build-cache-for-gradle)
+- [activate-build-cache-for-react-native](#activate-build-cache-for-react-native)
+- [activate-gradle-mirrors](#activate-gradle-mirrors)
+
+## Components
+
+- The Bitrise Build Cache CLI ([repository link](https://github.com/bitrise-io/bitrise-build-cache-cli)) supports multiple commands; the relevant one here is `activate gradle` (or `enable-for gradle` in older versions), which writes the Gradle init script `$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts` that pulls in the remote cache, analytics, and test-distribution plugins with the versions listed below.
+- The analytics plugin `io.bitrise.gradle:gradle-analytics` is published to Maven Central and provides build analytics (e.g. [critical path](https://bitrise.io/changelog/enhanced-gradle-critical-path/24815)).
+- The remote cache plugin `io.bitrise.gradle:remote-cache` is published to Maven Central and implements the client for the Bitrise remote build cache.
+- The test distribution plugin `io.bitrise.gradle:test-distribution` is published to Maven Central and integrates with Bitrise Test Distribution.
+- The common plugin `io.bitrise.gradle:common` is published to Maven Central and is a shared dependency of the above.
+
+## Gradle dependency verification
+
+If you use Gradle's [dependency verification](https://docs.gradle.org/current/userguide/dependency_verification.html), pin the activating step to a full patch version in your workflow and seed your `gradle/verification-metadata.xml` from the matching CLI release. Each CLI release page attaches a reference asset:
+
+- `verification-metadata.xml` — checksums for artifacts as served by the original Maven Central / Google / plugin-portal repositories. Use this when the Bitrise Maven Central mirror is **not** active in your workflow.
+- `verification-metadata-mirror.xml` (from `v2.4.6` onward) — checksums for artifacts as served by the **Bitrise Maven Central mirror**. The mirror is on by default for all Bitrise Android builds, so this is the file most workflows need; the plain origin file will fail verification when the mirror serves the artifacts.
+
+For the full setup walkthrough — including which step in your workflow activates the mirror, how to lock that step's version, and how to regenerate the metadata when the CLI is updated — see [Gradle dependency verification for the Maven Central mirror](https://docs.google.com/document/d/1mrquZ-n7dNNmQo0o4ddzY73JTsY5xkYRgRKARoKNFvs/edit).
+
+## CLI release table
+
+| CLI version | Release date | Analytics plugin | Cache plugin | Test Distribution plugin | Common plugin |
+|-------------|--------------|------------------|--------------|--------------------------|----------------|
+| [v2.7.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.7.3) | 2026-05-19 | 2.7.3 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.7.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.7.2) | 2026-05-18 | 2.7.3 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.7.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.7.1) | 2026-05-15 | 2.7.2 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.7.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.7.0) | 2026-05-15 | 2.7.2 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.6.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.7) | 2026-05-15 | 2.7.2 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.6.6](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.6) | 2026-05-13 | 2.7.2 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.6.5](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.5) | 2026-05-13 | 2.7.2 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.6.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.4) | 2026-05-13 | 2.7.2 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.6.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.3) | 2026-05-13 | 2.7.2 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.6.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.2) | 2026-05-13 | 2.7.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.6.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.1) | 2026-05-12 | 2.7.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.6.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.0) | 2026-05-05 | 2.7.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.5.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.5.0) | 2026-05-05 | 2.7.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.4.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.9) | 2026-04-30 | 2.7.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.4.8](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.8) | 2026-04-30 | 2.7.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.4.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.7) | 2026-04-30 | 2.7.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.4.6](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.6) | 2026-04-30 | 2.7.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.4.5](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.5) | 2026-04-30 | 2.7.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.4.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.4) | 2026-04-30 | 2.7.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.4.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.3) | 2026-04-30 | 2.7.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.4.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.2) | 2026-04-29 | 2.7.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.4.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.1) | 2026-04-29 | 2.7.0 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.4.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.0) | 2026-04-29 | 2.7.0 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.3.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.3.4) | 2026-04-28 | 2.7.0 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.3.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.3.3) | 2026-04-28 | 2.7.0 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.3.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.3.2) | 2026-04-28 | 2.7.0 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.3.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.3.1) | 2026-04-28 | 2.7.0 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.3.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.3.0) | 2026-04-27 | 2.7.0 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.2.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.2.2) | 2026-04-23 | 2.6.1 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.2.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.2.1) | 2026-04-22 | 2.6.0 | 1.3.3 | 2.2.10 | 1.0.7 |
+| [v2.2.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.2.0) | 2026-04-21 | 2.6.0 | 1.3.2 | 2.2.10 | 1.0.7 |
+| [v2.1.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.1.1) | 2026-04-21 | 2.6.0 | 1.3.1 | 2.2.10 | 1.0.7 |
+| [v2.1.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.1.0) | 2026-04-21 | 2.6.0 | 1.3.1 | 2.2.10 | 1.0.7 |
+| [v2.0.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.0.2) | 2026-04-20 | 2.6.0 | 1.3.1 | 2.2.10 | 1.0.7 |
+| [v2.0.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.0.1) | 2026-04-14 | 2.6.0 | 1.3.1 | 2.2.10 | 1.0.7 |
+| [v2.0.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.0.0) | 2026-04-14 | 2.6.0 | 1.3.1 | 2.2.10 | 1.0.7 |
+| [v1.6.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.6.0) | 2026-04-10 | 2.6.0 | 1.3.1 | 2.2.10 | 1.0.7 |
+| [v1.5.5](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.5.5) | 2026-04-02 | 2.6.0 | 1.3.1 | 2.2.10 | 1.0.7 |
+| [v1.5.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.5.4) | 2026-04-01 | 2.6.0 | 1.3.0 | 2.2.10 | 1.0.7 |
+| [v1.5.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.5.3) | 2026-03-31 | 2.6.0 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.5.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.5.2) | 2026-03-30 | 2.5.4 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.5.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.5.1) | 2026-03-30 | 2.5.4 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.5.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.5.0) | 2026-03-26 | 2.5.3 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.4.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.4.0) | 2026-03-20 | 2.5.3 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.3.5](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.3.5) | 2026-03-19 | 2.5.3 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.3.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.3.4) | 2026-03-18 | 2.5.3 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.3.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.3.3) | 2026-03-17 | 2.5.2 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.3.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.3.2) | 2026-03-13 | 2.5.1 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.3.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.3.1) | 2026-03-13 | 2.4.4 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.3.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.3.0) | 2026-03-11 | 2.4.3 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.2.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.2.0) | 2026-03-10 | 2.4.1 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.1.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.1.1) | 2026-03-03 | 2.4.1 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.1.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.1.0) | 2026-03-02 | 2.4.1 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.0.43](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.43) | 2026-02-24 | 2.4.0 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.0.42](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.42) | 2026-02-12 | 2.3.0 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.0.41](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.41) | 2026-02-03 | 2.2.5 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.0.40](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.40) | 2026-01-26 | 2.2.5 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.0.39](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.39) | 2026-01-22 | 2.2.5 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.0.38](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.38) | 2026-01-13 | 2.2.5 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.0.37](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.37) | 2026-01-12 | 2.2.4 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.0.36](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.36) | 2025-12-17 | 2.2.3 | 1.2.28 | 2.2.10 | 1.0.7 |
+| [v1.0.35](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.35) | 2025-12-15 | 2.2.3 | 1.2.28 | 2.2.9 | 1.0.7 |
+| [v1.0.34](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.34) | 2025-12-10 | 2.2.3 | 1.2.28 | 2.2.8 | 1.0.7 |
+| [v1.0.33](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.33) | 2025-12-10 | 2.2.3 | 1.2.28 | 2.2.7 | 1.0.7 |
+| [v1.0.32](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.32) | 2025-12-09 | 2.2.3 | 1.2.28 | 2.2.7 | 1.0.7 |
+| [v1.0.31](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.31) | 2025-12-08 | 2.2.3 | 1.2.28 | 2.2.6 | 1.0.7 |
+| [v1.0.30](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.30) | 2025-12-08 | 2.2.3 | 1.2.27 | 2.2.5 | 1.0.7 |
+| [v1.0.29](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.29) | 2025-12-08 | 2.2.3 | 1.2.27 | 2.2.5 | 1.0.7 |
+| [v1.0.28](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.28) | 2025-12-01 | 2.2.2 | 1.2.26 | 2.2.4 | 1.0.6 |
+| [v1.0.27](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.27) | 2025-11-28 | 2.2.2 | 1.2.26 | 2.2.4 | 1.0.6 |
+| [v1.0.26](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.26) | 2025-11-27 | 2.2.2 | 1.2.25 | 2.2.4 | 1.0.6 |
+| [v1.0.25](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.25) | 2025-11-26 | 2.2.2 | 1.2.25 | 2.2.3 | 1.0.6 |
+| [v1.0.24](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.24) | 2025-11-20 | 2.2.2 | 1.2.25 | 2.2.2 | 1.0.6 |
+| [v1.0.23](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.23) | 2025-11-20 | 2.2.2 | 1.2.25 | 2.2.1 | 1.0.6 |
+| [v1.0.22](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.22) | 2025-11-20 | 2.2.2 | 1.2.25 | 2.2.1 | 1.0.6 |
+| [v1.0.21](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.21) | 2025-11-20 | 2.2.2 | 1.2.25 | 2.2.1 | 1.0.6 |
+| [v1.0.20](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.20) | 2025-11-20 | 2.2.2 | 1.2.25 | 2.2.0 | 1.0.6 |
+| [v1.0.19](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.19) | 2025-11-19 | 2.2.1 | 1.2.25 | 2.2.0 | 1.0.6 |
+| [v1.0.18](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.18) | 2025-11-19 | 2.2.1 | 1.2.25 | 2.2.0 | 1.0.6 |
+| [v1.0.17](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.17) | 2025-11-19 | 2.2.1 | 1.2.25 | 2.2.0 | 1.0.6 |
+| [v1.0.16](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.16) | 2025-11-18 | 2.2.0 | 1.2.24 | 2.1.28 | 1.0.5 |
+| [v1.0.15](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.15) | 2025-11-17 | 2.2.0 | 1.2.24 | 2.1.28 | 1.0.5 |
+| [v1.0.14](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.14) | 2025-11-13 | 2.2.0 | 1.2.24 | 2.1.28 | 1.0.5 |
+| [v1.0.13](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.13) | 2025-11-05 | 2.1.36 | 1.2.24 | 2.1.28 | 1.0.5 |
+| [v1.0.12](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.12) | 2025-11-04 | 2.1.36 | 1.2.24 | 2.1.28 | 1.0.5 |
+| [v1.0.11](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.11) | 2025-10-31 | 2.1.35 | 1.2.23 | 2.1.27 | 1.0.4 |
+| [v1.0.10](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.10) | 2025-10-29 | 2.1.35 | 1.2.23 | 2.1.27 | 1.0.4 |
+| [v1.0.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.9) | 2025-10-28 | 2.1.35 | 1.2.23 | 2.1.27 | 1.0.4 |
+| [v1.0.8](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.8) | 2025-10-28 | 2.1.35 | 1.2.23 | 2.1.27 | 1.0.4 |
+| [v1.0.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.7) | 2025-10-28 | 2.1.35 | 1.2.23 | 2.1.27 | 1.0.4 |
+| [v1.0.6](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.6) | 2025-10-28 | 2.1.35 | 1.2.23 | 2.1.27 | 1.0.4 |
+| [v1.0.5](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.5) | 2025-10-13 | 2.1.33 | 1.2.21 | 2.1.25 | 1.0.2 |
+| [v1.0.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.4) | 2025-10-01 | 2.1.33 | 1.2.21 | 2.1.25 | 1.0.2 |
+| [v1.0.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.3) | 2025-09-29 | 2.1.32 | 1.2.21 | 2.1.25 | 1.0.2 |
+| [v1.0.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.2) | 2025-09-25 | 2.1.32 | 1.2.21 | 2.1.25 | 1.0.2 |
+| [v1.0.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.1) | 2025-09-23 | 2.1.32 | 1.2.21 | 2.1.25 | 1.0.2 |
+| [v0.17.10](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.10) | 2025-09-04 | 2.1.32 | 1.2.21 | 2.1.25 | 1.0.2 |
+| [v0.17.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.9) | 2025-09-02 | 2.1.32 | 1.2.21 | 2.1.25 | 1.0.2 |
+| [v0.17.8](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.8) | 2025-08-07 | 2.1.32 | 1.2.20 | 2.1.25 | 1.0.2 |
+| [v0.17.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.7) | 2025-07-30 | 2.1.32 | 1.2.20 | 2.1.25 | 1.0.2 |
+| [v0.17.6](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.6) | 2025-07-29 | 2.1.32 | 1.2.20 | 2.1.25 | 1.0.2 |
+| [v0.17.5](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.5) | 2025-07-10 | 2.1.31 | 1.2.20 | 2.1.25 | 1.0.2 |
+| [v0.17.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.4) | 2025-07-08 | 2.1.31 | 1.2.20 | 2.1.25 | 1.0.2 |
+| [v0.17.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.3) | 2025-07-08 | 2.1.30 | 1.2.20 | 2.1.25 | 1.0.2 |
+| [v0.17.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.2) | 2025-07-01 | 2.1.30 | 1.2.20 | 2.1.25 | 1.0.2 |
+| [v0.17.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.1) | 2025-07-01 | 2.1.30 | 1.2.20 | 2.1.25 | 1.0.2 |
+| [v0.17.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.0) | 2025-06-27 | 2.1.30 | 1.2.20 | 2.1.25 | 1.0.2 |
+| [v0.16.12](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.12) | 2025-06-26 | 2.1.30 | 1.2.20 | 2.1.25 | 1.0.2 |
+| [v0.16.11](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.11) | 2025-06-25 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.16.10](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.10) | 2025-06-19 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.16.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.9) | 2025-06-17 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.16.8](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.8) | 2025-06-17 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.16.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.7) | 2025-06-11 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.16.6](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.6) | 2025-06-11 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.16.5](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.5) | 2025-06-11 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.16.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.4) | 2025-06-11 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.16.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.3) | 2025-06-11 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.16.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.2) | 2025-06-11 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.16.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.1) | 2025-06-11 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.16.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.0) | 2025-06-04 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.15.38](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.38) | 2025-06-03 | 2.1.28 | 1.2.19 | 2.1.24 | 1.0.1 |
+| [v0.15.37](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.37) | 2025-05-13 | 2.1.25 | 1.2.18 | - | - |
+| [v0.15.36](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.36) | 2025-05-09 | 2.1.25 | 1.2.18 | - | - |
+| [v0.15.35](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.35) | 2025-05-08 | 2.1.24 | 1.2.18 | - | - |
+| [v0.15.33](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.33) | 2025-04-30 | 2.1.23 | 1.2.17 | - | - |
+| [v0.15.32](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.32) | 2025-04-24 | 2.1.22 | 1.2.17 | - | - |
+| [v0.15.31](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.31) | 2025-04-15 | 2.1.22 | 1.2.17 | - | - |
+| [v0.15.30](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.30) | 2025-04-10 | 2.1.22 | 1.2.17 | - | - |
+| [v0.15.29](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.29) | 2025-04-09 | 2.1.21 | 1.2.17 | - | - |
+| [v0.15.28](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.28) | 2025-04-07 | 2.1.20 | 1.2.17 | - | - |
+| [v0.15.27](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.27) | 2025-04-07 | 2.1.20 | 1.2.17 | - | - |
+| [v0.15.26](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.26) | 2025-04-04 | 2.1.20 | 1.2.17 | - | - |
+| [v0.15.25](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.25) | 2025-04-04 | 2.1.19 | 1.2.17 | - | - |
+| [v0.15.24](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.24) | 2025-04-01 | 2.1.18 | 1.2.16 | - | - |
+| [v0.15.23](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.23) | 2025-03-31 | 2.1.17 | 1.2.16 | - | - |
+| [v0.15.22](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.22) | 2025-03-26 | 2.1.17 | 1.2.16 | - | - |
+| [v0.15.21](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.21) | 2025-03-25 | 2.1.16 | 1.2.16 | - | - |
+| [v0.15.20](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.20) | 2025-03-18 | 2.1.15 | 1.2.16 | - | - |
+| [v0.15.19](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.19) | 2025-03-18 | 2.1.15 | 1.2.16 | - | - |
+| [v0.15.18](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.18) | 2025-03-18 | 2.1.15 | 1.2.16 | - | - |
+| [v0.15.17](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.17) | 2025-03-04 | 2.1.15 | 1.2.16 | - | - |
+| [v0.15.16](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.16) | 2025-02-06 | 2.1.14 | 1.2.16 | - | - |
+| [v0.15.15](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.15) | 2025-01-31 | 2.1.14 | 1.2.15 | - | - |
+| [v0.15.14](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.14) | 2025-01-30 | 2.1.13 | 1.2.15 | - | - |
+| [v0.15.13](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.13) | 2025-01-28 | 2.1.13 | 1.2.14 | - | - |
+| [v0.15.12](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.12) | 2025-01-27 | 2.1.13 | 1.2.14 | - | - |
+| [v0.15.11](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.11) | 2025-01-24 | 2.1.13 | 1.2.13 | - | - |
+| [v0.15.10](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.10) | 2025-01-21 | 2.1.13 | 1.2.13 | - | - |
+| [v0.15.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.9) | 2025-01-17 | 2.1.12 | 1.2.12 | - | - |
+| [v0.15.8](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.8) | 2025-01-16 | 2.1.11 | 1.2.11 | - | - |
+| [v0.15.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.7) | 2025-01-13 | 2.1.11 | 1.2.10 | - | - |
+| [v0.15.6](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.6) | 2025-01-13 | 2.1.11 | 1.2.9 | - | - |
+| [v0.15.5](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.5) | 2025-01-09 | 2.1.10 | 1.2.9 | - | - |
+| [v0.15.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.4) | 2024-12-12 | 2.1.10 | 1.2.9 | - | - |
+| [v0.15.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.3) | 2024-12-09 | 2.1.9 | 1.2.9 | - | - |
+| [v0.15.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.2) | 2024-12-02 | 2.1.8 | 1.2.9 | - | - |
+| [v0.15.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.1) | 2024-11-25 | 2.1.7 | 1.2.9 | - | - |
+| [v0.15.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.0) | 2024-10-16 | 2.1.7 | 1.2.9 | - | - |
+| [v0.14.8](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.8) | 2024-09-30 | 2.1.7 | 1.2.9 | - | - |
+| [v0.14.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.7) | 2024-08-02 | 2.1.7 | 1.2.8 | - | - |
+| [v0.14.6](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.6) | 2024-07-22 | 2.1.7 | 1.2.7 | - | - |
+| [v0.14.5](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.5) | 2024-07-03 | 2.1.7 | 1.2.6 | - | - |
+| [v0.14.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.4) | 2024-07-01 | 2.1.7 | 1.2.6 | - | - |
+| [v0.14.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.3) | 2024-05-29 | 2.1.6 | 1.2.6 | - | - |
+| [v0.14.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.2) | 2024-05-17 | 2.1.5 | 1.2.5 | - | - |
+| [v0.14.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.1) | 2024-05-15 | 2.1.4 | 1.2.5 | - | - |
+| [v0.14.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.0) | 2024-05-13 | 2.1.3 | 1.2.4 | - | - |
+| [v0.13.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.13.0) | 2024-05-08 | 2.1.3 | 1.2.4 | - | - |
+| [v0.12.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.12.0) | 2024-04-23 | 2.1.2 | 1.2.3 | - | - |
+| [v0.11.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.11.0) | 2024-04-03 | - | 1.2.3 | - | - |
+| [v0.10.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.10.0) | 2024-03-26 | - | - | - | - |
+| [v0.9.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.9.0) | 2024-02-27 | - | - | - | - |
+| [v0.8.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.8.3) | 2024-02-20 | 2.0.2 | - | - | - |
+| [v0.8.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.8.2) | 2024-02-16 | 2.0.1 | - | - | - |
+| [v0.8.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.8.1) | 2024-02-02 | - | - | - | - |
+| [v0.8.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.8.0) | 2024-01-30 | - | - | - | - |
+| [v0.7.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.7.0) | 2024-01-26 | - | - | - | - |
+| [v0.6.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.6.0) | 2024-01-26 | - | - | - | - |
+| [v0.5.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.5.0) | 2024-01-16 | - | - | - | - |
+| [v0.4.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.4.0) | 2024-01-15 | - | - | - | - |
+| [v0.3.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.3.0) | 2024-01-15 | - | - | - | - |
+| [v0.2.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.2.0) | 2024-01-15 | - | - | - | - |
+| [v0.1.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.1.0) | 2024-01-15 | - | - | - | - |
+
+## activate-build-cache-for-gradle
+
+| Step version | CLI version | Analytics plugin | Cache plugin | Test Distribution plugin |
+|--------------|-------------|------------------|--------------|--------------------------|
+| 2.20.6 | [v2.7.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.7.3) | 2.7.3 | 1.3.3 | 2.2.10 |
+| 2.20.5 | [v2.7.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.7.2) | 2.7.3 | 1.3.3 | 2.2.10 |
+| 2.20.4 | [v2.6.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.7) | 2.7.2 | 1.3.3 | 2.2.10 |
+| 2.20.3 | [v2.6.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.3) | 2.7.2 | 1.3.3 | 2.2.10 |
+| 2.20.2 | [v2.6.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.2) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 2.20.1 | [v2.6.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.0) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 2.20.0 | [v2.6.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.0) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 2.19.0 | [v2.5.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.5.0) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 2.18.9 | [v2.4.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.9) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 2.18.8 | [v2.4.8](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.8) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 2.18.7 | [v2.4.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.7) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 2.18.6 | [v2.4.6](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.6) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 2.18.5 | [v2.4.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.4) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 2.18.4 | [v2.4.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.3) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 2.18.3 | [v2.4.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.2) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 2.18.2 | [v2.4.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.1) | 2.7.0 | 1.3.3 | 2.2.10 |
+| 2.18.1 | [v2.4.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.1) | 2.7.0 | 1.3.3 | 2.2.10 |
+| 2.18.0 | [v2.4.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.0) | 2.7.0 | 1.3.3 | 2.2.10 |
+| 2.17.2 | [v2.3.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.3.4) | 2.7.0 | 1.3.3 | 2.2.10 |
+| 2.17.1 | [v2.3.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.3.3) | 2.7.0 | 1.3.3 | 2.2.10 |
+| 2.17.0 | [v2.3.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.3.0) | 2.7.0 | 1.3.3 | 2.2.10 |
+| 2.16.2 | [v2.2.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.2.2) | 2.6.1 | 1.3.3 | 2.2.10 |
+| 2.16.1 | [v2.2.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.2.1) | 2.6.0 | 1.3.3 | 2.2.10 |
+| 2.16.0 | [v2.2.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.2.0) | 2.6.0 | 1.3.2 | 2.2.10 |
+| 2.15.0 | [v2.1.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.1.0) | 2.6.0 | 1.3.1 | 2.2.10 |
+| 2.14.1 | [v1.6.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.6.0) | 2.6.0 | 1.3.1 | 2.2.10 |
+| 2.14.0 | [v1.6.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.6.0) | 2.6.0 | 1.3.1 | 2.2.10 |
+| 2.13.9 | [v1.5.5](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.5.5) | 2.6.0 | 1.3.1 | 2.2.10 |
+| 2.13.8 | [v1.5.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.5.4) | 2.6.0 | 1.3.0 | 2.2.10 |
+| 2.13.7 | [v1.5.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.5.3) | 2.6.0 | 1.2.28 | 2.2.10 |
+| 2.13.6 | [v1.5.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.5.2) | 2.5.4 | 1.2.28 | 2.2.10 |
+| 2.13.5 | [v1.5.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.5.1) | 2.5.4 | 1.2.28 | 2.2.10 |
+| 2.13.4 | [v1.3.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.3.4) | 2.5.3 | 1.2.28 | 2.2.10 |
+| 2.13.3 | [v1.3.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.3.3) | 2.5.2 | 1.2.28 | 2.2.10 |
+| 2.13.2 | [v1.3.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.3.2) | 2.5.1 | 1.2.28 | 2.2.10 |
+| 2.13.1 | [v1.3.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.3.1) | 2.4.4 | 1.2.28 | 2.2.10 |
+| 2.13.0 | [v1.3.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.3.0) | 2.4.3 | 1.2.28 | 2.2.10 |
+| 2.12.0 | [v1.1.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.1.1) | 2.4.1 | 1.2.28 | 2.2.10 |
+| 2.11.0 | [v1.1.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.1.0) | 2.4.1 | 1.2.28 | 2.2.10 |
+| 2.10.0 | [v1.0.43](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.43) | 2.4.0 | 1.2.28 | 2.2.10 |
+| 2.9.0 | [v1.0.42](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.42) | 2.3.0 | 1.2.28 | 2.2.10 |
+| 2.8.8 | [v1.0.38](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.38) | 2.2.5 | 1.2.28 | 2.2.10 |
+| 2.8.7 | [v1.0.37](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.37) | 2.2.4 | 1.2.28 | 2.2.10 |
+| 2.8.4 | [v1.0.27](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.27) | 2.2.2 | 1.2.26 | 2.2.4 |
+| 2.8.3 | [v1.0.25](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.25) | 2.2.2 | 1.2.25 | 2.2.3 |
+| 2.8.2 | [v1.0.20](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.20) | 2.2.2 | 1.2.25 | 2.2.0 |
+| 2.8.1 | [v1.0.17](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.17) | 2.2.1 | 1.2.25 | 2.2.0 |
+| 2.8.0 | [v1.0.14](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.14) | 2.2.0 | 1.2.24 | 2.1.28 |
+| 2.7.60 | [v1.0.13](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.13) | 2.1.36 | 1.2.24 | 2.1.28 |
+| 2.7.59 | [v1.0.12](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.12) | 2.1.36 | 1.2.24 | 2.1.28 |
+| 2.7.58 | [v1.0.10](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.10) | 2.1.35 | 1.2.23 | 2.1.27 |
+| 2.7.57 | [v1.0.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.9) | 2.1.35 | 1.2.23 | 2.1.27 |
+| 2.7.56 | [v1.0.6](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.6) | 2.1.35 | 1.2.23 | 2.1.27 |
+| 2.7.55 | [v1.0.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v1.0.4) | 2.1.33 | 1.2.21 | 2.1.25 |
+| 2.7.54 | [v0.17.10](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.10) | 2.1.32 | 1.2.21 | 2.1.25 |
+| 2.7.53 | [v0.17.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.9) | 2.1.32 | 1.2.21 | 2.1.25 |
+| 2.7.52 | [v0.17.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.7) | 2.1.32 | 1.2.20 | 2.1.25 |
+| 2.7.50 | [v0.17.6](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.6) | 2.1.32 | 1.2.20 | 2.1.25 |
+| 2.7.49 | [v0.17.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.4) | 2.1.31 | 1.2.20 | 2.1.25 |
+| 2.7.48 | [v0.17.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.3) | 2.1.30 | 1.2.20 | 2.1.25 |
+| 2.7.47 | [v0.17.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.2) | 2.1.30 | 1.2.20 | 2.1.25 |
+| 2.7.46 | [v0.17.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.17.1) | 2.1.30 | 1.2.20 | 2.1.25 |
+| 2.7.44 | [v0.16.12](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.12) | 2.1.30 | 1.2.20 | 2.1.25 |
+| 2.7.43 | [v0.16.11](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.11) | 2.1.28 | 1.2.19 | 2.1.24 |
+| 2.7.42 | [v0.16.10](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.10) | 2.1.28 | 1.2.19 | 2.1.24 |
+| 2.7.41 | [v0.16.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.9) | 2.1.28 | 1.2.19 | 2.1.24 |
+| 2.7.40 | [v0.16.8](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.8) | 2.1.28 | 1.2.19 | 2.1.24 |
+| 2.7.39 | [v0.16.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.7) | 2.1.28 | 1.2.19 | 2.1.24 |
+| 2.7.38 | [v0.16.6](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.6) | 2.1.28 | 1.2.19 | 2.1.24 |
+| 2.7.37 | [v0.16.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.2) | 2.1.28 | 1.2.19 | 2.1.24 |
+| 2.7.36 | [v0.16.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.16.0) | 2.1.28 | 1.2.19 | 2.1.24 |
+| 2.7.35 | [v0.15.38](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.38) | 2.1.28 | 1.2.19 | 2.1.24 |
+| 2.7.34 | [v0.15.37](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.37) | 2.1.25 | 1.2.18 | - |
+| 2.7.33 | [v0.15.36](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.36) | 2.1.25 | 1.2.18 | - |
+| 2.7.32 | [v0.15.35](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.35) | 2.1.24 | 1.2.18 | - |
+| 2.7.31 | [v0.15.34](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.34) | - | - | - |
+| 2.7.30 | [v0.15.30](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.30) | 2.1.22 | 1.2.17 | - |
+| 2.7.29 | [v0.15.29](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.29) | 2.1.21 | 1.2.17 | - |
+| 2.7.28 | [v0.15.26](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.26) | 2.1.20 | 1.2.17 | - |
+| 2.7.27 | [v0.15.25](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.25) | 2.1.19 | 1.2.17 | - |
+| 2.7.26 | [v0.15.24](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.24) | 2.1.18 | 1.2.16 | - |
+| 2.7.25 | [v0.15.22](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.22) | 2.1.17 | 1.2.16 | - |
+| 2.7.24 | [v0.15.21](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.21) | 2.1.16 | 1.2.16 | - |
+| 2.7.23 | [v0.15.20](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.20) | 2.1.15 | 1.2.16 | - |
+| 2.7.22 | [v0.15.17](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.17) | 2.1.15 | 1.2.16 | - |
+| 2.7.21 | [v0.15.16](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.16) | 2.1.14 | 1.2.16 | - |
+| 2.7.20 | [v0.15.15](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.15) | 2.1.14 | 1.2.15 | - |
+| 2.7.19 | [v0.15.14](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.14) | 2.1.13 | 1.2.15 | - |
+| 2.7.18 | [v0.15.13](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.13) | 2.1.13 | 1.2.14 | - |
+| 2.7.17 | [v0.15.12](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.12) | 2.1.13 | 1.2.14 | - |
+| 2.7.16 | [v0.15.10](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.10) | 2.1.13 | 1.2.13 | - |
+| 2.7.15 | [v0.15.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.9) | 2.1.12 | 1.2.12 | - |
+| 2.7.14 | [v0.15.8](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.8) | 2.1.11 | 1.2.11 | - |
+| 2.7.13 | [v0.15.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.7) | 2.1.11 | 1.2.10 | - |
+| 2.7.12 | [v0.15.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.4) | 2.1.10 | 1.2.9 | - |
+| 2.7.11 | [v0.15.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.2) | 2.1.8 | 1.2.9 | - |
+| 2.7.10 | [v0.15.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.3) | 2.1.9 | 1.2.9 | - |
+| 2.7.9 | [v0.15.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.2) | 2.1.8 | 1.2.9 | - |
+| 2.7.8 | [v0.15.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.15.2) | 2.1.8 | 1.2.9 | - |
+| 2.7.7 | [v0.14.8](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.8) | 2.1.7 | 1.2.9 | - |
+| 2.7.6 | [v0.14.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.7) | 2.1.7 | 1.2.8 | - |
+| 2.7.5 | [v0.14.5](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.5) | 2.1.7 | 1.2.6 | - |
+| 2.7.4 | [v0.14.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.4) | 2.1.7 | 1.2.6 | - |
+| 2.7.3 | [v0.14.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.3) | 2.1.6 | 1.2.6 | - |
+| 2.7.2 | [v0.14.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.2) | 2.1.5 | 1.2.5 | - |
+| 2.7.1 | [v0.14.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.1) | 2.1.4 | 1.2.5 | - |
+| 2.7.0 | [v0.14.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.14.0) | 2.1.3 | 1.2.4 | - |
+| 2.6.0 | [v0.13.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.13.0) | 2.1.3 | 1.2.4 | - |
+| 2.5.0 | [v0.12.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.12.0) | 2.1.2 | 1.2.3 | - |
+| 2.4.0 | [v0.11.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.11.0) | - | 1.2.3 | - |
+| 2.3.0 | [v0.11.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.11.0) | - | 1.2.3 | - |
+| 2.2.0 | [v0.10.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.10.0) | - | - | - |
+| 2.1.0 | [v0.9.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.9.0) | - | - | - |
+| 2.0.3 | [v0.8.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.8.3) | 2.0.2 | - | - |
+| 2.0.2 | [v0.8.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.8.2) | 2.0.1 | - | - |
+| 2.0.1 | [v0.8.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.8.0) | - | - | - |
+| 2.0.0 | [v0.8.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v0.8.0) | - | - | - |
+
+## activate-build-cache-for-react-native
+
+| Step version | CLI version | Analytics plugin | Cache plugin | Test Distribution plugin |
+|--------------|-------------|------------------|--------------|--------------------------|
+| 0.8.3 | [v2.7.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.7.3) | 2.7.3 | 1.3.3 | 2.2.10 |
+| 0.8.2 | [v2.7.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.7.2) | 2.7.3 | 1.3.3 | 2.2.10 |
+| 0.8.1 | [v2.7.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.7.1) | 2.7.2 | 1.3.3 | 2.2.10 |
+| 0.8.0 | [v2.7.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.7.0) | 2.7.2 | 1.3.3 | 2.2.10 |
+| 0.7.3 | [v2.6.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.3) | 2.7.2 | 1.3.3 | 2.2.10 |
+| 0.7.2 | [v2.6.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.2) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.7.1 | [v2.6.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.0) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.7.0 | [v2.6.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.0) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.6.0 | [v2.5.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.5.0) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.5.7 | [v2.4.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.9) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.5.6 | [v2.4.8](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.8) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.5.5 | [v2.4.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.7) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.5.4 | [v2.4.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.4) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.5.3 | [v2.4.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.2) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.5.2 | [v2.4.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.1) | 2.7.0 | 1.3.3 | 2.2.10 |
+| 0.5.1 | [v2.4.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.1) | 2.7.0 | 1.3.3 | 2.2.10 |
+| 0.5.0 | [v2.4.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.0) | 2.7.0 | 1.3.3 | 2.2.10 |
+| 0.4.1 | [v2.3.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.3.4) | 2.7.0 | 1.3.3 | 2.2.10 |
+| 0.4.0 | [v2.3.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.3.0) | 2.7.0 | 1.3.3 | 2.2.10 |
+| 0.3.0 | [v2.2.2](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.2.2) | 2.6.1 | 1.3.3 | 2.2.10 |
+| 0.2.0 | [v2.0.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.0.1) | 2.6.0 | 1.3.1 | 2.2.10 |
+
+## activate-gradle-mirrors
+
+| Step version | CLI version | Analytics plugin | Cache plugin | Test Distribution plugin |
+|--------------|-------------|------------------|--------------|--------------------------|
+| 0.2.1 | [v2.6.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.6.1) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.2.0 | [v2.5.0](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.5.0) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.1.4 | [v2.4.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.9) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.1.3 | [v2.4.7](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.7) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.1.2 | [v2.4.4](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.4) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.1.1 | [v2.4.3](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.3) | 2.7.1 | 1.3.3 | 2.2.10 |
+| 0.1.0 | [v2.4.1](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.1) | 2.7.0 | 1.3.3 | 2.2.10 |

--- a/internal/config/bazel/bazel_config_generate_test.go
+++ b/internal/config/bazel/bazel_config_generate_test.go
@@ -239,7 +239,7 @@ build --remote_header=x-flare-builduser=CIProviderValue
 build --remote_upload_local_results
 build --bes_backend=grpcs://flare-bes.services.bitrise.io:443
 build --bes_header=authorization="Bearer AuthTokenValue"
-build --bes_results_url=https://app.bitrise.io/build-cache/invocations/bazel/
+build --bes_results_url=https://app-staging.bitrise.io/build-cache/invocations/bazel/
 build --bes_timeout=2m
 build --bes_upload_mode=wait_for_upload_complete
 build --build_event_publish_all_actions

--- a/internal/config/bazel/bazelrc.gotemplate
+++ b/internal/config/bazel/bazelrc.gotemplate
@@ -14,7 +14,7 @@ build --noremote_upload_local_results
 {{- if .BES.Enabled }}
 build --bes_backend={{ .BES.EndpointURLWithPort }}
 build --bes_header=authorization="Bearer {{ .Common.AuthToken }}"
-build --bes_results_url=https://app.bitrise.io/build-cache/invocations/bazel/
+build --bes_results_url=https://app-staging.bitrise.io/build-cache/invocations/bazel/
 build --bes_timeout=2m
 build --bes_upload_mode=wait_for_upload_complete
 build --build_event_publish_all_actions

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -13,7 +13,7 @@ const (
 	XcodeAnalyticsServiceEndpoint         = "https://xcode-analytics.services.bitrise.io"
 	MultiplatformAnalyticsServiceEndpoint = "https://multiplatform-analytics.services.bitrise.io"
 
-	BitriseWebsiteBaseURL = "https://app.bitrise.io"
+	BitriseWebsiteBaseURL = "https://app-staging.bitrise.io"
 
 	// Gradle Remote Build Cache related consts
 	GradleRemoteBuildCachePluginDepVersion = "1.3.4"

--- a/mockups/desktop-app/index.html
+++ b/mockups/desktop-app/index.html
@@ -1,0 +1,775 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Bitrise Build Cache — Menubar Mockups (ACI-4337)</title>
+  <style>
+    /* =========================================================
+       Bitrise Build Cache — macOS menubar companion
+       Two states: default (running) and Gradle setup
+       ========================================================= */
+
+    :root {
+      --primary:        #6e22db;
+      --primary-soft:   #efe6ff;
+      --text:           #1c1a23;
+      --text-muted:     #6b6577;
+      --link:           #3573f0;
+      --success:        #14a45c;
+      --warning:        #d4860a;
+      --danger:         #d83a3a;
+      --shadow:         0 30px 60px -20px rgba(46, 28, 75, 0.35),
+                        0 8px 16px -8px rgba(46, 28, 75, 0.15);
+    }
+
+    * { box-sizing: border-box; }
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Inter", "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 14px;
+      color: var(--text);
+      background:
+        radial-gradient(1200px 800px at 80% -10%, #d4c4ff33, transparent 60%),
+        radial-gradient(1000px 700px at -10% 110%, #ffb8d233, transparent 60%),
+        linear-gradient(180deg, #f3eef8 0%, #efe9f4 100%);
+      min-height: 100vh;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .board {
+      max-width: 1700px;
+      margin: 0 auto;
+      padding: 48px 24px 80px;
+    }
+
+    .board-header h1 {
+      font-size: 28px;
+      margin: 0 0 6px;
+      letter-spacing: -0.01em;
+    }
+    .board-header p {
+      margin: 0 0 36px;
+      color: var(--text-muted);
+      max-width: 760px;
+      line-height: 1.5;
+    }
+    .board-header a { color: var(--link); }
+
+    .frames {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(640px, 1fr));
+      gap: 48px;
+      align-items: start;
+    }
+
+    .panel-label {
+      font-size: 11.5px;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--primary);
+      background: var(--primary-soft);
+      padding: 4px 10px;
+      border-radius: 999px;
+      display: inline-block;
+      margin-bottom: 10px;
+    }
+    .panel-title {
+      font-size: 16px;
+      font-weight: 700;
+      margin: 0 0 4px;
+      letter-spacing: -0.005em;
+    }
+    .panel-desc {
+      font-size: 13px;
+      color: var(--text-muted);
+      margin: 0 0 16px;
+      line-height: 1.5;
+      max-width: 520px;
+    }
+
+    /* ============ macOS frame ============ */
+
+    .mb-frame {
+      border-radius: 12px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      background: linear-gradient(180deg, #6b5fa8 0%, #4f4283 100%);
+    }
+
+    .mb-statusbar {
+      height: 28px;
+      background: linear-gradient(180deg, rgba(0,0,0,0.42), rgba(0,0,0,0.28));
+      backdrop-filter: blur(20px);
+      color: rgba(255,255,255,0.95);
+      display: flex;
+      align-items: center;
+      padding: 0 12px;
+      gap: 14px;
+      font-size: 13px;
+    }
+    .mb-statusbar .apple { width: 14px; height: 14px; opacity: 0.95; }
+    .mb-statusbar .app-name { font-weight: 700; }
+    .mb-statusbar .menu-item { opacity: 0.95; }
+    .mb-statusbar .spacer { flex: 1; }
+    .mb-statusbar .right-icons {
+      display: flex; align-items: center; gap: 14px;
+      font-size: 12.5px;
+    }
+    .mb-statusbar .clock {
+      font-variant-numeric: tabular-nums;
+      letter-spacing: 0.01em;
+    }
+
+    .mb-trigger {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 2px 6px;
+      border-radius: 4px;
+      background: rgba(255,255,255,0.18);
+    }
+    .mb-trigger .glyph-dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      box-shadow: 0 0 0 2px rgba(0,0,0,0.25);
+    }
+    .mb-trigger .glyph-dot.ok   { background: #4ade80; }
+    .mb-trigger .glyph-dot.warn { background: #facc15; }
+
+    .mb-stage {
+      position: relative;
+      padding: 0 14px 28px;
+      min-height: 660px;
+      background:
+        radial-gradient(800px 500px at 80% 0%, rgba(255,255,255,0.18), transparent 60%),
+        radial-gradient(800px 500px at 0% 100%, rgba(0,0,0,0.18), transparent 60%);
+    }
+
+    /* ============ Dropdown — shared ============ */
+
+    .mb-dropdown {
+      position: absolute;
+      top: -2px;
+      right: 20px;
+      width: 360px;
+      background: rgba(40, 28, 60, 0.78);
+      backdrop-filter: blur(40px) saturate(140%);
+      -webkit-backdrop-filter: blur(40px) saturate(140%);
+      border-radius: 10px;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.35),
+                  0 0 0 0.5px rgba(255,255,255,0.18) inset,
+                  0 1px 0 rgba(255,255,255,0.2) inset;
+      color: #fff;
+      font-size: 13px;
+      padding: 6px 0;
+    }
+    .mb-dropdown.setup { width: 380px; }
+    .mb-dropdown .group { padding: 4px 0; }
+
+    .mb-header {
+      display: flex; align-items: center; gap: 10px;
+      padding: 12px 14px 8px;
+    }
+    .mb-header .badge {
+      width: 28px; height: 28px;
+      border-radius: 7px;
+      background: linear-gradient(135deg, #6e22db 0%, #b347d9 50%, #ff6fb4 100%);
+      display: flex; align-items: center; justify-content: center;
+      color: #fff;
+    }
+    .mb-header .badge.gradle {
+      background: linear-gradient(135deg, #02303a 0%, #0c5364 100%);
+      color: #fff;
+      font-weight: 800;
+      font-size: 15px;
+    }
+    .mb-header .title { font-weight: 700; font-size: 14px; line-height: 1.1; }
+    .mb-header .sub   { font-size: 12px; color: rgba(255,255,255,0.7); margin-top: 1px; }
+    .mb-header .header-action {
+      margin-left: auto;
+      font-size: 12px;
+      color: rgba(255,255,255,0.65);
+      cursor: pointer;
+    }
+
+    .mb-divider {
+      height: 0.5px;
+      background: rgba(255,255,255,0.14);
+      margin: 4px 0;
+    }
+
+    .mb-section-title {
+      font-size: 11px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgba(255,255,255,0.55);
+      padding: 6px 14px 4px;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .mb-section-title .action {
+      color: rgba(255,255,255,0.7);
+      font-weight: 500;
+      text-transform: none;
+      letter-spacing: 0;
+      font-size: 12px;
+      cursor: pointer;
+    }
+
+    /* Tool rows */
+    .mb-tool-row {
+      display: grid;
+      grid-template-columns: 18px 1fr auto;
+      gap: 10px;
+      align-items: center;
+      padding: 6px 14px;
+      color: rgba(255,255,255,0.95);
+    }
+    .mb-tool-row .name { font-weight: 500; }
+    .mb-tool-row .state { color: rgba(255,255,255,0.7); font-size: 12px; }
+    .mb-tool-row .state.ok   { color: #6ee7b7; }
+    .mb-tool-row .state.warn { color: #fde68a; }
+    .mb-tool-row .state.err  { color: #fda4af; }
+
+    /* Dot */
+    .dot {
+      width: 8px; height: 8px;
+      border-radius: 50%;
+    }
+    .dot.ok   { background: #4ade80; box-shadow: 0 0 0 3px rgba(74,222,128,0.2); }
+    .dot.warn { background: #facc15; box-shadow: 0 0 0 3px rgba(250,204,21,0.2); }
+    .dot.err  { background: #f87171; box-shadow: 0 0 0 3px rgba(248,113,113,0.2); }
+    .dot.off  { background: #b8b3c4; }
+
+    /* Stat rows */
+    .mb-stat {
+      display: flex; justify-content: space-between;
+      padding: 4px 14px;
+      color: rgba(255,255,255,0.85);
+      font-size: 12.5px;
+    }
+    .mb-stat .num { font-weight: 700; font-variant-numeric: tabular-nums; }
+
+    /* Action rows */
+    .mb-row {
+      display: flex; align-items: center; gap: 10px;
+      padding: 6px 12px;
+      color: rgba(255,255,255,0.95);
+    }
+    .mb-row.hover {
+      background: rgba(89, 100, 235, 0.85);
+      color: #fff;
+      border-radius: 4px;
+      margin: 0 4px;
+      padding: 6px 8px;
+    }
+    .mb-row .grow { flex: 1; }
+    .mb-row .right { color: rgba(255,255,255,0.65); font-size: 12px; }
+    .mb-row .kbd {
+      font-family: -apple-system, "SF Pro Display", system-ui;
+      font-size: 12px;
+      color: rgba(255,255,255,0.55);
+      letter-spacing: 0.02em;
+    }
+    .mb-icon {
+      width: 16px; height: 16px;
+      color: rgba(255,255,255,0.85);
+      flex: none;
+    }
+
+    /* Healthcheck */
+    .mb-health-row {
+      display: grid;
+      grid-template-columns: 18px 1fr auto;
+      gap: 10px;
+      align-items: center;
+      padding: 6px 14px;
+      color: rgba(255,255,255,0.95);
+    }
+    .mb-health-row .name { font-weight: 500; font-size: 13px; }
+    .mb-health-row .meta { color: rgba(255,255,255,0.7); font-size: 12px; }
+    .mb-health-row .meta.ok   { color: #6ee7b7; }
+    .mb-health-row .meta.warn { color: #fde68a; }
+    .mb-health-row .meta.err  { color: #fda4af; }
+    .mb-health-row .value {
+      font-size: 12px;
+      color: rgba(255,255,255,0.85);
+      font-variant-numeric: tabular-nums;
+    }
+
+    /* ============ Setup-mode controls ============ */
+
+    .mb-steps {
+      display: flex;
+      align-items: center;
+      padding: 6px 14px 10px;
+      font-size: 11px;
+      color: rgba(255,255,255,0.7);
+    }
+    .mb-step { display: flex; align-items: center; gap: 6px; }
+    .mb-step-bullet {
+      width: 18px; height: 18px;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.10);
+      border: 1px solid rgba(255,255,255,0.25);
+      color: rgba(255,255,255,0.75);
+      font-size: 10.5px;
+      font-weight: 700;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .mb-step.done .mb-step-bullet    { background: #4ade80; border-color: #4ade80; color: #0b3d23; }
+    .mb-step.current .mb-step-bullet { background: #818cf8; border-color: #a5b4fc; color: #1f1750; box-shadow: 0 0 0 3px rgba(129,140,248,0.25); }
+    .mb-step.current .mb-step-label  { color: #fff; font-weight: 600; }
+    .mb-step-connector {
+      flex: 1;
+      height: 1px;
+      background: rgba(255,255,255,0.18);
+      margin: 0 6px;
+    }
+    .mb-step.done + .mb-step-connector { background: #4ade80; }
+
+    .mb-field {
+      padding: 6px 14px;
+    }
+    .mb-field-label {
+      display: flex; align-items: center; justify-content: space-between;
+      font-size: 11px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgba(255,255,255,0.6);
+      margin-bottom: 5px;
+      font-weight: 600;
+    }
+    .mb-field-label .hint {
+      text-transform: none;
+      letter-spacing: 0;
+      font-weight: 400;
+      color: rgba(255,255,255,0.5);
+      font-size: 11px;
+    }
+
+    .mb-input-wrap { position: relative; }
+    .mb-input {
+      width: 100%;
+      padding: 7px 10px;
+      font: inherit;
+      font-size: 13px;
+      color: #fff;
+      background: rgba(255,255,255,0.08);
+      border: 1px solid rgba(255,255,255,0.18);
+      border-radius: 7px;
+      outline: none;
+    }
+    .mb-input::placeholder { color: rgba(255,255,255,0.4); }
+    .mb-input:focus {
+      border-color: rgba(129,140,248,0.95);
+      background: rgba(255,255,255,0.12);
+      box-shadow: 0 0 0 3px rgba(129,140,248,0.22);
+    }
+    .mb-input.with-action { padding-right: 70px; }
+    .mb-input-action {
+      position: absolute;
+      right: 4px; top: 50%;
+      transform: translateY(-50%);
+      background: rgba(255,255,255,0.12);
+      color: #fff;
+      border: 0;
+      border-radius: 5px;
+      padding: 4px 10px;
+      font: inherit;
+      font-size: 11.5px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .mb-input-action:hover { background: rgba(255,255,255,0.18); }
+
+    select.mb-input {
+      appearance: none;
+      -webkit-appearance: none;
+      padding-right: 28px;
+      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+      background-repeat: no-repeat;
+      background-position: right 10px center;
+    }
+    select.mb-input option { color: #1c1a23; }
+
+    .mb-field-help {
+      font-size: 11.5px;
+      color: rgba(255,255,255,0.6);
+      margin-top: 5px;
+      line-height: 1.4;
+    }
+    .mb-field-help a { color: #a5b4fc; font-weight: 600; text-decoration: none; }
+    .mb-field-help a:hover { text-decoration: underline; }
+
+    .mb-actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 14px 12px;
+    }
+    .mb-actions .spacer { flex: 1; }
+    .mb-btn {
+      font: inherit;
+      font-size: 12.5px;
+      font-weight: 600;
+      padding: 6px 14px;
+      border-radius: 7px;
+      border: 1px solid rgba(255,255,255,0.18);
+      background: rgba(255,255,255,0.08);
+      color: #fff;
+      cursor: pointer;
+    }
+    .mb-btn:hover { background: rgba(255,255,255,0.14); }
+    .mb-btn.primary {
+      background: #5964eb;
+      border-color: #5964eb;
+    }
+    .mb-btn.primary:hover { background: #4f59d8; }
+    .mb-btn.ghost {
+      background: transparent;
+      border-color: transparent;
+      color: rgba(255,255,255,0.65);
+    }
+    .mb-btn.ghost:hover {
+      background: rgba(255,255,255,0.08);
+      color: #fff;
+    }
+
+    /* ============ Legend ============ */
+
+    .legend-row {
+      display: flex; flex-wrap: wrap; gap: 18px;
+      font-size: 12.5px;
+      color: var(--text-muted);
+      margin-top: 28px;
+    }
+    .legend-row b { color: var(--text); font-weight: 600; }
+
+  </style>
+</head>
+<body>
+
+<div class="board">
+  <div class="board-header">
+    <h1>Bitrise Build Cache — menubar companion</h1>
+    <p>
+      Always-on macOS menubar app for the local Build Cache experience —
+      brainstormed under <a href="https://bitrise.atlassian.net/browse/ACI-4337">ACI-4337</a>.
+      Same dropdown chrome serves both the default running state and in-flow setup wizards.
+      Healthcheck answers P5 ("is it working right now?") at a glance.
+    </p>
+  </div>
+
+  <div class="frames">
+
+    <!-- ============ FRAME 1 — DEFAULT / RUNNING ============ -->
+    <section>
+      <div class="panel-label">Default</div>
+      <h2 class="panel-title">Running — Xcode proxy up, Gradle configured, RN not set up</h2>
+      <p class="panel-desc">
+        Click the menubar glyph and you land here. Healthcheck surfaces CLI version
+        and PAT validity, then tools, then today's local invocation counters, then quick actions.
+      </p>
+
+      <div class="mb-frame">
+        <div class="mb-statusbar">
+          <svg class="apple" viewBox="0 0 170 170" fill="currentColor"><path d="M150.37 130.25c-2.45 5.66-5.35 10.87-8.71 15.66-4.58 6.53-8.33 11.05-11.22 13.56-4.48 4.12-9.28 6.23-14.42 6.35-3.69 0-8.14-1.05-13.32-3.18-5.197-2.12-9.973-3.17-14.34-3.17-4.58 0-9.492 1.05-14.746 3.17-5.262 2.13-9.501 3.24-12.742 3.35-4.929.21-9.842-1.96-14.746-6.52-3.13-2.73-7.045-7.41-11.735-14.04-5.032-7.08-9.169-15.29-12.41-24.65-3.471-10.11-5.211-19.9-5.211-29.378 0-10.857 2.346-20.221 7.045-28.068 3.693-6.303 8.606-11.275 14.755-14.925s12.793-5.51 19.948-5.629c3.915 0 9.049 1.211 15.429 3.591 6.362 2.388 10.443 3.599 12.227 3.599 1.334 0 5.868-1.416 13.55-4.239 7.265-2.618 13.397-3.702 18.444-3.274 13.676 1.104 23.948 6.495 30.781 16.196-12.228 7.41-18.276 17.787-18.156 31.114.11 10.385 3.86 19.024 11.235 25.882 3.34 3.17 7.07 5.62 11.22 7.36-.9 2.61-1.85 5.11-2.86 7.51zM119.11 7.24c0 8.1-2.96 15.66-8.86 22.66-7.12 8.32-15.732 13.13-25.071 12.37-.119-.972-.188-1.995-.188-3.07 0-7.778 3.386-16.1 9.397-22.903 3.002-3.444 6.821-6.31 11.45-8.597 4.619-2.253 8.987-3.498 13.099-3.71.12 1.083.181 2.166.181 3.24 0 .03-.001.04-.001.05z"/></svg>
+          <span class="app-name">Finder</span>
+          <span class="menu-item">File</span>
+          <span class="menu-item">Edit</span>
+          <span class="menu-item">View</span>
+          <span class="menu-item">Go</span>
+          <span class="menu-item">Window</span>
+          <span class="menu-item">Help</span>
+          <span class="spacer"></span>
+          <div class="right-icons">
+            <span class="mb-trigger" title="Bitrise Build Cache — active">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" fill="currentColor" stroke="none"/></svg>
+              <span class="glyph-dot ok"></span>
+            </span>
+            <span>🔋 87%</span>
+            <span>🔍</span>
+            <span class="clock">Thu 21 May 14:32</span>
+          </div>
+        </div>
+
+        <div class="mb-stage">
+
+          <div class="mb-dropdown">
+            <!-- Header -->
+            <div class="mb-header">
+              <div class="badge">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" fill="currentColor" stroke="none"/></svg>
+              </div>
+              <div>
+                <div class="title">Build Cache · Active</div>
+                <div class="sub">Advanced CI · zsolt.marta</div>
+              </div>
+            </div>
+
+            <div class="mb-divider"></div>
+
+            <!-- Healthcheck -->
+            <div class="group">
+              <div class="mb-section-title">
+                Healthcheck
+                <span class="action">Re-run</span>
+              </div>
+              <div class="mb-health-row">
+                <span class="dot ok"></span>
+                <div>
+                  <div class="name">CLI version</div>
+                  <div class="meta ok">1.34.2 · up to date</div>
+                </div>
+              </div>
+              <div class="mb-health-row">
+                <span class="dot ok"></span>
+                <div>
+                  <div class="name">Personal access token</div>
+                  <div class="meta ok">Valid · expires in 42d</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="mb-divider"></div>
+
+            <!-- Tools -->
+            <div class="group">
+              <div class="mb-section-title">Tools</div>
+              <div class="mb-tool-row">
+                <span class="dot ok"></span>
+                <div>
+                  <div class="name">Xcode <span style="opacity:.65; font-weight:500;">(XCC)</span></div>
+                  <div class="state ok">Proxy running · 2h 14m</div>
+                </div>
+                <span class="kbd">⌘1</span>
+              </div>
+              <div class="mb-tool-row">
+                <span class="dot ok"></span>
+                <div>
+                  <div class="name">Gradle</div>
+                  <div class="state ok">Configured · plugin v2.7.4</div>
+                </div>
+                <span class="kbd">⌘2</span>
+              </div>
+              <div class="mb-tool-row">
+                <span class="dot off"></span>
+                <div>
+                  <div class="name" style="opacity:.85;">React Native</div>
+                  <div class="state">Not configured</div>
+                </div>
+                <span class="kbd">⌘3</span>
+              </div>
+            </div>
+
+            <div class="mb-divider"></div>
+
+            <!-- Today on this Mac -->
+            <div class="group">
+              <div class="mb-section-title">Today on this Mac</div>
+              <div class="mb-stat"><span>Invocations</span><span class="num">60</span></div>
+              <div class="mb-stat"><span>Cache hit rate</span><span class="num">71%</span></div>
+              <div class="mb-stat"><span>Time saved</span><span class="num">28m 42s</span></div>
+            </div>
+
+            <div class="mb-divider"></div>
+
+            <!-- Actions -->
+            <div class="group">
+              <div class="mb-row hover">
+                <svg class="mb-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                <span class="grow">Open my local invocations…</span>
+              </div>
+              <div class="mb-row">
+                <svg class="mb-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+                <span class="grow">Check for updates…</span>
+                <span class="right">CLI 1.34.2</span>
+              </div>
+            </div>
+
+            <div class="mb-divider"></div>
+
+            <!-- Preferences / quit -->
+            <div class="group">
+              <div class="mb-row">
+                <svg class="mb-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+                <span class="grow">Preferences…</span>
+                <span class="kbd">⌘,</span>
+              </div>
+              <div class="mb-row">
+                <svg class="mb-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+                <span class="grow">Quit Build Cache</span>
+                <span class="kbd">⌘Q</span>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+
+    <!-- ============ FRAME 2 — SETUP MODE / GRADLE AUTH ============ -->
+    <section>
+      <div class="panel-label">Setup mode</div>
+      <h2 class="panel-title">Set up Gradle — authenticate</h2>
+      <p class="panel-desc">
+        Same dropdown chrome, opened in wizard mode. Step 2 of 4: paste or generate
+        a PAT, pick a workspace, set an optional username override. Token lands in Keychain
+        — no terminal env vars (addresses P2).
+      </p>
+
+      <div class="mb-frame">
+        <div class="mb-statusbar">
+          <svg class="apple" viewBox="0 0 170 170" fill="currentColor"><path d="M150.37 130.25c-2.45 5.66-5.35 10.87-8.71 15.66-4.58 6.53-8.33 11.05-11.22 13.56-4.48 4.12-9.28 6.23-14.42 6.35-3.69 0-8.14-1.05-13.32-3.18-5.197-2.12-9.973-3.17-14.34-3.17-4.58 0-9.492 1.05-14.746 3.17-5.262 2.13-9.501 3.24-12.742 3.35-4.929.21-9.842-1.96-14.746-6.52-3.13-2.73-7.045-7.41-11.735-14.04-5.032-7.08-9.169-15.29-12.41-24.65-3.471-10.11-5.211-19.9-5.211-29.378 0-10.857 2.346-20.221 7.045-28.068 3.693-6.303 8.606-11.275 14.755-14.925s12.793-5.51 19.948-5.629c3.915 0 9.049 1.211 15.429 3.591 6.362 2.388 10.443 3.599 12.227 3.599 1.334 0 5.868-1.416 13.55-4.239 7.265-2.618 13.397-3.702 18.444-3.274 13.676 1.104 23.948 6.495 30.781 16.196-12.228 7.41-18.276 17.787-18.156 31.114.11 10.385 3.86 19.024 11.235 25.882 3.34 3.17 7.07 5.62 11.22 7.36-.9 2.61-1.85 5.11-2.86 7.51zM119.11 7.24c0 8.1-2.96 15.66-8.86 22.66-7.12 8.32-15.732 13.13-25.071 12.37-.119-.972-.188-1.995-.188-3.07 0-7.778 3.386-16.1 9.397-22.903 3.002-3.444 6.821-6.31 11.45-8.597 4.619-2.253 8.987-3.498 13.099-3.71.12 1.083.181 2.166.181 3.24 0 .03-.001.04-.001.05z"/></svg>
+          <span class="app-name">Finder</span>
+          <span class="menu-item">File</span>
+          <span class="menu-item">Edit</span>
+          <span class="menu-item">View</span>
+          <span class="menu-item">Go</span>
+          <span class="menu-item">Window</span>
+          <span class="menu-item">Help</span>
+          <span class="spacer"></span>
+          <div class="right-icons">
+            <span class="mb-trigger" title="Bitrise Build Cache — setup in progress">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" fill="currentColor" stroke="none"/></svg>
+              <span class="glyph-dot warn"></span>
+            </span>
+            <span>🔋 87%</span>
+            <span>🔍</span>
+            <span class="clock">Thu 21 May 14:32</span>
+          </div>
+        </div>
+
+        <div class="mb-stage">
+
+          <div class="mb-dropdown setup">
+            <!-- Header -->
+            <div class="mb-header">
+              <div class="badge gradle">G</div>
+              <div>
+                <div class="title">Set up Gradle</div>
+                <div class="sub">~/work/code/my-android-app</div>
+              </div>
+              <span class="header-action" title="Cancel setup">✕</span>
+            </div>
+
+            <!-- Steps -->
+            <div class="mb-steps">
+              <div class="mb-step done">
+                <div class="mb-step-bullet">✓</div>
+                <div class="mb-step-label">Detect</div>
+              </div>
+              <div class="mb-step-connector"></div>
+              <div class="mb-step current">
+                <div class="mb-step-bullet">2</div>
+                <div class="mb-step-label">Authenticate</div>
+              </div>
+              <div class="mb-step-connector"></div>
+              <div class="mb-step">
+                <div class="mb-step-bullet">3</div>
+                <div class="mb-step-label">Config</div>
+              </div>
+              <div class="mb-step-connector"></div>
+              <div class="mb-step">
+                <div class="mb-step-bullet">4</div>
+                <div class="mb-step-label">Verify</div>
+              </div>
+            </div>
+
+            <div class="mb-divider"></div>
+
+            <!-- PAT input -->
+            <div class="mb-field">
+              <div class="mb-field-label">
+                Personal access token
+                <span class="hint">required</span>
+              </div>
+              <div class="mb-input-wrap">
+                <input class="mb-input with-action" type="password" value="••••••••••••••••••••••••••••" />
+                <button class="mb-input-action">Paste</button>
+              </div>
+              <div class="mb-field-help">
+                Don't have one? <a href="#">Generate on bitrise.io ↗</a> — we'll open the
+                browser and walk you back here. Token stays in your macOS Keychain.
+              </div>
+            </div>
+
+            <!-- Workspace -->
+            <div class="mb-field">
+              <div class="mb-field-label">Workspace</div>
+              <select class="mb-input">
+                <option>Advanced CI · 322a005426441b60</option>
+                <option>Bitrise #Core · 26e1bb55524221dd</option>
+                <option>Bitrise #steps · 864c2feb914c2615</option>
+              </select>
+            </div>
+
+            <!-- Local username -->
+            <div class="mb-field">
+              <div class="mb-field-label">
+                Local username override
+                <span class="hint">optional</span>
+              </div>
+              <input class="mb-input" type="text" value="zsolt.marta" placeholder="zsolt.marta" />
+              <div class="mb-field-help">
+                Tags this Mac's invocations in Insights so you can filter to your own.
+              </div>
+            </div>
+
+            <div class="mb-divider"></div>
+
+            <!-- Healthcheck preview -->
+            <div class="group">
+              <div class="mb-section-title">Healthcheck</div>
+              <div class="mb-health-row">
+                <span class="dot ok"></span>
+                <div>
+                  <div class="name">CLI version</div>
+                  <div class="meta ok">1.34.2 · up to date</div>
+                </div>
+              </div>
+              <div class="mb-health-row">
+                <span class="dot warn"></span>
+                <div>
+                  <div class="name">Personal access token</div>
+                  <div class="meta warn">Pending — enter token to verify</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="mb-divider"></div>
+
+            <!-- Actions -->
+            <div class="mb-actions">
+              <button class="mb-btn ghost">Skip for now</button>
+              <span class="spacer"></span>
+              <button class="mb-btn">Back</button>
+              <button class="mb-btn primary">Continue</button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+  </div>
+
+  <div class="legend-row">
+    <span><b>Green dot</b> — at least one tool active, all healthchecks pass.</span>
+    <span><b>Yellow dot</b> — setup in progress, CLI update available, or PAT expiring soon.</span>
+    <span><b>Red dot</b> — proxy crashed, PAT invalid, or CLI unreachable.</span>
+    <span><b>Hollow dot</b> — paused or signed out.</span>
+  </div>
+</div>
+
+</body>
+</html>

--- a/pkg/reactnative/post_run_deps.go
+++ b/pkg/reactnative/post_run_deps.go
@@ -37,7 +37,7 @@ const MsgRNInvocationSaved = "React Native invocation saved. Visit 👉 %s"
 // session, but RN does not). Callers must only invoke this once the runner
 // has confirmed activation is complete and the workspace slug is set.
 func rnInvocationDetailsURL(workspaceSlug, invocationID string) string {
-	return fmt.Sprintf("https://app.bitrise.io/build-cache/%s/invocations/react-native/%s", workspaceSlug, invocationID)
+	return fmt.Sprintf("https://app-staging.bitrise.io/build-cache/%s/invocations/react-native/%s", workspaceSlug, invocationID)
 }
 
 // postRunDeps handles post-run analytics: invocation reporting, ccache stats

--- a/pkg/reactnative/post_run_deps_test.go
+++ b/pkg/reactnative/post_run_deps_test.go
@@ -11,7 +11,7 @@ import (
 func TestRNInvocationDetailsURL_WithWorkspace(t *testing.T) {
 	got := rnInvocationDetailsURL("ws-slug", "inv-id")
 	assert.Equal(t,
-		"https://app.bitrise.io/build-cache/ws-slug/invocations/react-native/inv-id",
+		"https://app-staging.bitrise.io/build-cache/ws-slug/invocations/react-native/inv-id",
 		got,
 	)
 }


### PR DESCRIPTION
## Summary

Swaps `app.bitrise.io` → `app-staging.bitrise.io` so CLI features (e.g. **benchmark phase** API calls) can be exercised against staging instead of production.

Changed references:
- `internal/consts/consts.go` — `BitriseWebsiteBaseURL` (the benchmark phase API base URL, the main "calls" target)
- `cmd/xcode/xcodebuild.go` — invocation-saved link shown to the user
- `pkg/reactnative/post_run_deps.go` — RN invocation details link
- `internal/config/bazel/bazelrc.gotemplate` — `bes_results_url` in generated bazelrc

Corresponding test assertions updated.

## Notes

⚠️ **Not for merge.** This is a throwaway branch used only to test CLI features against staging. Keep it as a draft.

## Test plan
- `make test-unit` — green
- `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)