### PR TITLE
feat: ACI-5028 store auth credentials in OS keychain

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -1,14 +1,22 @@
 package auth
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
 // nolint:gochecknoglobals
@@ -51,36 +59,236 @@ var authSetCmd = &cobra.Command{
 		}
 
 		logger.TInfof("✅ Credentials saved to the OS keychain")
+
+		switch scrubbed, err := scrubDiskCredentials(); {
+		case err != nil:
+			logger.Warnf("Saved to keychain, but could not strip plain-text credentials from disk: %v", err)
+			logger.Warnf("Run `bitrise-build-cache auth get` to audit remaining sources.")
+		case len(scrubbed) > 0:
+			logger.TInfof("Scrubbed plain-text credentials from %s", strings.Join(scrubbed, ", "))
+		}
+
 		logger.Infof("You can now remove BITRISE_BUILD_CACHE_AUTH_TOKEN + BITRISE_BUILD_CACHE_WORKSPACE_ID from your shell rc files.")
+		logger.Infof("If you have running Gradle daemons, stop them so the new token is picked up: `./gradlew --stop`.")
 
 		return nil
 	},
 }
 
+func scrubDiskCredentials() ([]string, error) {
+	osProxy := utils.DefaultOsProxy{}
+
+	cfg, err := multiplatformconfig.ReadConfig(osProxy, utils.DefaultDecoderFactory{})
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return nil, nil
+	case err != nil:
+		return nil, fmt.Errorf("read multiplatform config: %w", err)
+	}
+
+	if cfg.AuthConfig.AuthToken == "" && cfg.AuthConfig.WorkspaceID == "" {
+		return nil, nil
+	}
+
+	cfg.AuthConfig = configcommon.CacheAuthConfig{}
+	if err := cfg.Save(osProxy, utils.DefaultEncoderFactory{}); err != nil {
+		return nil, fmt.Errorf("save scrubbed multiplatform config: %w", err)
+	}
+
+	return []string{"~/.bitrise/analytics/multiplatform/config.json"}, nil
+}
+
 // nolint:gochecknoglobals
 var authGetCmd = &cobra.Command{
 	Use:          "get",
-	Short:        "Show whether Bitrise Build Cache credentials are stored in the OS keychain",
+	Short:        "Show Bitrise Build Cache credentials discovered across all known sources",
+	Long:         "Lists credentials found in the OS keychain, the multiplatform analytics config on disk, and the BITRISE_BUILD_CACHE_AUTH_TOKEN / BITRISE_BUILD_CACHE_WORKSPACE_ID / BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN env vars. Use this to audit where your credentials live and to migrate them to the OS keychain.",
 	SilenceUsage: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
-		creds, err := keychain.New().Load()
-		switch {
-		case errors.Is(err, keychain.ErrNotFound):
-			logger.Warnf("No Bitrise Build Cache credentials stored in the OS keychain.")
-			logger.Infof("Run `bitrise-build-cache auth set --token <token> --workspace-id <id>` to store them, or rely on env vars.")
+		sources := credSources(utils.AllEnvs())
 
-			return nil
-		case err != nil:
-			return fmt.Errorf("read credentials from keychain: %w", err)
+		var keychainPopulated, foundElsewhere bool
+		for i, s := range sources {
+			populated := printSource(logger, s)
+			switch {
+			case i == 0:
+				keychainPopulated = populated
+			case populated:
+				foundElsewhere = true
+			}
 		}
 
-		logger.TInfof("Workspace ID: %s", creds.WorkspaceID)
-		logger.TInfof("Auth token:   %s", maskToken(creds.AuthToken))
+		if !keychainPopulated && foundElsewhere {
+			logger.Println()
+			logger.Infof("Credentials exist outside the OS keychain — migrate with:")
+			logger.Infof("  bitrise-build-cache auth set --token <token> --workspace-id <workspace-id>")
+			logger.Infof("`auth set` scrubs the multiplatform config in place; xcelerate and ccache configs are re-written cleanly on the next `activate xcode` / `activate c++`.")
+		}
 
 		return nil
 	},
+}
+
+type credSourceState int
+
+const (
+	sourceAbsent credSourceState = iota
+	sourcePartial
+	sourceReadError
+	sourcePopulated
+	sourcePopulatedTokenOnly
+)
+
+type credAudit struct {
+	state       credSourceState
+	workspaceID string
+	authToken   string
+	note        string
+	err         error
+}
+
+type credSource struct {
+	label    string
+	location string
+	probe    func() credAudit
+}
+
+// First entry MUST be the keychain — RunE treats sources[0] as the target.
+func credSources(envs map[string]string) []credSource {
+	return []credSource{
+		{"OS keychain", "<system keychain>", probeKeychain},
+		{"Multiplatform config", "~/.bitrise/analytics/multiplatform/config.json", probeMultiplatform},
+		{"Xcelerate config", "~/.bitrise-xcelerate/config.json", probeRawConfig("~/.bitrise-xcelerate/config.json")},
+		{"Ccache config", "~/.bitrise/cache/ccache/config.json", probeRawConfig("~/.bitrise/cache/ccache/config.json")},
+		{"Env vars (BITRISE_BUILD_CACHE_AUTH_TOKEN + BITRISE_BUILD_CACHE_WORKSPACE_ID)", "process env", func() credAudit { return probeEnvVars(envs) }},
+		{"CI JWT (BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN)", "process env", func() credAudit { return probeJWT(envs) }},
+	}
+}
+
+func printSource(logger log.Logger, s credSource) bool {
+	if s.location != "" {
+		logger.TInfof("%s (%s):", s.label, s.location)
+	} else {
+		logger.TInfof("%s:", s.label)
+	}
+
+	a := s.probe()
+	switch a.state {
+	case sourceAbsent:
+		if a.note != "" {
+			logger.Infof("  %s", a.note)
+		} else {
+			logger.Infof("  not configured")
+		}
+
+		return false
+	case sourcePartial:
+		logger.Warnf("  partial: %s", a.note)
+
+		return false
+	case sourceReadError:
+		logger.Errorf("  read failed: %v", a.err)
+
+		return false
+	case sourcePopulated:
+		logger.Infof("  Workspace ID: %s", a.workspaceID)
+		logger.Infof("  Auth token:   %s", maskToken(a.authToken))
+
+		return true
+	case sourcePopulatedTokenOnly:
+		logger.Infof("  set (%s)", maskToken(a.authToken))
+
+		return true
+	}
+
+	return false
+}
+
+func probeKeychain() credAudit {
+	creds, err := keychain.New().Load()
+	switch {
+	case errors.Is(err, keychain.ErrNotFound):
+		return credAudit{state: sourceAbsent}
+	case err != nil:
+		return credAudit{state: sourceReadError, err: err}
+	}
+
+	return credAudit{state: sourcePopulated, workspaceID: creds.WorkspaceID, authToken: creds.AuthToken}
+}
+
+func probeMultiplatform() credAudit {
+	cfg, err := multiplatformconfig.ReadConfig(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return credAudit{state: sourceAbsent, note: "not present"}
+	case err != nil:
+		return credAudit{state: sourceReadError, err: err}
+	case cfg.AuthConfig.AuthToken == "":
+		return credAudit{state: sourceAbsent, note: "present but no credentials"}
+	}
+
+	return credAudit{state: sourcePopulated, workspaceID: cfg.AuthConfig.WorkspaceID, authToken: cfg.AuthConfig.AuthToken}
+}
+
+// probeRawConfig reads the file directly — the per-tool ReadConfig overlays multiplatform credentials, which would mask the actual on-disk content this audit needs to see.
+func probeRawConfig(displayPath string) func() credAudit {
+	return func() credAudit {
+		home, err := utils.DefaultOsProxy{}.UserHomeDir()
+		if err != nil {
+			return credAudit{state: sourceReadError, err: fmt.Errorf("resolve home dir: %w", err)}
+		}
+
+		fullPath := filepath.Join(home, strings.TrimPrefix(displayPath, "~/"))
+
+		body, err := os.ReadFile(fullPath) //nolint:gosec // path composed from home + constant
+		switch {
+		case errors.Is(err, fs.ErrNotExist):
+			return credAudit{state: sourceAbsent, note: "not present"}
+		case err != nil:
+			return credAudit{state: sourceReadError, err: err}
+		}
+
+		var raw struct {
+			AuthConfig struct {
+				AuthToken   string `json:"authToken"`
+				WorkspaceID string `json:"workspaceID"`
+			} `json:"authConfig"`
+		}
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return credAudit{state: sourceReadError, err: fmt.Errorf("decode: %w", err)}
+		}
+
+		if raw.AuthConfig.AuthToken == "" {
+			return credAudit{state: sourceAbsent, note: "present but no embedded credentials"}
+		}
+
+		return credAudit{state: sourcePopulated, workspaceID: raw.AuthConfig.WorkspaceID, authToken: raw.AuthConfig.AuthToken}
+	}
+}
+
+func probeEnvVars(envs map[string]string) credAudit {
+	tok := envs["BITRISE_BUILD_CACHE_AUTH_TOKEN"]
+	ws := envs["BITRISE_BUILD_CACHE_WORKSPACE_ID"]
+
+	switch {
+	case tok != "" && ws != "":
+		return credAudit{state: sourcePopulated, workspaceID: ws, authToken: tok}
+	case tok != "" || ws != "":
+		return credAudit{state: sourcePartial, note: "only one of AUTH_TOKEN / WORKSPACE_ID is set"}
+	}
+
+	return credAudit{state: sourceAbsent, note: "not set"}
+}
+
+func probeJWT(envs map[string]string) credAudit {
+	jwt := envs["BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN"]
+	if jwt == "" {
+		return credAudit{state: sourceAbsent, note: "not set"}
+	}
+
+	return credAudit{state: sourcePopulatedTokenOnly, authToken: jwt}
 }
 
 // nolint:gochecknoglobals
@@ -96,6 +304,29 @@ var authClearCmd = &cobra.Command{
 		}
 
 		logger.TInfof("✅ Credentials removed from the OS keychain")
+
+		return nil
+	},
+}
+
+// nolint:gochecknoglobals
+var authTokenCmd = &cobra.Command{
+	Use:           "token",
+	Short:         "Resolve and print the Bitrise Build Cache auth token to stdout",
+	Long:          "Resolves the auth token via the same precedence chain as the rest of the CLI (env vars → OS keychain → multiplatform analytics config) and prints it to stdout. Intended for build-time consumers (Gradle init script, future Bazel workspace_status_command) that need the resolved token without baking it into a config file. On failure exits non-zero with a short one-line message on stderr (no cobra Error: prefix) — callers framing the wrapper script own the wording.",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cfg, err := configcommon.ResolveAuthConfig(utils.AllEnvs())
+		if err != nil {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+
+			return fmt.Errorf("resolve auth config: %w", err)
+		}
+
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), cfg.AuthToken); err != nil {
+			return fmt.Errorf("write auth token: %w", err)
+		}
 
 		return nil
 	},
@@ -119,6 +350,7 @@ func init() {
 	authCmd.AddCommand(authSetCmd)
 	authCmd.AddCommand(authGetCmd)
 	authCmd.AddCommand(authClearCmd)
+	authCmd.AddCommand(authTokenCmd)
 
 	common.RootCmd.AddCommand(authCmd)
 }

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -15,7 +15,7 @@ import (
 var authCmd = &cobra.Command{
 	Use:          "auth",
 	Short:        "Manage Bitrise Build Cache credentials stored in the OS keychain",
-	Long:         `Manage Bitrise Build Cache credentials stored in the OS keychain (macOS Keychain, Linux secret-service). Credentials persisted here are used in preference to the BITRISE_BUILD_CACHE_AUTH_TOKEN / BITRISE_BUILD_CACHE_WORKSPACE_ID env vars.`,
+	Long:         `Manage Bitrise Build Cache credentials stored in the OS keychain (macOS Keychain, Linux secret-service). Stored credentials are used when BITRISE_BUILD_CACHE_AUTH_TOKEN / BITRISE_BUILD_CACHE_WORKSPACE_ID (or BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN on Bitrise CI) are not set — env vars take precedence so you can override the stored credentials for a single run.`,
 	SilenceUsage: true,
 }
 
@@ -32,6 +32,15 @@ var authSetCmd = &cobra.Command{
 	SilenceUsage: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+
+		switch {
+		case setToken == "" && setWorkspaceID == "":
+			return errors.New("--token and --workspace-id are required and must not be empty")
+		case setToken == "":
+			return errors.New("--token is required and must not be empty")
+		case setWorkspaceID == "":
+			return errors.New("--workspace-id is required and must not be empty")
+		}
 
 		kc := keychain.New()
 		if err := kc.Save(keychain.Credentials{
@@ -57,14 +66,13 @@ var authGetCmd = &cobra.Command{
 		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
 		creds, err := keychain.New().Load()
-		if err != nil {
-			if errors.Is(err, keychain.ErrNotFound) {
-				logger.Warnf("No Bitrise Build Cache credentials stored in the OS keychain.")
-				logger.Infof("Run `bitrise-build-cache auth set --token <token> --workspace-id <id>` to store them, or rely on env vars.")
+		switch {
+		case errors.Is(err, keychain.ErrNotFound):
+			logger.Warnf("No Bitrise Build Cache credentials stored in the OS keychain.")
+			logger.Infof("Run `bitrise-build-cache auth set --token <token> --workspace-id <id>` to store them, or rely on env vars.")
 
-				return nil
-			}
-
+			return nil
+		case err != nil:
 			return fmt.Errorf("read credentials from keychain: %w", err)
 		}
 

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -72,10 +72,15 @@ var authSetCmd = &cobra.Command{
 			logger.Warnf("Saved to keychain, but could not strip plain-text credentials from disk: %v", err)
 			logger.Warnf("Run `bitrise-build-cache auth list` to audit remaining sources.")
 		case len(scrubbed) > 0:
-			logger.TInfof("Scrubbed plain-text credentials from %s", strings.Join(scrubbed, ", "))
-			for _, p := range scrubbed {
-				if hint, ok := reactivateHints[p]; ok {
-					logger.Infof("  → %s", hint)
+			scrubbedPaths := make([]string, len(scrubbed))
+			for i, item := range scrubbed {
+				scrubbedPaths[i] = item.path
+			}
+
+			logger.TInfof("Scrubbed plain-text credentials from %s", strings.Join(scrubbedPaths, ", "))
+			for _, item := range scrubbed {
+				if item.hint != "" {
+					logger.Infof("  → %s", item.hint)
 				}
 			}
 		}
@@ -87,58 +92,73 @@ var authSetCmd = &cobra.Command{
 	},
 }
 
-func scrubDiskCredentials() ([]string, error) {
+// scrubbedItem pairs a scrubbed file path with the reactivate command the user
+// should run to regenerate a clean config (empty hint = no follow-up needed).
+type scrubbedItem struct {
+	path string
+	hint string
+}
+
+func scrubDiskCredentials() ([]scrubbedItem, error) {
 	osProxy := utils.DefaultOsProxy{}
 
-	var scrubbed []string
+	var scrubbed []scrubbedItem
 
-	if path, err := scrubMultiplatform(osProxy); err != nil {
-		return scrubbed, err
-	} else if path != "" {
-		scrubbed = append(scrubbed, path)
-	}
-
-	for _, fullPath := range []string{
-		xceleratconfig.ConfigFile(osProxy),
-		ccacheconfig.ConfigFile(osProxy),
+	for _, scrub := range []func(utils.OsProxy) (scrubbedItem, error){
+		scrubMultiplatform,
+		scrubXcelerate,
+		scrubCcache,
+		scrubGradleInitKts,
 	} {
-		path, err := scrubRawConfigAuthToken(osProxy, fullPath)
+		item, err := scrub(osProxy)
 		if err != nil {
 			return scrubbed, err
 		}
-		if path != "" {
-			scrubbed = append(scrubbed, path)
+		if item.path != "" {
+			scrubbed = append(scrubbed, item)
 		}
-	}
-
-	if path, err := scrubGradleInitKts(osProxy); err != nil {
-		return scrubbed, err
-	} else if path != "" {
-		scrubbed = append(scrubbed, path)
 	}
 
 	return scrubbed, nil
 }
 
-func scrubMultiplatform(osProxy utils.OsProxy) (string, error) {
+func scrubMultiplatform(osProxy utils.OsProxy) (scrubbedItem, error) {
 	cfg, err := multiplatformconfig.ReadConfig(osProxy, utils.DefaultDecoderFactory{})
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
-		return "", nil
+		return scrubbedItem{}, nil
 	case err != nil:
-		return "", fmt.Errorf("read multiplatform config: %w", err)
+		return scrubbedItem{}, fmt.Errorf("read multiplatform config: %w", err)
 	}
 
 	if cfg.AuthConfig.AuthToken == "" && cfg.AuthConfig.WorkspaceID == "" {
-		return "", nil
+		return scrubbedItem{}, nil
 	}
 
 	cfg.AuthConfig = configcommon.CacheAuthConfig{}
 	if err := cfg.Save(osProxy, utils.DefaultEncoderFactory{}); err != nil {
-		return "", fmt.Errorf("save scrubbed multiplatform config: %w", err)
+		return scrubbedItem{}, fmt.Errorf("save scrubbed multiplatform config: %w", err)
 	}
 
-	return displayHomePath(osProxy, multiplatformconfig.FilePath(osProxy)), nil
+	return scrubbedItem{path: displayHomePath(osProxy, multiplatformconfig.FilePath(osProxy))}, nil
+}
+
+func scrubXcelerate(osProxy utils.OsProxy) (scrubbedItem, error) {
+	path, err := scrubRawConfigAuthToken(osProxy, xceleratconfig.ConfigFile(osProxy))
+	if err != nil || path == "" {
+		return scrubbedItem{}, err
+	}
+
+	return scrubbedItem{path: path, hint: "Run `bitrise-build-cache activate xcode` to regenerate a clean config"}, nil
+}
+
+func scrubCcache(osProxy utils.OsProxy) (scrubbedItem, error) {
+	path, err := scrubRawConfigAuthToken(osProxy, ccacheconfig.ConfigFile(osProxy))
+	if err != nil || path == "" {
+		return scrubbedItem{}, err
+	}
+
+	return scrubbedItem{path: path, hint: "Run `bitrise-build-cache activate c++` to regenerate a clean config"}, nil
 }
 
 // Legacy files from older CLI versions still carry authConfig on disk; current activate path no longer writes it.
@@ -189,10 +209,10 @@ func scrubRawConfigAuthToken(osProxy utils.OsProxy, fullPath string) (string, er
 }
 
 // Older templates and CI activates bake the token as a literal in init.kts; ValueSource activates leave nothing to scrub.
-func scrubGradleInitKts(osProxy utils.OsProxy) (string, error) {
+func scrubGradleInitKts(osProxy utils.OsProxy) (scrubbedItem, error) {
 	home, err := osProxy.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("resolve home dir: %w", err)
+		return scrubbedItem{}, fmt.Errorf("resolve home dir: %w", err)
 	}
 
 	fullPath := paths.FromHome(home).GradleInitScriptFile()
@@ -200,9 +220,9 @@ func scrubGradleInitKts(osProxy utils.OsProxy) (string, error) {
 	body, err := os.ReadFile(fullPath) //nolint:gosec // path composed via the typed paths helpers
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
-		return "", nil
+		return scrubbedItem{}, nil
 	case err != nil:
-		return "", fmt.Errorf("read gradle init.kts: %w", err)
+		return scrubbedItem{}, fmt.Errorf("read gradle init.kts: %w", err)
 	}
 
 	scrubbed := authTokenLiteralRE.ReplaceAllStringFunc(string(body), func(match string) string {
@@ -210,14 +230,17 @@ func scrubGradleInitKts(osProxy utils.OsProxy) (string, error) {
 	})
 
 	if scrubbed == string(body) {
-		return "", nil
+		return scrubbedItem{}, nil
 	}
 
 	if err := os.WriteFile(fullPath, []byte(scrubbed), 0o600); err != nil {
-		return "", fmt.Errorf("write scrubbed gradle init.kts: %w", err)
+		return scrubbedItem{}, fmt.Errorf("write scrubbed gradle init.kts: %w", err)
 	}
 
-	return displayHomePath(osProxy, fullPath), nil
+	return scrubbedItem{
+		path: displayHomePath(osProxy, fullPath),
+		hint: "Run `bitrise-build-cache activate gradle` to regenerate the init script with the ValueSource resolver",
+	}, nil
 }
 
 // displayHomePath returns the absolute path with the user's home dir replaced by `~`.
@@ -239,12 +262,6 @@ func displayHomePath(osProxy utils.OsProxy, full string) string {
 var (
 	authTokenLiteralRE = regexp.MustCompile(`authToken(?:\s*=\s*|\.set\()"[^"]+"`)
 	quotedStringRE     = regexp.MustCompile(`"[^"]+"`)
-
-	reactivateHints = map[string]string{
-		"~/.bitrise-xcelerate/config.json":                     "Run `bitrise-build-cache activate xcode` to regenerate a clean config",
-		"~/.bitrise/cache/ccache/config.json":                  "Run `bitrise-build-cache activate c++` to regenerate a clean config",
-		"~/.gradle/init.d/bitrise-build-cache.init.gradle.kts": "Run `bitrise-build-cache activate gradle` to regenerate the init script with the ValueSource resolver",
-	}
 )
 
 // nolint:gochecknoglobals

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -66,9 +67,14 @@ var authSetCmd = &cobra.Command{
 		switch scrubbed, err := scrubDiskCredentials(); {
 		case err != nil:
 			logger.Warnf("Saved to keychain, but could not strip plain-text credentials from disk: %v", err)
-			logger.Warnf("Run `bitrise-build-cache auth get` to audit remaining sources.")
+			logger.Warnf("Run `bitrise-build-cache auth list` to audit remaining sources.")
 		case len(scrubbed) > 0:
 			logger.TInfof("Scrubbed plain-text credentials from %s", strings.Join(scrubbed, ", "))
+			for _, p := range scrubbed {
+				if hint, ok := reactivateHints[p]; ok {
+					logger.Infof("  → %s", hint)
+				}
+			}
 		}
 
 		logger.Infof("You can now remove BITRISE_BUILD_CACHE_AUTH_TOKEN + BITRISE_BUILD_CACHE_WORKSPACE_ID from your shell rc files.")
@@ -81,44 +87,170 @@ var authSetCmd = &cobra.Command{
 func scrubDiskCredentials() ([]string, error) {
 	osProxy := utils.DefaultOsProxy{}
 
+	var scrubbed []string
+
+	if path, err := scrubMultiplatform(osProxy); err != nil {
+		return scrubbed, err
+	} else if path != "" {
+		scrubbed = append(scrubbed, path)
+	}
+
+	for _, displayPath := range []string{
+		"~/.bitrise-xcelerate/config.json",
+		"~/.bitrise/cache/ccache/config.json",
+	} {
+		path, err := scrubRawConfigAuthToken(osProxy, displayPath)
+		if err != nil {
+			return scrubbed, err
+		}
+		if path != "" {
+			scrubbed = append(scrubbed, path)
+		}
+	}
+
+	if path, err := scrubGradleInitKts(osProxy); err != nil {
+		return scrubbed, err
+	} else if path != "" {
+		scrubbed = append(scrubbed, path)
+	}
+
+	return scrubbed, nil
+}
+
+func scrubMultiplatform(osProxy utils.OsProxy) (string, error) {
 	cfg, err := multiplatformconfig.ReadConfig(osProxy, utils.DefaultDecoderFactory{})
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
-		return nil, nil
+		return "", nil
 	case err != nil:
-		return nil, fmt.Errorf("read multiplatform config: %w", err)
+		return "", fmt.Errorf("read multiplatform config: %w", err)
 	}
 
 	if cfg.AuthConfig.AuthToken == "" && cfg.AuthConfig.WorkspaceID == "" {
-		return nil, nil
+		return "", nil
 	}
 
 	cfg.AuthConfig = configcommon.CacheAuthConfig{}
 	if err := cfg.Save(osProxy, utils.DefaultEncoderFactory{}); err != nil {
-		return nil, fmt.Errorf("save scrubbed multiplatform config: %w", err)
+		return "", fmt.Errorf("save scrubbed multiplatform config: %w", err)
 	}
 
-	return []string{"~/.bitrise/analytics/multiplatform/config.json"}, nil
+	return "~/.bitrise/analytics/multiplatform/config.json", nil
 }
 
+// Legacy files from older CLI versions still carry authConfig on disk; current activate path no longer writes it.
+func scrubRawConfigAuthToken(osProxy utils.OsProxy, displayPath string) (string, error) {
+	home, err := osProxy.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+
+	fullPath := filepath.Join(home, strings.TrimPrefix(displayPath, "~/"))
+
+	body, err := os.ReadFile(fullPath) //nolint:gosec // path composed from home + constant
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return "", nil
+	case err != nil:
+		return "", fmt.Errorf("read %s: %w", displayPath, err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return "", fmt.Errorf("decode %s: %w", displayPath, err)
+	}
+
+	ac, hasAuth := raw["authConfig"]
+	if !hasAuth {
+		return "", nil
+	}
+
+	var auth struct {
+		AuthToken   string `json:"authToken"`
+		WorkspaceID string `json:"workspaceID"`
+	}
+	if err := json.Unmarshal(ac, &auth); err != nil {
+		return "", fmt.Errorf("decode authConfig in %s: %w", displayPath, err)
+	}
+	if auth.AuthToken == "" && auth.WorkspaceID == "" {
+		return "", nil
+	}
+
+	delete(raw, "authConfig")
+
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("re-encode %s: %w", displayPath, err)
+	}
+
+	if err := os.WriteFile(fullPath, append(out, '\n'), 0o600); err != nil {
+		return "", fmt.Errorf("write scrubbed %s: %w", displayPath, err)
+	}
+
+	return displayPath, nil
+}
+
+// Older templates and CI activates bake the token as a literal in init.kts; ValueSource activates leave nothing to scrub.
+func scrubGradleInitKts(osProxy utils.OsProxy) (string, error) {
+	home, err := osProxy.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+
+	const relPath = ".gradle/init.d/bitrise-build-cache.init.gradle.kts"
+	fullPath := filepath.Join(home, relPath)
+
+	body, err := os.ReadFile(fullPath) //nolint:gosec // path composed from home + constant
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return "", nil
+	case err != nil:
+		return "", fmt.Errorf("read gradle init.kts: %w", err)
+	}
+
+	scrubbed := authTokenLiteralRE.ReplaceAllStringFunc(string(body), func(match string) string {
+		return quotedStringRE.ReplaceAllString(match, `""`)
+	})
+
+	if scrubbed == string(body) {
+		return "", nil
+	}
+
+	if err := os.WriteFile(fullPath, []byte(scrubbed), 0o600); err != nil {
+		return "", fmt.Errorf("write scrubbed gradle init.kts: %w", err)
+	}
+
+	return "~/" + relPath, nil
+}
+
+//nolint:gochecknoglobals
+var (
+	authTokenLiteralRE = regexp.MustCompile(`authToken(?:\s*=\s*|\.set\()"[^"]+"`)
+	quotedStringRE     = regexp.MustCompile(`"[^"]+"`)
+
+	reactivateHints = map[string]string{
+		"~/.bitrise-xcelerate/config.json":                     "Run `bitrise-build-cache activate xcode` to regenerate a clean config",
+		"~/.bitrise/cache/ccache/config.json":                  "Run `bitrise-build-cache activate c++` to regenerate a clean config",
+		"~/.gradle/init.d/bitrise-build-cache.init.gradle.kts": "Run `bitrise-build-cache activate gradle` to regenerate the init script with the ValueSource resolver",
+	}
+)
+
 // nolint:gochecknoglobals
-var authGetCmd = &cobra.Command{
-	Use:          "get",
+var authListCmd = &cobra.Command{
+	Use:          "list",
 	Short:        "Show Bitrise Build Cache credentials discovered across all known sources",
 	Long:         "Lists credentials found in the OS keychain, the multiplatform analytics config on disk, and the BITRISE_BUILD_CACHE_AUTH_TOKEN / BITRISE_BUILD_CACHE_WORKSPACE_ID / BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN env vars. Use this to audit where your credentials live and to migrate them to the OS keychain.",
 	SilenceUsage: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
-		sources := credSources(utils.AllEnvs())
+		target, migrationSources := credSources(utils.AllEnvs())
 
-		var keychainPopulated, foundElsewhere bool
-		for i, s := range sources {
-			populated := printSource(logger, s)
-			switch {
-			case i == 0:
-				keychainPopulated = populated
-			case populated:
+		keychainPopulated := printSource(logger, target)
+
+		var foundElsewhere bool
+		for _, s := range migrationSources {
+			if printSource(logger, s) {
 				foundElsewhere = true
 			}
 		}
@@ -158,16 +290,19 @@ type credSource struct {
 	probe    func() credAudit
 }
 
-// First entry MUST be the keychain — RunE treats sources[0] as the target.
-func credSources(envs map[string]string) []credSource {
-	return []credSource{
-		{"OS keychain", "<system keychain>", probeKeychain},
+// Returns (target, migrationSources). The target is the canonical home for credentials (OS keychain);
+// migrationSources are inspected to nudge the user toward `auth set` when creds live elsewhere.
+func credSources(envs map[string]string) (credSource, []credSource) {
+	target := credSource{"OS keychain", "<system keychain>", probeKeychain}
+	migrationSources := []credSource{
 		{"Multiplatform config", "~/.bitrise/analytics/multiplatform/config.json", probeMultiplatform},
 		{"Xcelerate config", "~/.bitrise-xcelerate/config.json", probeRawConfig("~/.bitrise-xcelerate/config.json")},
 		{"Ccache config", "~/.bitrise/cache/ccache/config.json", probeRawConfig("~/.bitrise/cache/ccache/config.json")},
 		{"Env vars (BITRISE_BUILD_CACHE_AUTH_TOKEN + BITRISE_BUILD_CACHE_WORKSPACE_ID)", "process env", func() credAudit { return probeEnvVars(envs) }},
 		{"CI JWT (BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN)", "process env", func() credAudit { return probeJWT(envs) }},
 	}
+
+	return target, migrationSources
 }
 
 func printSource(logger log.Logger, s credSource) bool {
@@ -351,7 +486,7 @@ func init() {
 	_ = authSetCmd.MarkFlagRequired("workspace-id")
 
 	authCmd.AddCommand(authSetCmd)
-	authCmd.AddCommand(authGetCmd)
+	authCmd.AddCommand(authListCmd)
 	authCmd.AddCommand(authClearCmd)
 	authCmd.AddCommand(authTokenCmd)
 

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -15,8 +15,11 @@ import (
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
+	xceleratconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
@@ -95,11 +98,11 @@ func scrubDiskCredentials() ([]string, error) {
 		scrubbed = append(scrubbed, path)
 	}
 
-	for _, displayPath := range []string{
-		"~/.bitrise-xcelerate/config.json",
-		"~/.bitrise/cache/ccache/config.json",
+	for _, fullPath := range []string{
+		xceleratconfig.ConfigFile(osProxy),
+		ccacheconfig.ConfigFile(osProxy),
 	} {
-		path, err := scrubRawConfigAuthToken(osProxy, displayPath)
+		path, err := scrubRawConfigAuthToken(osProxy, fullPath)
 		if err != nil {
 			return scrubbed, err
 		}
@@ -135,19 +138,14 @@ func scrubMultiplatform(osProxy utils.OsProxy) (string, error) {
 		return "", fmt.Errorf("save scrubbed multiplatform config: %w", err)
 	}
 
-	return "~/.bitrise/analytics/multiplatform/config.json", nil
+	return displayHomePath(osProxy, multiplatformconfig.FilePath(osProxy)), nil
 }
 
 // Legacy files from older CLI versions still carry authConfig on disk; current activate path no longer writes it.
-func scrubRawConfigAuthToken(osProxy utils.OsProxy, displayPath string) (string, error) {
-	home, err := osProxy.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve home dir: %w", err)
-	}
+func scrubRawConfigAuthToken(osProxy utils.OsProxy, fullPath string) (string, error) {
+	displayPath := displayHomePath(osProxy, fullPath)
 
-	fullPath := filepath.Join(home, strings.TrimPrefix(displayPath, "~/"))
-
-	body, err := os.ReadFile(fullPath) //nolint:gosec // path composed from home + constant
+	body, err := os.ReadFile(fullPath) //nolint:gosec // path composed via the typed paths helpers
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
 		return "", nil
@@ -197,10 +195,9 @@ func scrubGradleInitKts(osProxy utils.OsProxy) (string, error) {
 		return "", fmt.Errorf("resolve home dir: %w", err)
 	}
 
-	const relPath = ".gradle/init.d/bitrise-build-cache.init.gradle.kts"
-	fullPath := filepath.Join(home, relPath)
+	fullPath := paths.FromHome(home).GradleInitScriptFile()
 
-	body, err := os.ReadFile(fullPath) //nolint:gosec // path composed from home + constant
+	body, err := os.ReadFile(fullPath) //nolint:gosec // path composed via the typed paths helpers
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
 		return "", nil
@@ -220,7 +217,22 @@ func scrubGradleInitKts(osProxy utils.OsProxy) (string, error) {
 		return "", fmt.Errorf("write scrubbed gradle init.kts: %w", err)
 	}
 
-	return "~/" + relPath, nil
+	return displayHomePath(osProxy, fullPath), nil
+}
+
+// displayHomePath returns the absolute path with the user's home dir replaced by `~`.
+func displayHomePath(osProxy utils.OsProxy, full string) string {
+	home, err := osProxy.UserHomeDir()
+	if err != nil {
+		return full
+	}
+
+	rel, err := filepath.Rel(home, full)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return full
+	}
+
+	return "~/" + filepath.ToSlash(rel)
 }
 
 //nolint:gochecknoglobals
@@ -246,13 +258,23 @@ var authListCmd = &cobra.Command{
 
 		target, migrationSources := credSources(utils.AllEnvs())
 
-		keychainPopulated := printSource(logger, target)
+		keychainPopulated := renderSource(logger, target, target.probe())
 
-		var foundElsewhere bool
+		var foundElsewhere, suppressed bool
 		for _, s := range migrationSources {
-			if printSource(logger, s) {
+			audit := s.probe()
+			if audit.state == sourceAbsent && !common.IsDebugLogMode {
+				suppressed = true
+
+				continue
+			}
+			if renderSource(logger, s, audit) {
 				foundElsewhere = true
 			}
+		}
+
+		if suppressed {
+			logger.Infof("(absent sources hidden — re-run with --debug to see the full audit)")
 		}
 
 		if !keychainPopulated && foundElsewhere {
@@ -293,11 +315,17 @@ type credSource struct {
 // Returns (target, migrationSources). The target is the canonical home for credentials (OS keychain);
 // migrationSources are inspected to nudge the user toward `auth set` when creds live elsewhere.
 func credSources(envs map[string]string) (credSource, []credSource) {
+	osProxy := utils.DefaultOsProxy{}
+
+	xcelerateConfigPath := xceleratconfig.ConfigFile(osProxy)
+	ccacheConfigPath := ccacheconfig.ConfigFile(osProxy)
+	multiplatformConfigPath := multiplatformconfig.FilePath(osProxy)
+
 	target := credSource{"OS keychain", "<system keychain>", probeKeychain}
 	migrationSources := []credSource{
-		{"Multiplatform config", "~/.bitrise/analytics/multiplatform/config.json", probeMultiplatform},
-		{"Xcelerate config", "~/.bitrise-xcelerate/config.json", probeRawConfig("~/.bitrise-xcelerate/config.json")},
-		{"Ccache config", "~/.bitrise/cache/ccache/config.json", probeRawConfig("~/.bitrise/cache/ccache/config.json")},
+		{"Multiplatform config", displayHomePath(osProxy, multiplatformConfigPath), probeMultiplatform},
+		{"Xcelerate config", displayHomePath(osProxy, xcelerateConfigPath), probeRawConfig(xcelerateConfigPath)},
+		{"Ccache config", displayHomePath(osProxy, ccacheConfigPath), probeRawConfig(ccacheConfigPath)},
 		{"Env vars (BITRISE_BUILD_CACHE_AUTH_TOKEN + BITRISE_BUILD_CACHE_WORKSPACE_ID)", "process env", func() credAudit { return probeEnvVars(envs) }},
 		{"CI JWT (BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN)", "process env", func() credAudit { return probeJWT(envs) }},
 	}
@@ -305,14 +333,13 @@ func credSources(envs map[string]string) (credSource, []credSource) {
 	return target, migrationSources
 }
 
-func printSource(logger log.Logger, s credSource) bool {
+func renderSource(logger log.Logger, s credSource, a credAudit) bool {
 	if s.location != "" {
 		logger.TInfof("%s (%s):", s.label, s.location)
 	} else {
 		logger.TInfof("%s:", s.label)
 	}
 
-	a := s.probe()
 	switch a.state {
 	case sourceAbsent:
 		if a.note != "" {
@@ -371,16 +398,9 @@ func probeMultiplatform() credAudit {
 }
 
 // probeRawConfig reads the file directly — the per-tool ReadConfig overlays multiplatform credentials, which would mask the actual on-disk content this audit needs to see.
-func probeRawConfig(displayPath string) func() credAudit {
+func probeRawConfig(fullPath string) func() credAudit {
 	return func() credAudit {
-		home, err := utils.DefaultOsProxy{}.UserHomeDir()
-		if err != nil {
-			return credAudit{state: sourceReadError, err: fmt.Errorf("resolve home dir: %w", err)}
-		}
-
-		fullPath := filepath.Join(home, strings.TrimPrefix(displayPath, "~/"))
-
-		body, err := os.ReadFile(fullPath) //nolint:gosec // path composed from home + constant
+		body, err := os.ReadFile(fullPath) //nolint:gosec // path composed via the typed paths helpers
 		switch {
 		case errors.Is(err, fs.ErrNotExist):
 			return credAudit{state: sourceAbsent, note: "not present"}

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -93,8 +93,6 @@ var authClearCmd = &cobra.Command{
 	},
 }
 
-// maskToken returns a short hint preserving only the last 4 characters, so
-// `auth get` can confirm presence without leaking the secret to terminal scrollback.
 func maskToken(token string) string {
 	const tailLen = 4
 	if len(token) <= tailLen {

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -41,6 +41,9 @@ var authSetCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, _ []string) error {
 		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
+		setToken = strings.TrimSpace(setToken)
+		setWorkspaceID = strings.TrimSpace(setWorkspaceID)
+
 		switch {
 		case setToken == "" && setWorkspaceID == "":
 			return errors.New("--token and --workspace-id are required and must not be empty")

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -1,0 +1,118 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+)
+
+// nolint:gochecknoglobals
+var authCmd = &cobra.Command{
+	Use:          "auth",
+	Short:        "Manage Bitrise Build Cache credentials stored in the OS keychain",
+	Long:         `Manage Bitrise Build Cache credentials stored in the OS keychain (macOS Keychain, Linux secret-service). Credentials persisted here are used in preference to the BITRISE_BUILD_CACHE_AUTH_TOKEN / BITRISE_BUILD_CACHE_WORKSPACE_ID env vars.`,
+	SilenceUsage: true,
+}
+
+// nolint:gochecknoglobals
+var (
+	setToken       string
+	setWorkspaceID string
+)
+
+// nolint:gochecknoglobals
+var authSetCmd = &cobra.Command{
+	Use:          "set",
+	Short:        "Store Bitrise Build Cache credentials in the OS keychain",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+
+		kc := keychain.New()
+		if err := kc.Save(keychain.Credentials{
+			AuthToken:   setToken,
+			WorkspaceID: setWorkspaceID,
+		}); err != nil {
+			return fmt.Errorf("save credentials to keychain: %w", err)
+		}
+
+		logger.TInfof("✅ Credentials saved to the OS keychain")
+		logger.Infof("You can now remove BITRISE_BUILD_CACHE_AUTH_TOKEN + BITRISE_BUILD_CACHE_WORKSPACE_ID from your shell rc files.")
+
+		return nil
+	},
+}
+
+// nolint:gochecknoglobals
+var authGetCmd = &cobra.Command{
+	Use:          "get",
+	Short:        "Show whether Bitrise Build Cache credentials are stored in the OS keychain",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+
+		creds, err := keychain.New().Load()
+		if err != nil {
+			if errors.Is(err, keychain.ErrNotFound) {
+				logger.Warnf("No Bitrise Build Cache credentials stored in the OS keychain.")
+				logger.Infof("Run `bitrise-build-cache auth set --token <token> --workspace-id <id>` to store them, or rely on env vars.")
+
+				return nil
+			}
+
+			return fmt.Errorf("read credentials from keychain: %w", err)
+		}
+
+		logger.TInfof("Workspace ID: %s", creds.WorkspaceID)
+		logger.TInfof("Auth token:   %s", maskToken(creds.AuthToken))
+
+		return nil
+	},
+}
+
+// nolint:gochecknoglobals
+var authClearCmd = &cobra.Command{
+	Use:          "clear",
+	Short:        "Remove Bitrise Build Cache credentials from the OS keychain",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+
+		if err := keychain.New().Clear(); err != nil {
+			return fmt.Errorf("clear credentials from keychain: %w", err)
+		}
+
+		logger.TInfof("✅ Credentials removed from the OS keychain")
+
+		return nil
+	},
+}
+
+// maskToken returns a short hint preserving only the last 4 characters, so
+// `auth get` can confirm presence without leaking the secret to terminal scrollback.
+func maskToken(token string) string {
+	const tailLen = 4
+	if len(token) <= tailLen {
+		return "(present, length too short to mask)"
+	}
+
+	return fmt.Sprintf("****%s", token[len(token)-tailLen:])
+}
+
+func init() {
+	authSetCmd.Flags().StringVar(&setToken, "token", "", "Bitrise Build Cache auth token (required)")
+	authSetCmd.Flags().StringVar(&setWorkspaceID, "workspace-id", "", "Bitrise workspace ID (required)")
+	_ = authSetCmd.MarkFlagRequired("token")
+	_ = authSetCmd.MarkFlagRequired("workspace-id")
+
+	authCmd.AddCommand(authSetCmd)
+	authCmd.AddCommand(authGetCmd)
+	authCmd.AddCommand(authClearCmd)
+
+	common.RootCmd.AddCommand(authCmd)
+}

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -57,7 +57,7 @@ func TestScrubRawConfigAuthToken_stripsAuthAndKeepsRest(t *testing.T) {
 }`
 	require.NoError(t, os.WriteFile(configPath, []byte(body), 0o600))
 
-	scrubbed, err := scrubRawConfigAuthToken(utils.DefaultOsProxy{}, "~/.bitrise-xcelerate/config.json")
+	scrubbed, err := scrubRawConfigAuthToken(utils.DefaultOsProxy{}, configPath)
 	require.NoError(t, err)
 	assert.Equal(t, "~/.bitrise-xcelerate/config.json", scrubbed)
 
@@ -83,7 +83,7 @@ func TestScrubRawConfigAuthToken_noopWhenAlreadyClean(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(configPath, []byte(`{"proxyVersion":"1"}`), 0o600))
 
-	scrubbed, err := scrubRawConfigAuthToken(utils.DefaultOsProxy{}, "~/.bitrise-xcelerate/config.json")
+	scrubbed, err := scrubRawConfigAuthToken(utils.DefaultOsProxy{}, configPath)
 	require.NoError(t, err)
 	assert.Empty(t, scrubbed)
 }

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -4,10 +4,15 @@ package auth
 
 import (
 	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
 // 4096 < typical kernel pipe buffer (16-64KB); the Gradle init script reads stdout then stderr sequentially, a larger stderr could deadlock.
@@ -32,4 +37,116 @@ func TestAuthTokenCmd_stderrIsBoundedOnError(t *testing.T) {
 	require.Less(t, stderr.Len(), pipeBufferSafeBound,
 		"auth token stderr must stay under %d bytes so the Gradle init script's sequential stdout+stderr drain can't deadlock", pipeBufferSafeBound)
 	assert.NotEmpty(t, stderr.Bytes(), "error path must surface a one-line message on stderr")
+}
+
+func TestScrubRawConfigAuthToken_stripsAuthAndKeepsRest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configDir := filepath.Join(home, ".bitrise-xcelerate")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	configPath := filepath.Join(configDir, "config.json")
+
+	body := `{
+  "proxyVersion": "1.2.3",
+  "buildCacheEnabled": true,
+  "authConfig": {
+    "authToken": "secret-token-value",
+    "workspaceID": "ws-123"
+  }
+}`
+	require.NoError(t, os.WriteFile(configPath, []byte(body), 0o600))
+
+	scrubbed, err := scrubRawConfigAuthToken(utils.DefaultOsProxy{}, "~/.bitrise-xcelerate/config.json")
+	require.NoError(t, err)
+	assert.Equal(t, "~/.bitrise-xcelerate/config.json", scrubbed)
+
+	rewritten, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rewritten, &got))
+
+	_, hasAuth := got["authConfig"]
+	assert.False(t, hasAuth, "authConfig must be removed")
+	assert.Equal(t, "1.2.3", got["proxyVersion"])
+	assert.Equal(t, true, got["buildCacheEnabled"])
+}
+
+func TestScrubRawConfigAuthToken_noopWhenAlreadyClean(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configDir := filepath.Join(home, ".bitrise-xcelerate")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	configPath := filepath.Join(configDir, "config.json")
+
+	require.NoError(t, os.WriteFile(configPath, []byte(`{"proxyVersion":"1"}`), 0o600))
+
+	scrubbed, err := scrubRawConfigAuthToken(utils.DefaultOsProxy{}, "~/.bitrise-xcelerate/config.json")
+	require.NoError(t, err)
+	assert.Empty(t, scrubbed)
+}
+
+func TestScrubGradleInitKts_blanksLiteralTokens(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	initDir := filepath.Join(home, ".gradle", "init.d")
+	require.NoError(t, os.MkdirAll(initDir, 0o755))
+	initFile := filepath.Join(initDir, "bitrise-build-cache.init.gradle.kts")
+
+	body := `settingsEvaluated {
+    buildCache {
+        remote(BitriseBuildCache::class.java) {
+            endpoint = "https://cache.example"
+            authToken = "secret-cache-token"
+        }
+    }
+    rootProject {
+        analytics {
+            authToken.set("secret-analytics-token")
+        }
+    }
+}
+rootProject {
+    rbe {
+        authToken.set("secret-rbe-token")
+    }
+}
+`
+	require.NoError(t, os.WriteFile(initFile, []byte(body), 0o600))
+
+	scrubbed, err := scrubGradleInitKts(utils.DefaultOsProxy{})
+	require.NoError(t, err)
+	assert.Equal(t, "~/.gradle/init.d/bitrise-build-cache.init.gradle.kts", scrubbed)
+
+	rewritten, err := os.ReadFile(initFile)
+	require.NoError(t, err)
+
+	got := string(rewritten)
+	assert.NotContains(t, got, "secret-cache-token")
+	assert.NotContains(t, got, "secret-analytics-token")
+	assert.NotContains(t, got, "secret-rbe-token")
+	assert.Contains(t, got, `authToken = ""`)
+	assert.Contains(t, got, `authToken.set("")`)
+	assert.Contains(t, got, `endpoint = "https://cache.example"`)
+}
+
+func TestScrubGradleInitKts_noopWhenValueSourceForm(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	initDir := filepath.Join(home, ".gradle", "init.d")
+	require.NoError(t, os.MkdirAll(initDir, 0o755))
+	initFile := filepath.Join(initDir, "bitrise-build-cache.init.gradle.kts")
+
+	body := `authToken = providers.bitriseAuthToken()
+authToken.set(providers.bitriseAuthToken())
+`
+	require.NoError(t, os.WriteFile(initFile, []byte(body), 0o600))
+
+	scrubbed, err := scrubGradleInitKts(utils.DefaultOsProxy{})
+	require.NoError(t, err)
+	assert.Empty(t, scrubbed, "value-source form has no literal to scrub")
 }

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -119,7 +119,8 @@ rootProject {
 
 	scrubbed, err := scrubGradleInitKts(utils.DefaultOsProxy{})
 	require.NoError(t, err)
-	assert.Equal(t, "~/.gradle/init.d/bitrise-build-cache.init.gradle.kts", scrubbed)
+	assert.Equal(t, "~/.gradle/init.d/bitrise-build-cache.init.gradle.kts", scrubbed.path)
+	assert.Contains(t, scrubbed.hint, "activate gradle")
 
 	rewritten, err := os.ReadFile(initFile)
 	require.NoError(t, err)
@@ -148,5 +149,5 @@ authToken.set(providers.bitriseAuthToken())
 
 	scrubbed, err := scrubGradleInitKts(utils.DefaultOsProxy{})
 	require.NoError(t, err)
-	assert.Empty(t, scrubbed, "value-source form has no literal to scrub")
+	assert.Empty(t, scrubbed.path, "value-source form has no literal to scrub")
 }

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -1,0 +1,35 @@
+//go:build unit
+
+package auth
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 4096 < typical kernel pipe buffer (16-64KB); the Gradle init script reads stdout then stderr sequentially, a larger stderr could deadlock.
+const pipeBufferSafeBound = 4096
+
+func TestAuthTokenCmd_stderrIsBoundedOnError(t *testing.T) {
+	cmd := authTokenCmd
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	t.Setenv("BITRISE_BUILD_CACHE_AUTH_TOKEN", "")
+	t.Setenv("BITRISE_BUILD_CACHE_WORKSPACE_ID", "")
+	t.Setenv("BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN", "")
+
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Skip("dev machine has credentials configured; cannot exercise error path here")
+	}
+
+	require.Less(t, stderr.Len(), pipeBufferSafeBound,
+		"auth token stderr must stay under %d bytes so the Gradle init script's sequential stdout+stderr drain can't deadlock", pipeBufferSafeBound)
+	assert.NotEmpty(t, stderr.Bytes(), "error path must surface a one-line message on stderr")
+}

--- a/cmd/bazel/enableForBazel_test.go
+++ b/cmd/bazel/enableForBazel_test.go
@@ -55,7 +55,7 @@ func Test_enableForBazelCmdFn(t *testing.T) {
 		err := bazel.EnableForBazelCmdFn(mockLogger, mockOsProxy, envVars)
 
 		// then
-		require.EqualError(t, err, "template inventory error: read auth config from environment variables: BITRISE_BUILD_CACHE_AUTH_TOKEN or BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN environment variable not set")
+		require.EqualError(t, err, "template inventory error: resolve auth config: BITRISE_BUILD_CACHE_AUTH_TOKEN or BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN environment variable not set")
 	})
 
 	t.Run("BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN specified", func(t *testing.T) {

--- a/cmd/gradle/activate_gradle.go
+++ b/cmd/gradle/activate_gradle.go
@@ -43,6 +43,10 @@ If the "# [start/end] generated-by-bitrise-build-cache" block is already present
 
 		allEnvs := utils.AllEnvs()
 
+		if cliPath, exeErr := os.Executable(); exeErr == nil {
+			activateGradleParams.CLIPath = cliPath
+		}
+
 		if err := gradleconfig.Activate(
 			logger,
 			gradleHome,

--- a/cmd/gradle/activate_gradle_test.go
+++ b/cmd/gradle/activate_gradle_test.go
@@ -40,7 +40,7 @@ func Test_activateGradleCmdFn(t *testing.T) {
 		err := gradle.ActivateGradleCmdFn(
 			mockLogger,
 			"~/.gradle",
-			map[string]string{},
+			map[string]string{"BITRISE_BUILD_CACHE_AUTH_TOKEN": "AuthTokenValue", "BITRISE_BUILD_CACHE_WORKSPACE_ID": "WorkspaceIDValue"},
 			func(log.Logger, map[string]string, bool, common.BenchmarkPhaseProvider) (gradleconfig.TemplateInventory, error) {
 				return templateInventory, nil
 			},
@@ -81,7 +81,7 @@ func Test_activateGradleCmdFn(t *testing.T) {
 		err := gradle.ActivateGradleCmdFn(
 			mockLogger,
 			"~/.gradle",
-			map[string]string{},
+			map[string]string{"BITRISE_BUILD_CACHE_AUTH_TOKEN": "AuthTokenValue", "BITRISE_BUILD_CACHE_WORKSPACE_ID": "WorkspaceIDValue"},
 			func(log.Logger, map[string]string, bool, common.BenchmarkPhaseProvider) (gradleconfig.TemplateInventory, error) {
 				return gradleconfig.TemplateInventory{}, inventoryCreationError
 			},
@@ -117,7 +117,7 @@ func Test_activateGradleCmdFn(t *testing.T) {
 		err := gradle.ActivateGradleCmdFn(
 			mockLogger,
 			"~/.gradle",
-			map[string]string{},
+			map[string]string{"BITRISE_BUILD_CACHE_AUTH_TOKEN": "AuthTokenValue", "BITRISE_BUILD_CACHE_WORKSPACE_ID": "WorkspaceIDValue"},
 			func(log.Logger, map[string]string, bool, common.BenchmarkPhaseProvider) (gradleconfig.TemplateInventory, error) {
 				return gradleconfig.TemplateInventory{}, nil
 			},
@@ -153,7 +153,7 @@ func Test_activateGradleCmdFn(t *testing.T) {
 		err := gradle.ActivateGradleCmdFn(
 			mockLogger,
 			"~/.gradle",
-			map[string]string{},
+			map[string]string{"BITRISE_BUILD_CACHE_AUTH_TOKEN": "AuthTokenValue", "BITRISE_BUILD_CACHE_WORKSPACE_ID": "WorkspaceIDValue"},
 			func(log.Logger, map[string]string, bool, common.BenchmarkPhaseProvider) (gradleconfig.TemplateInventory, error) {
 				return gradleconfig.TemplateInventory{}, nil
 			},

--- a/cmd/gradle/enable_for_gradle.go
+++ b/cmd/gradle/enable_for_gradle.go
@@ -82,7 +82,7 @@ func EnableForGradleCmdFn(logger log.Logger, gradleHomePath string, envProvider 
 	activateGradleParams.Analytics.Enabled = paramIsGradleMetricsEnabled
 	activateGradleParams.TestDistro.Enabled = false
 
-	authConfig, _ := configcommon.ReadAuthConfigFromEnvironments(envProvider)
+	authConfig, _ := configcommon.ResolveAuthConfig(envProvider)
 	benchmarkClient := configcommon.NewBenchmarkPhaseClient(consts.BitriseWebsiteBaseURL, authConfig, logger)
 
 	templateInventory, err := activateGradleParams.TemplateInventory(logger, envProvider, common.IsDebugLogMode, benchmarkClient)

--- a/cmd/gradle/enable_for_gradle.go
+++ b/cmd/gradle/enable_for_gradle.go
@@ -82,7 +82,11 @@ func EnableForGradleCmdFn(logger log.Logger, gradleHomePath string, envProvider 
 	activateGradleParams.Analytics.Enabled = paramIsGradleMetricsEnabled
 	activateGradleParams.TestDistro.Enabled = false
 
-	authConfig, _ := configcommon.ResolveAuthConfig(envProvider)
+	authConfig, err := configcommon.ResolveAuthConfig(envProvider)
+	if err != nil {
+		return fmt.Errorf(FmtErrorEnableForGradle, err)
+	}
+
 	benchmarkClient := configcommon.NewBenchmarkPhaseClient(consts.BitriseWebsiteBaseURL, authConfig, logger)
 
 	templateInventory, err := activateGradleParams.TemplateInventory(logger, envProvider, common.IsDebugLogMode, benchmarkClient)

--- a/cmd/gradle/enable_for_gradle.go
+++ b/cmd/gradle/enable_for_gradle.go
@@ -84,7 +84,7 @@ func EnableForGradleCmdFn(logger log.Logger, gradleHomePath string, envProvider 
 
 	authConfig, err := configcommon.ResolveAuthConfig(envProvider)
 	if err != nil {
-		return fmt.Errorf(FmtErrorEnableForGradle, err)
+		return fmt.Errorf(FmtErrorEnableForGradle, fmt.Errorf(gradleconfig.ErrFmtReadAuthConfig, err))
 	}
 
 	benchmarkClient := configcommon.NewBenchmarkPhaseClient(consts.BitriseWebsiteBaseURL, authConfig, logger)

--- a/cmd/gradle/enable_for_gradle.go
+++ b/cmd/gradle/enable_for_gradle.go
@@ -2,6 +2,7 @@ package gradle
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
@@ -81,6 +82,10 @@ func EnableForGradleCmdFn(logger log.Logger, gradleHomePath string, envProvider 
 	activateGradleParams.Cache.Endpoint = paramRemoteCacheEndpoint
 	activateGradleParams.Analytics.Enabled = paramIsGradleMetricsEnabled
 	activateGradleParams.TestDistro.Enabled = false
+
+	if cliPath, exeErr := os.Executable(); exeErr == nil {
+		activateGradleParams.CLIPath = cliPath
+	}
 
 	authConfig, err := configcommon.ResolveAuthConfig(envProvider)
 	if err != nil {

--- a/cmd/gradle/restoreGradleConfigurationCache.go
+++ b/cmd/gradle/restoreGradleConfigurationCache.go
@@ -45,7 +45,7 @@ var restoreGradleConfigCacheCmd = &cobra.Command{
 
 		logger.Infof("(i) Check Auth Config")
 		allEnvs := utils.AllEnvs()
-		authConfig, err := configcommon.ReadAuthConfigFromEnvironments(allEnvs)
+		authConfig, err := configcommon.ResolveAuthConfig(allEnvs)
 		if err != nil {
 			return fmt.Errorf("read auth config from environments: %w", err)
 		}

--- a/cmd/gradle/restoreGradleConfigurationCache.go
+++ b/cmd/gradle/restoreGradleConfigurationCache.go
@@ -47,7 +47,7 @@ var restoreGradleConfigCacheCmd = &cobra.Command{
 		allEnvs := utils.AllEnvs()
 		authConfig, err := configcommon.ResolveAuthConfig(allEnvs)
 		if err != nil {
-			return fmt.Errorf("read auth config from environments: %w", err)
+			return fmt.Errorf("resolve auth config: %w", err)
 		}
 
 		err = restoreGradleConfigCacheCmdFn(cmd.Context(),

--- a/cmd/gradle/saveGradleConfigurationCache.go
+++ b/cmd/gradle/saveGradleConfigurationCache.go
@@ -43,7 +43,7 @@ var saveGradleConfigCacheCmd = &cobra.Command{
 		allEnvs := utils.AllEnvs()
 		authConfig, err := configcommon.ResolveAuthConfig(allEnvs)
 		if err != nil {
-			return fmt.Errorf("read auth config from environments: %w", err)
+			return fmt.Errorf("resolve auth config: %w", err)
 		}
 
 		err = saveGradleConfigCacheCmdFn(cmd.Context(),

--- a/cmd/gradle/saveGradleConfigurationCache.go
+++ b/cmd/gradle/saveGradleConfigurationCache.go
@@ -41,7 +41,7 @@ var saveGradleConfigCacheCmd = &cobra.Command{
 
 		logger.Infof("(i) Check Auth Config")
 		allEnvs := utils.AllEnvs()
-		authConfig, err := configcommon.ReadAuthConfigFromEnvironments(allEnvs)
+		authConfig, err := configcommon.ResolveAuthConfig(allEnvs)
 		if err != nil {
 			return fmt.Errorf("read auth config from environments: %w", err)
 		}

--- a/cmd/xcode/deleteXcodeDerivedData.go
+++ b/cmd/xcode/deleteXcodeDerivedData.go
@@ -72,7 +72,7 @@ func deleteXcodeDerivedDataCmdFn(ctx context.Context,
 	logger.Infof("(i) Check Auth Config")
 	authConfig, err := configcommon.ResolveAuthConfig(envProvider)
 	if err != nil {
-		return fmt.Errorf("read auth config from environments: %w", err)
+		return fmt.Errorf("resolve auth config: %w", err)
 	}
 
 	var cacheKey string

--- a/cmd/xcode/deleteXcodeDerivedData.go
+++ b/cmd/xcode/deleteXcodeDerivedData.go
@@ -70,7 +70,7 @@ func deleteXcodeDerivedDataCmdFn(ctx context.Context,
 	commandFunc func(string, ...string) (string, error),
 ) error {
 	logger.Infof("(i) Check Auth Config")
-	authConfig, err := configcommon.ReadAuthConfigFromEnvironments(envProvider)
+	authConfig, err := configcommon.ResolveAuthConfig(envProvider)
 	if err != nil {
 		return fmt.Errorf("read auth config from environments: %w", err)
 	}

--- a/cmd/xcode/restoreXcodeDerivedDataFiles.go
+++ b/cmd/xcode/restoreXcodeDerivedDataFiles.go
@@ -53,7 +53,7 @@ var restoreXcodeDerivedDataFilesCmd = &cobra.Command{
 		logger.Infof("(i) Check Auth Config")
 		authConfig, err := configcommon.ResolveAuthConfig(allEnvs)
 		if err != nil {
-			return fmt.Errorf("read auth config from environments: %w", err)
+			return fmt.Errorf("resolve auth config: %w", err)
 		}
 
 		op, cmdError := restoreXcodeDerivedDataFilesCmdFn(cmd.Context(),

--- a/cmd/xcode/restoreXcodeDerivedDataFiles.go
+++ b/cmd/xcode/restoreXcodeDerivedDataFiles.go
@@ -51,7 +51,7 @@ var restoreXcodeDerivedDataFilesCmd = &cobra.Command{
 		startT := time.Now()
 
 		logger.Infof("(i) Check Auth Config")
-		authConfig, err := configcommon.ReadAuthConfigFromEnvironments(allEnvs)
+		authConfig, err := configcommon.ResolveAuthConfig(allEnvs)
 		if err != nil {
 			return fmt.Errorf("read auth config from environments: %w", err)
 		}

--- a/cmd/xcode/saveXcodeDerivedDataFiles.go
+++ b/cmd/xcode/saveXcodeDerivedDataFiles.go
@@ -53,7 +53,7 @@ var saveXcodeDerivedDataFilesCmd = &cobra.Command{
 		allEnvs := utils.AllEnvs()
 		authConfig, err := configcommon.ResolveAuthConfig(allEnvs)
 		if err != nil {
-			return fmt.Errorf("read auth config from environments: %w", err)
+			return fmt.Errorf("resolve auth config: %w", err)
 		}
 
 		op, cmdError := SaveXcodeDerivedDataFilesCmdFn(cmd.Context(),

--- a/cmd/xcode/saveXcodeDerivedDataFiles.go
+++ b/cmd/xcode/saveXcodeDerivedDataFiles.go
@@ -51,7 +51,7 @@ var saveXcodeDerivedDataFilesCmd = &cobra.Command{
 
 		logger.Infof("(i) Check Auth Config")
 		allEnvs := utils.AllEnvs()
-		authConfig, err := configcommon.ReadAuthConfigFromEnvironments(allEnvs)
+		authConfig, err := configcommon.ResolveAuthConfig(allEnvs)
 		if err != nil {
 			return fmt.Errorf("read auth config from environments: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	github.com/zalando/go-keyring v0.2.8
 	github.com/zeebo/blake3 v0.2.4
 	golang.org/x/mod v0.33.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260203192932-546029d2fa20
@@ -31,10 +32,12 @@ require (
 	github.com/bitrise-io/go-utils v1.0.13 // indirect
 	github.com/bitrise-io/got v0.0.0-20240902113940-25f6469d1456 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.17.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -36,6 +38,8 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/gofrs/uuid/v5 v5.4.0 h1:EfbpCTjqMuGyq5ZJwxqzn3Cbr2d0rUZU7v5ycAk/e/0=
 github.com/gofrs/uuid/v5 v5.4.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -109,6 +113,8 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
 github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=

--- a/internal/auth/keychain/keychain.go
+++ b/internal/auth/keychain/keychain.go
@@ -1,0 +1,107 @@
+// Package keychain stores the Bitrise Build Cache auth credentials in the OS
+// secret store (macOS Keychain, Linux secret-service) instead of forcing the
+// user to keep BITRISE_BUILD_CACHE_AUTH_TOKEN in shell rc files.
+//
+// Credentials are JSON-encoded into a single keychain item under
+// service="bitrise-build-cache", account="default".
+package keychain
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	keyring "github.com/zalando/go-keyring"
+)
+
+const (
+	serviceName = "bitrise-build-cache"
+	accountName = "default"
+)
+
+// ErrNotFound is returned by Load when no credentials are stored yet.
+var ErrNotFound = errors.New("no Bitrise Build Cache credentials in keychain")
+
+// Credentials are the auth fields stored in the keychain.
+type Credentials struct {
+	AuthToken   string `json:"auth_token"`
+	WorkspaceID string `json:"workspace_id"`
+}
+
+// Backend is the slice of zalando/go-keyring the Keychain depends on. Exported
+// so tests can inject an in-memory implementation.
+type Backend interface {
+	Get(service, account string) (string, error)
+	Set(service, account, secret string) error
+	Delete(service, account string) error
+}
+
+type defaultBackend struct{}
+
+func (defaultBackend) Get(service, account string) (string, error) {
+	return keyring.Get(service, account) //nolint:wrapcheck // wrapped in Keychain methods
+}
+
+func (defaultBackend) Set(service, account, secret string) error {
+	return keyring.Set(service, account, secret) //nolint:wrapcheck
+}
+
+func (defaultBackend) Delete(service, account string) error {
+	return keyring.Delete(service, account) //nolint:wrapcheck
+}
+
+// Keychain reads + writes Credentials via a Backend.
+type Keychain struct {
+	Backend Backend
+}
+
+// New returns a Keychain backed by the real OS secret store.
+func New() *Keychain {
+	return &Keychain{Backend: defaultBackend{}}
+}
+
+// Load returns the stored credentials, or ErrNotFound if nothing was stored.
+func (k *Keychain) Load() (Credentials, error) {
+	raw, err := k.Backend.Get(serviceName, accountName)
+	if err != nil {
+		if errors.Is(err, keyring.ErrNotFound) {
+			return Credentials{}, ErrNotFound
+		}
+
+		return Credentials{}, fmt.Errorf("keychain read: %w", err)
+	}
+
+	var c Credentials
+	if err := json.Unmarshal([]byte(raw), &c); err != nil {
+		return Credentials{}, fmt.Errorf("keychain decode: %w", err)
+	}
+
+	return c, nil
+}
+
+// Save persists the credentials, replacing whatever was there before.
+func (k *Keychain) Save(c Credentials) error {
+	raw, err := json.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("keychain encode: %w", err)
+	}
+
+	if err := k.Backend.Set(serviceName, accountName, string(raw)); err != nil {
+		return fmt.Errorf("keychain write: %w", err)
+	}
+
+	return nil
+}
+
+// Clear removes the stored credentials. No-op when nothing is stored.
+func (k *Keychain) Clear() error {
+	err := k.Backend.Delete(serviceName, accountName)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, keyring.ErrNotFound) {
+		return nil
+	}
+
+	return fmt.Errorf("keychain delete: %w", err)
+}

--- a/internal/auth/keychain/keychain.go
+++ b/internal/auth/keychain/keychain.go
@@ -50,11 +50,10 @@ func New() *Keychain {
 
 func (k *Keychain) Load() (Credentials, error) {
 	raw, err := k.Backend.Get(serviceName, accountName)
-	if err != nil {
-		if errors.Is(err, keyring.ErrNotFound) {
-			return Credentials{}, ErrNotFound
-		}
-
+	switch {
+	case errors.Is(err, keyring.ErrNotFound):
+		return Credentials{}, ErrNotFound
+	case err != nil:
 		return Credentials{}, fmt.Errorf("keychain read: %w", err)
 	}
 
@@ -80,13 +79,10 @@ func (k *Keychain) Save(c Credentials) error {
 }
 
 func (k *Keychain) Clear() error {
-	err := k.Backend.Delete(serviceName, accountName)
-	if err == nil {
+	switch err := k.Backend.Delete(serviceName, accountName); {
+	case err == nil, errors.Is(err, keyring.ErrNotFound):
 		return nil
+	default:
+		return fmt.Errorf("keychain delete: %w", err)
 	}
-	if errors.Is(err, keyring.ErrNotFound) {
-		return nil
-	}
-
-	return fmt.Errorf("keychain delete: %w", err)
 }

--- a/internal/auth/keychain/keychain.go
+++ b/internal/auth/keychain/keychain.go
@@ -1,9 +1,3 @@
-// Package keychain stores the Bitrise Build Cache auth credentials in the OS
-// secret store (macOS Keychain, Linux secret-service) instead of forcing the
-// user to keep BITRISE_BUILD_CACHE_AUTH_TOKEN in shell rc files.
-//
-// Credentials are JSON-encoded into a single keychain item under
-// service="bitrise-build-cache", account="default".
 package keychain
 
 import (
@@ -19,17 +13,13 @@ const (
 	accountName = "default"
 )
 
-// ErrNotFound is returned by Load when no credentials are stored yet.
 var ErrNotFound = errors.New("no Bitrise Build Cache credentials in keychain")
 
-// Credentials are the auth fields stored in the keychain.
 type Credentials struct {
 	AuthToken   string `json:"auth_token"`
 	WorkspaceID string `json:"workspace_id"`
 }
 
-// Backend is the slice of zalando/go-keyring the Keychain depends on. Exported
-// so tests can inject an in-memory implementation.
 type Backend interface {
 	Get(service, account string) (string, error)
 	Set(service, account, secret string) error
@@ -50,17 +40,14 @@ func (defaultBackend) Delete(service, account string) error {
 	return keyring.Delete(service, account) //nolint:wrapcheck
 }
 
-// Keychain reads + writes Credentials via a Backend.
 type Keychain struct {
 	Backend Backend
 }
 
-// New returns a Keychain backed by the real OS secret store.
 func New() *Keychain {
 	return &Keychain{Backend: defaultBackend{}}
 }
 
-// Load returns the stored credentials, or ErrNotFound if nothing was stored.
 func (k *Keychain) Load() (Credentials, error) {
 	raw, err := k.Backend.Get(serviceName, accountName)
 	if err != nil {
@@ -79,7 +66,6 @@ func (k *Keychain) Load() (Credentials, error) {
 	return c, nil
 }
 
-// Save persists the credentials, replacing whatever was there before.
 func (k *Keychain) Save(c Credentials) error {
 	raw, err := json.Marshal(c)
 	if err != nil {
@@ -93,7 +79,6 @@ func (k *Keychain) Save(c Credentials) error {
 	return nil
 }
 
-// Clear removes the stored credentials. No-op when nothing is stored.
 func (k *Keychain) Clear() error {
 	err := k.Backend.Delete(serviceName, accountName)
 	if err == nil {

--- a/internal/auth/keychain/keychain_test.go
+++ b/internal/auth/keychain/keychain_test.go
@@ -1,0 +1,120 @@
+//go:build unit
+
+package keychain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	keyring "github.com/zalando/go-keyring"
+)
+
+type fakeBackend struct {
+	store    map[string]string
+	getErr   error
+	setErr   error
+	delErr   error
+	notFound bool
+}
+
+func newFakeBackend() *fakeBackend {
+	return &fakeBackend{store: map[string]string{}}
+}
+
+func (f *fakeBackend) key(service, account string) string {
+	return service + "|" + account
+}
+
+func (f *fakeBackend) Get(service, account string) (string, error) {
+	if f.getErr != nil {
+		return "", f.getErr
+	}
+	v, ok := f.store[f.key(service, account)]
+	if !ok || f.notFound {
+		return "", keyring.ErrNotFound
+	}
+
+	return v, nil
+}
+
+func (f *fakeBackend) Set(service, account, secret string) error {
+	if f.setErr != nil {
+		return f.setErr
+	}
+	f.store[f.key(service, account)] = secret
+
+	return nil
+}
+
+func (f *fakeBackend) Delete(service, account string) error {
+	if f.delErr != nil {
+		return f.delErr
+	}
+	if _, ok := f.store[f.key(service, account)]; !ok {
+		return keyring.ErrNotFound
+	}
+	delete(f.store, f.key(service, account))
+
+	return nil
+}
+
+func TestSaveAndLoadRoundTrip(t *testing.T) {
+	k := &Keychain{Backend: newFakeBackend()}
+
+	creds := Credentials{AuthToken: "tok-xyz", WorkspaceID: "ws-123"}
+	require.NoError(t, k.Save(creds))
+
+	got, err := k.Load()
+	require.NoError(t, err)
+	assert.Equal(t, creds, got)
+}
+
+func TestLoadEmptyReturnsErrNotFound(t *testing.T) {
+	k := &Keychain{Backend: newFakeBackend()}
+
+	_, err := k.Load()
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestSaveReplacesPreviousValue(t *testing.T) {
+	k := &Keychain{Backend: newFakeBackend()}
+
+	require.NoError(t, k.Save(Credentials{AuthToken: "first", WorkspaceID: "ws-1"}))
+	require.NoError(t, k.Save(Credentials{AuthToken: "second", WorkspaceID: "ws-2"}))
+
+	got, err := k.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "second", got.AuthToken)
+	assert.Equal(t, "ws-2", got.WorkspaceID)
+}
+
+func TestClearRemoves(t *testing.T) {
+	k := &Keychain{Backend: newFakeBackend()}
+
+	require.NoError(t, k.Save(Credentials{AuthToken: "tok", WorkspaceID: "ws"}))
+	require.NoError(t, k.Clear())
+
+	_, err := k.Load()
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestClearNoopOnEmpty(t *testing.T) {
+	k := &Keychain{Backend: newFakeBackend()}
+
+	assert.NoError(t, k.Clear())
+}
+
+func TestLoadWrapsBackendError(t *testing.T) {
+	backendErr := errors.New("dbus connection failed")
+	be := newFakeBackend()
+	be.getErr = backendErr
+
+	k := &Keychain{Backend: be}
+	_, err := k.Load()
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound)
+	assert.Contains(t, err.Error(), "dbus connection failed")
+}

--- a/internal/config/bazel/activate_bazel_params.go
+++ b/internal/config/bazel/activate_bazel_params.go
@@ -82,7 +82,7 @@ func (params ActivateBazelParams) commonTemplateInventory(
 
 	// Required configs
 	logger.Infof("(i) Check Auth Config")
-	authConfig, err := common.ReadAuthConfigFromEnvironments(envs)
+	authConfig, err := common.ResolveAuthConfig(envs)
 	if err != nil {
 		return CommonTemplateInventory{},
 			fmt.Errorf("read auth config from environment variables: %w", err)

--- a/internal/config/bazel/activate_bazel_params.go
+++ b/internal/config/bazel/activate_bazel_params.go
@@ -85,7 +85,7 @@ func (params ActivateBazelParams) commonTemplateInventory(
 	authConfig, err := common.ResolveAuthConfig(envs)
 	if err != nil {
 		return CommonTemplateInventory{},
-			fmt.Errorf("read auth config from environment variables: %w", err)
+			fmt.Errorf("resolve auth config: %w", err)
 	}
 
 	cacheConfig := common.NewMetadata(envs,

--- a/internal/config/bazel/activate_bazel_params_test.go
+++ b/internal/config/bazel/activate_bazel_params_test.go
@@ -101,7 +101,7 @@ func Test_ActivateBazelParams(t *testing.T) {
 		}, false)
 
 		// then
-		require.EqualError(t, err, fmt.Errorf("read auth config from environment variables: %w", common.ErrAuthTokenNotProvided).Error())
+		require.EqualError(t, err, fmt.Errorf("resolve auth config: %w", common.ErrAuthTokenNotProvided).Error())
 	})
 
 	t.Run("TemplateInventory with cache enabled and custom endpoint", func(t *testing.T) {

--- a/internal/config/ccache/config.go
+++ b/internal/config/ccache/config.go
@@ -92,7 +92,7 @@ func DefaultParams() Params {
 }
 
 func NewConfig(envs map[string]string, osProxy utils.OsProxy, params Params) (Config, error) {
-	authConfig, err := common.ReadAuthConfigFromEnvironments(envs)
+	authConfig, err := common.ResolveAuthConfig(envs)
 	if err != nil {
 		return Config{}, fmt.Errorf(ErrNoAuthConfig, err)
 	}

--- a/internal/config/ccache/config.go
+++ b/internal/config/ccache/config.go
@@ -85,6 +85,11 @@ func PathFor(osProxy utils.OsProxy, subpath string) string {
 	return filepath.Join(DirPath(osProxy), subpath)
 }
 
+// ConfigFile returns the absolute path of the ccache config.json.
+func ConfigFile(osProxy utils.OsProxy) string {
+	return PathFor(osProxy, ccacheConfigFile)
+}
+
 func DefaultParams() Params {
 	return Params{
 		PushEnabled: true,

--- a/internal/config/ccache/config.go
+++ b/internal/config/ccache/config.go
@@ -29,7 +29,7 @@ const (
 	ErrFmtCreateConfigFile = "failed to create ccache config file: %w"
 	ErrFmtEncodeConfigFile = "failed to encode ccache config file: %w"
 	ErrFmtCreateFolder     = "failed to create .bitrise/cache/ccache folder (%s): %w"
-	ErrNoAuthConfig        = "read auth config: %w"
+	ErrNoAuthConfig        = "resolve auth config: %w"
 )
 
 // Params holds the parameters for creating a ccache activate config.

--- a/internal/config/common/auth.go
+++ b/internal/config/common/auth.go
@@ -42,6 +42,10 @@ func ResolveAuthConfig(envs map[string]string) (CacheAuthConfig, error) {
 }
 
 func resolveAuthConfig(envs map[string]string, loader authLoader) (CacheAuthConfig, error) {
+	if hasAuthEnvVars(envs) {
+		return ReadAuthConfigFromEnvironments(envs)
+	}
+
 	creds, err := loader.Load()
 	if err == nil && creds.AuthToken != "" && creds.WorkspaceID != "" {
 		return CacheAuthConfig{
@@ -51,6 +55,14 @@ func resolveAuthConfig(envs map[string]string, loader authLoader) (CacheAuthConf
 	}
 
 	return ReadAuthConfigFromEnvironments(envs)
+}
+
+func hasAuthEnvVars(envs map[string]string) bool {
+	if envs["BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN"] != "" {
+		return true
+	}
+
+	return envs["BITRISE_BUILD_CACHE_AUTH_TOKEN"] != "" && envs["BITRISE_BUILD_CACHE_WORKSPACE_ID"] != ""
 }
 
 // ReadAuthConfigFromEnvironments reads auth information from the environment variables

--- a/internal/config/common/auth.go
+++ b/internal/config/common/auth.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
 )
 
 var (
@@ -29,6 +31,33 @@ func (cac CacheAuthConfig) TokenInGradleFormat() string {
 	}
 
 	return cac.WorkspaceID + ":" + cac.AuthToken
+}
+
+// authLoader is the slice of *keychain.Keychain the resolver depends on.
+// Exported indirectly so tests can inject a fake without touching the OS keychain.
+type authLoader interface {
+	Load() (keychain.Credentials, error)
+}
+
+// ResolveAuthConfig returns the cache auth config from the OS keychain when
+// available, falling back to environment variables for back-compat (CI and
+// for users who haven't migrated yet). Keychain errors other than ErrNotFound
+// fall through to env as well — common in headless boxes without a secret
+// service backend.
+func ResolveAuthConfig(envs map[string]string) (CacheAuthConfig, error) {
+	return resolveAuthConfig(envs, keychain.New())
+}
+
+func resolveAuthConfig(envs map[string]string, loader authLoader) (CacheAuthConfig, error) {
+	creds, err := loader.Load()
+	if err == nil && creds.AuthToken != "" && creds.WorkspaceID != "" {
+		return CacheAuthConfig{
+			AuthToken:   creds.AuthToken,
+			WorkspaceID: creds.WorkspaceID,
+		}, nil
+	}
+
+	return ReadAuthConfigFromEnvironments(envs)
 }
 
 // ReadAuthConfigFromEnvironments reads auth information from the environment variables

--- a/internal/config/common/auth.go
+++ b/internal/config/common/auth.go
@@ -33,17 +33,10 @@ func (cac CacheAuthConfig) TokenInGradleFormat() string {
 	return cac.WorkspaceID + ":" + cac.AuthToken
 }
 
-// authLoader is the slice of *keychain.Keychain the resolver depends on.
-// Exported indirectly so tests can inject a fake without touching the OS keychain.
 type authLoader interface {
 	Load() (keychain.Credentials, error)
 }
 
-// ResolveAuthConfig returns the cache auth config from the OS keychain when
-// available, falling back to environment variables for back-compat (CI and
-// for users who haven't migrated yet). Keychain errors other than ErrNotFound
-// fall through to env as well — common in headless boxes without a secret
-// service backend.
 func ResolveAuthConfig(envs map[string]string) (CacheAuthConfig, error) {
 	return resolveAuthConfig(envs, keychain.New())
 }

--- a/internal/config/common/auth.go
+++ b/internal/config/common/auth.go
@@ -37,11 +37,20 @@ type authLoader interface {
 	Load() (keychain.Credentials, error)
 }
 
-func ResolveAuthConfig(envs map[string]string) (CacheAuthConfig, error) {
-	return resolveAuthConfig(envs, keychain.New())
+// Wired via RegisterMultiplatformReader to avoid a multiplatform→common import cycle.
+//
+//nolint:gochecknoglobals
+var multiplatformConfigReader func() (CacheAuthConfig, error)
+
+func RegisterMultiplatformReader(fn func() (CacheAuthConfig, error)) {
+	multiplatformConfigReader = fn
 }
 
-func resolveAuthConfig(envs map[string]string, loader authLoader) (CacheAuthConfig, error) {
+func ResolveAuthConfig(envs map[string]string) (CacheAuthConfig, error) {
+	return resolveAuthConfig(envs, keychain.New(), multiplatformConfigReader)
+}
+
+func resolveAuthConfig(envs map[string]string, loader authLoader, readMultiplatform func() (CacheAuthConfig, error)) (CacheAuthConfig, error) {
 	if hasAuthEnvVars(envs) {
 		return ReadAuthConfigFromEnvironments(envs)
 	}
@@ -52,6 +61,12 @@ func resolveAuthConfig(envs map[string]string, loader authLoader) (CacheAuthConf
 			AuthToken:   creds.AuthToken,
 			WorkspaceID: creds.WorkspaceID,
 		}, nil
+	}
+
+	if readMultiplatform != nil {
+		if mpCfg, mpErr := readMultiplatform(); mpErr == nil && mpCfg.AuthToken != "" && mpCfg.WorkspaceID != "" {
+			return mpCfg, nil
+		}
 	}
 
 	return ReadAuthConfigFromEnvironments(envs)

--- a/internal/config/common/auth_test.go
+++ b/internal/config/common/auth_test.go
@@ -26,7 +26,7 @@ func TestResolveAuthConfig_envVarsWinOverKeychain(t *testing.T) {
 		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
 	}
 
-	got, err := resolveAuthConfig(envs, loader)
+	got, err := resolveAuthConfig(envs, loader, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "env-tok", got.AuthToken, "env vars take precedence over stored creds")
 	assert.Equal(t, "env-ws", got.WorkspaceID)
@@ -38,7 +38,7 @@ func TestResolveAuthConfig_jwtEnvWinsOverKeychain(t *testing.T) {
 		"BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN": makeUMAJWT("ci-ws"),
 	}
 
-	got, err := resolveAuthConfig(envs, loader)
+	got, err := resolveAuthConfig(envs, loader, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "ci-ws", got.WorkspaceID, "CI JWT env var overrides stored creds")
 	assert.True(t, got.IsJWT)
@@ -47,7 +47,7 @@ func TestResolveAuthConfig_jwtEnvWinsOverKeychain(t *testing.T) {
 func TestResolveAuthConfig_noEnv_keychainHit(t *testing.T) {
 	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok", WorkspaceID: "kc-ws"}}
 
-	got, err := resolveAuthConfig(map[string]string{}, loader)
+	got, err := resolveAuthConfig(map[string]string{}, loader, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "kc-tok", got.AuthToken)
 	assert.Equal(t, "kc-ws", got.WorkspaceID)
@@ -56,21 +56,21 @@ func TestResolveAuthConfig_noEnv_keychainHit(t *testing.T) {
 func TestResolveAuthConfig_noEnv_keychainNotFound_returnsEnvNotSetError(t *testing.T) {
 	loader := fakeAuthLoader{err: keychain.ErrNotFound}
 
-	_, err := resolveAuthConfig(map[string]string{}, loader)
+	_, err := resolveAuthConfig(map[string]string{}, loader, nil)
 	require.ErrorIs(t, err, ErrAuthTokenNotProvided)
 }
 
 func TestResolveAuthConfig_noEnv_keychainError_returnsEnvNotSetError(t *testing.T) {
 	loader := fakeAuthLoader{err: errors.New("dbus connection failed")}
 
-	_, err := resolveAuthConfig(map[string]string{}, loader)
+	_, err := resolveAuthConfig(map[string]string{}, loader, nil)
 	require.ErrorIs(t, err, ErrAuthTokenNotProvided)
 }
 
 func TestResolveAuthConfig_noEnv_keychainPartial_returnsEnvNotSetError(t *testing.T) {
 	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok"}}
 
-	_, err := resolveAuthConfig(map[string]string{}, loader)
+	_, err := resolveAuthConfig(map[string]string{}, loader, nil)
 	require.ErrorIs(t, err, ErrAuthTokenNotProvided)
 }
 
@@ -80,10 +80,70 @@ func TestResolveAuthConfig_partialEnv_fallsBackToKeychain(t *testing.T) {
 		"BITRISE_BUILD_CACHE_AUTH_TOKEN": "env-tok",
 	}
 
-	got, err := resolveAuthConfig(envs, loader)
+	got, err := resolveAuthConfig(envs, loader, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "kc-tok", got.AuthToken, "incomplete env vars should not silently mix with keychain")
 	assert.Equal(t, "kc-ws", got.WorkspaceID)
+}
+
+func TestResolveAuthConfig_noEnv_noKeychain_fallsBackToMultiplatformConfig(t *testing.T) {
+	loader := fakeAuthLoader{err: keychain.ErrNotFound}
+	readMp := func() (CacheAuthConfig, error) {
+		return CacheAuthConfig{AuthToken: "mp-tok", WorkspaceID: "mp-ws"}, nil
+	}
+
+	got, err := resolveAuthConfig(map[string]string{}, loader, readMp)
+	require.NoError(t, err)
+	assert.Equal(t, "mp-tok", got.AuthToken)
+	assert.Equal(t, "mp-ws", got.WorkspaceID)
+}
+
+func TestResolveAuthConfig_keychainWinsOverMultiplatformConfig(t *testing.T) {
+	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok", WorkspaceID: "kc-ws"}}
+	readMp := func() (CacheAuthConfig, error) {
+		return CacheAuthConfig{AuthToken: "mp-tok", WorkspaceID: "mp-ws"}, nil
+	}
+
+	got, err := resolveAuthConfig(map[string]string{}, loader, readMp)
+	require.NoError(t, err)
+	assert.Equal(t, "kc-tok", got.AuthToken, "keychain takes precedence over multiplatform config")
+	assert.Equal(t, "kc-ws", got.WorkspaceID)
+}
+
+func TestResolveAuthConfig_envWinsOverMultiplatformConfig(t *testing.T) {
+	loader := fakeAuthLoader{err: keychain.ErrNotFound}
+	readMp := func() (CacheAuthConfig, error) {
+		return CacheAuthConfig{AuthToken: "mp-tok", WorkspaceID: "mp-ws"}, nil
+	}
+	envs := map[string]string{
+		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
+		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
+	}
+
+	got, err := resolveAuthConfig(envs, loader, readMp)
+	require.NoError(t, err)
+	assert.Equal(t, "env-tok", got.AuthToken, "env vars take precedence over multiplatform config")
+	assert.Equal(t, "env-ws", got.WorkspaceID)
+}
+
+func TestResolveAuthConfig_multiplatformReaderErrorIsSwallowed(t *testing.T) {
+	loader := fakeAuthLoader{err: keychain.ErrNotFound}
+	readMp := func() (CacheAuthConfig, error) {
+		return CacheAuthConfig{}, errors.New("disk read failed")
+	}
+
+	_, err := resolveAuthConfig(map[string]string{}, loader, readMp)
+	require.ErrorIs(t, err, ErrAuthTokenNotProvided, "multiplatform read error falls through to env-not-set canonical error")
+}
+
+func TestResolveAuthConfig_multiplatformPartial_fallsThroughToEnvError(t *testing.T) {
+	loader := fakeAuthLoader{err: keychain.ErrNotFound}
+	readMp := func() (CacheAuthConfig, error) {
+		return CacheAuthConfig{AuthToken: "mp-tok"}, nil
+	}
+
+	_, err := resolveAuthConfig(map[string]string{}, loader, readMp)
+	require.ErrorIs(t, err, ErrAuthTokenNotProvided)
 }
 
 func makeJWT(payload map[string]any) string {

--- a/internal/config/common/auth_test.go
+++ b/internal/config/common/auth_test.go
@@ -19,7 +19,7 @@ type fakeAuthLoader struct {
 
 func (f fakeAuthLoader) Load() (keychain.Credentials, error) { return f.creds, f.err }
 
-func TestResolveAuthConfig_keychainHit(t *testing.T) {
+func TestResolveAuthConfig_envVarsWinOverKeychain(t *testing.T) {
 	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok", WorkspaceID: "kc-ws"}}
 	envs := map[string]string{
 		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
@@ -28,58 +28,62 @@ func TestResolveAuthConfig_keychainHit(t *testing.T) {
 
 	got, err := resolveAuthConfig(envs, loader)
 	require.NoError(t, err)
-	assert.Equal(t, "kc-tok", got.AuthToken, "keychain wins over env")
+	assert.Equal(t, "env-tok", got.AuthToken, "env vars take precedence over stored creds")
+	assert.Equal(t, "env-ws", got.WorkspaceID)
+}
+
+func TestResolveAuthConfig_jwtEnvWinsOverKeychain(t *testing.T) {
+	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok", WorkspaceID: "kc-ws"}}
+	envs := map[string]string{
+		"BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN": makeUMAJWT("ci-ws"),
+	}
+
+	got, err := resolveAuthConfig(envs, loader)
+	require.NoError(t, err)
+	assert.Equal(t, "ci-ws", got.WorkspaceID, "CI JWT env var overrides stored creds")
+	assert.True(t, got.IsJWT)
+}
+
+func TestResolveAuthConfig_noEnv_keychainHit(t *testing.T) {
+	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok", WorkspaceID: "kc-ws"}}
+
+	got, err := resolveAuthConfig(map[string]string{}, loader)
+	require.NoError(t, err)
+	assert.Equal(t, "kc-tok", got.AuthToken)
 	assert.Equal(t, "kc-ws", got.WorkspaceID)
 }
 
-func TestResolveAuthConfig_keychainNotFound_fallsBackToEnv(t *testing.T) {
+func TestResolveAuthConfig_noEnv_keychainNotFound_returnsEnvNotSetError(t *testing.T) {
 	loader := fakeAuthLoader{err: keychain.ErrNotFound}
-	envs := map[string]string{
-		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
-		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
-	}
 
-	got, err := resolveAuthConfig(envs, loader)
-	require.NoError(t, err)
-	assert.Equal(t, "env-tok", got.AuthToken)
-	assert.Equal(t, "env-ws", got.WorkspaceID)
+	_, err := resolveAuthConfig(map[string]string{}, loader)
+	require.ErrorIs(t, err, ErrAuthTokenNotProvided)
 }
 
-func TestResolveAuthConfig_keychainError_fallsBackToEnv(t *testing.T) {
+func TestResolveAuthConfig_noEnv_keychainError_returnsEnvNotSetError(t *testing.T) {
 	loader := fakeAuthLoader{err: errors.New("dbus connection failed")}
-	envs := map[string]string{
-		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
-		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
-	}
 
-	got, err := resolveAuthConfig(envs, loader)
-	require.NoError(t, err)
-	assert.Equal(t, "env-tok", got.AuthToken)
+	_, err := resolveAuthConfig(map[string]string{}, loader)
+	require.ErrorIs(t, err, ErrAuthTokenNotProvided)
 }
 
-func TestResolveAuthConfig_keychainEmpty_fallsBackToEnv(t *testing.T) {
-	loader := fakeAuthLoader{creds: keychain.Credentials{}}
-	envs := map[string]string{
-		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
-		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
-	}
-
-	got, err := resolveAuthConfig(envs, loader)
-	require.NoError(t, err)
-	assert.Equal(t, "env-tok", got.AuthToken)
-}
-
-func TestResolveAuthConfig_keychainPartial_fallsBackToEnv(t *testing.T) {
+func TestResolveAuthConfig_noEnv_keychainPartial_returnsEnvNotSetError(t *testing.T) {
 	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok"}}
+
+	_, err := resolveAuthConfig(map[string]string{}, loader)
+	require.ErrorIs(t, err, ErrAuthTokenNotProvided)
+}
+
+func TestResolveAuthConfig_partialEnv_fallsBackToKeychain(t *testing.T) {
+	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok", WorkspaceID: "kc-ws"}}
 	envs := map[string]string{
-		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
-		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
+		"BITRISE_BUILD_CACHE_AUTH_TOKEN": "env-tok",
 	}
 
 	got, err := resolveAuthConfig(envs, loader)
 	require.NoError(t, err)
-	assert.Equal(t, "env-tok", got.AuthToken)
-	assert.Equal(t, "env-ws", got.WorkspaceID)
+	assert.Equal(t, "kc-tok", got.AuthToken, "incomplete env vars should not silently mix with keychain")
+	assert.Equal(t, "kc-ws", got.WorkspaceID)
 }
 
 func makeJWT(payload map[string]any) string {

--- a/internal/config/common/auth_test.go
+++ b/internal/config/common/auth_test.go
@@ -3,11 +3,88 @@ package common
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
 )
+
+type fakeAuthLoader struct {
+	creds keychain.Credentials
+	err   error
+}
+
+func (f fakeAuthLoader) Load() (keychain.Credentials, error) { return f.creds, f.err }
+
+func TestResolveAuthConfig_keychainHit(t *testing.T) {
+	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok", WorkspaceID: "kc-ws"}}
+	envs := map[string]string{
+		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
+		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
+	}
+
+	got, err := resolveAuthConfig(envs, loader)
+	require.NoError(t, err)
+	assert.Equal(t, "kc-tok", got.AuthToken, "keychain wins over env")
+	assert.Equal(t, "kc-ws", got.WorkspaceID)
+}
+
+func TestResolveAuthConfig_keychainNotFound_fallsBackToEnv(t *testing.T) {
+	loader := fakeAuthLoader{err: keychain.ErrNotFound}
+	envs := map[string]string{
+		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
+		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
+	}
+
+	got, err := resolveAuthConfig(envs, loader)
+	require.NoError(t, err)
+	assert.Equal(t, "env-tok", got.AuthToken)
+	assert.Equal(t, "env-ws", got.WorkspaceID)
+}
+
+func TestResolveAuthConfig_keychainError_fallsBackToEnv(t *testing.T) {
+	// Any keychain error (e.g. no D-Bus on a headless box) should fall through,
+	// not propagate up. Env path is the back-compat safety net.
+	loader := fakeAuthLoader{err: errors.New("dbus connection failed")}
+	envs := map[string]string{
+		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
+		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
+	}
+
+	got, err := resolveAuthConfig(envs, loader)
+	require.NoError(t, err)
+	assert.Equal(t, "env-tok", got.AuthToken)
+}
+
+func TestResolveAuthConfig_keychainEmpty_fallsBackToEnv(t *testing.T) {
+	// Stored zero-value creds → not usable, fall through to env.
+	loader := fakeAuthLoader{creds: keychain.Credentials{}}
+	envs := map[string]string{
+		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
+		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
+	}
+
+	got, err := resolveAuthConfig(envs, loader)
+	require.NoError(t, err)
+	assert.Equal(t, "env-tok", got.AuthToken)
+}
+
+func TestResolveAuthConfig_keychainPartial_fallsBackToEnv(t *testing.T) {
+	// Stored token but no workspace ID (or vice versa) → incomplete, fall through.
+	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok"}}
+	envs := map[string]string{
+		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
+		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
+	}
+
+	got, err := resolveAuthConfig(envs, loader)
+	require.NoError(t, err)
+	assert.Equal(t, "env-tok", got.AuthToken)
+	assert.Equal(t, "env-ws", got.WorkspaceID)
+}
 
 func makeJWT(payload map[string]any) string {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))

--- a/internal/config/common/auth_test.go
+++ b/internal/config/common/auth_test.go
@@ -46,8 +46,6 @@ func TestResolveAuthConfig_keychainNotFound_fallsBackToEnv(t *testing.T) {
 }
 
 func TestResolveAuthConfig_keychainError_fallsBackToEnv(t *testing.T) {
-	// Any keychain error (e.g. no D-Bus on a headless box) should fall through,
-	// not propagate up. Env path is the back-compat safety net.
 	loader := fakeAuthLoader{err: errors.New("dbus connection failed")}
 	envs := map[string]string{
 		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
@@ -60,7 +58,6 @@ func TestResolveAuthConfig_keychainError_fallsBackToEnv(t *testing.T) {
 }
 
 func TestResolveAuthConfig_keychainEmpty_fallsBackToEnv(t *testing.T) {
-	// Stored zero-value creds → not usable, fall through to env.
 	loader := fakeAuthLoader{creds: keychain.Credentials{}}
 	envs := map[string]string{
 		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
@@ -73,7 +70,6 @@ func TestResolveAuthConfig_keychainEmpty_fallsBackToEnv(t *testing.T) {
 }
 
 func TestResolveAuthConfig_keychainPartial_fallsBackToEnv(t *testing.T) {
-	// Stored token but no workspace ID (or vice versa) → incomplete, fall through.
 	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok"}}
 	envs := map[string]string{
 		"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",

--- a/internal/config/gradle/activate.go
+++ b/internal/config/gradle/activate.go
@@ -25,7 +25,7 @@ func Activate(
 	updater GradlePropertiesUpdater,
 	params ActivateGradleParams,
 ) error {
-	authConfig, _ := configcommon.ReadAuthConfigFromEnvironments(envProvider)
+	authConfig, _ := configcommon.ResolveAuthConfig(envProvider)
 	benchmarkClient := configcommon.NewBenchmarkPhaseClient(consts.BitriseWebsiteBaseURL, authConfig, logger)
 
 	templateInventory, err := templateInventoryProvider(logger, envProvider, debugLogging, benchmarkClient)

--- a/internal/config/gradle/activate.go
+++ b/internal/config/gradle/activate.go
@@ -25,7 +25,11 @@ func Activate(
 	updater GradlePropertiesUpdater,
 	params ActivateGradleParams,
 ) error {
-	authConfig, _ := configcommon.ResolveAuthConfig(envProvider)
+	authConfig, err := configcommon.ResolveAuthConfig(envProvider)
+	if err != nil {
+		return fmt.Errorf(ErrFmtReadAuthConfig, err)
+	}
+
 	benchmarkClient := configcommon.NewBenchmarkPhaseClient(consts.BitriseWebsiteBaseURL, authConfig, logger)
 
 	templateInventory, err := templateInventoryProvider(logger, envProvider, debugLogging, benchmarkClient)

--- a/internal/config/gradle/activate_for_gradle_params.go
+++ b/internal/config/gradle/activate_for_gradle_params.go
@@ -78,7 +78,7 @@ func (params ActivateGradleParams) TemplateInventory(
 
 	// Read auth config and metadata upfront
 	logger.Infof("(i) Check Auth Config")
-	authConfig, err := common.ReadAuthConfigFromEnvironments(envs)
+	authConfig, err := common.ResolveAuthConfig(envs)
 	if err != nil {
 		return TemplateInventory{}, fmt.Errorf(ErrFmtReadAuthConfig, err)
 	}

--- a/internal/config/gradle/activate_for_gradle_params.go
+++ b/internal/config/gradle/activate_for_gradle_params.go
@@ -45,6 +45,8 @@ type ActivateGradleParams struct {
 	Cache      CacheParams
 	Analytics  AnalyticsParams
 	TestDistro TestDistroParams
+
+	CLIPath string
 }
 
 func DefaultActivateGradleParams() ActivateGradleParams {
@@ -123,12 +125,18 @@ func (params ActivateGradleParams) commonTemplateInventory(
 	metadata common.CacheConfigMetadata,
 	isDebug bool,
 ) PluginCommonTemplateInventory {
+	cliPath := params.CLIPath
+	if cliPath == "" {
+		cliPath = "bitrise-build-cache"
+	}
+
 	return PluginCommonTemplateInventory{
 		AuthToken:  authConfig.TokenInGradleFormat(),
 		Debug:      isDebug,
 		AppSlug:    metadata.BitriseAppID,
 		CIProvider: metadata.CIProvider,
 		Version:    consts.GradleCommonPluginDepVersion,
+		CLIPath:    cliPath,
 	}
 }
 

--- a/internal/config/gradle/activate_for_gradle_params.go
+++ b/internal/config/gradle/activate_for_gradle_params.go
@@ -15,7 +15,7 @@ import (
 const (
 	errFmtInvalidCacheLevel        = "invalid cache validation level, valid options: none, warning, error"
 	errFmtTestDistroAppSlug        = "test distribution plugin was enabled but no BITRISE_APP_SLUG was specified"
-	ErrFmtReadAuthConfig           = "read auth config from environment variables: %w"
+	ErrFmtReadAuthConfig           = "resolve auth config: %w"
 	errFmtCacheConfigCreation      = "couldn't create cache configuration: %w"
 	errFmtTestDistroConfigCreation = "couldn't create test distribution configuration: %w"
 	errFmtInvalidValidationLevel   = "invalid validation level: '%s'"

--- a/internal/config/gradle/activate_for_gradle_params_test.go
+++ b/internal/config/gradle/activate_for_gradle_params_test.go
@@ -77,6 +77,7 @@ func Test_activateGradleParams(t *testing.T) {
 				Common: PluginCommonTemplateInventory{
 					AuthToken: "WorkspaceIDValue:AuthTokenValue",
 					Version:   consts.GradleCommonPluginDepVersion,
+					CLIPath:   "bitrise-build-cache",
 				},
 				Cache: CacheTemplateInventory{
 					Usage: UsageLevelNone,
@@ -113,6 +114,7 @@ func Test_activateGradleParams(t *testing.T) {
 				Common: PluginCommonTemplateInventory{
 					AuthToken: "WorkspaceIDValue:AuthTokenValue",
 					Version:   consts.GradleCommonPluginDepVersion,
+					CLIPath:   "bitrise-build-cache",
 				},
 				Cache: CacheTemplateInventory{
 					Usage:   UsageLevelDependency,
@@ -153,6 +155,7 @@ func Test_activateGradleParams(t *testing.T) {
 				Common: PluginCommonTemplateInventory{
 					AuthToken: "WorkspaceIDValue:AuthTokenValue",
 					Version:   consts.GradleCommonPluginDepVersion,
+					CLIPath:   "bitrise-build-cache",
 				},
 				Cache: CacheTemplateInventory{
 					Usage:               UsageLevelEnabled,
@@ -213,6 +216,7 @@ func Test_activateGradleParams(t *testing.T) {
 				Common: PluginCommonTemplateInventory{
 					AuthToken: "WorkspaceIDValue:AuthTokenValue",
 					Version:   consts.GradleCommonPluginDepVersion,
+					CLIPath:   "bitrise-build-cache",
 				},
 				Cache: CacheTemplateInventory{
 					Usage: UsageLevelNone,
@@ -258,6 +262,7 @@ func Test_activateGradleParams(t *testing.T) {
 					AppSlug:    "AppSlugValue",
 					CIProvider: "bitrise",
 					Version:    consts.GradleCommonPluginDepVersion,
+					CLIPath:    "bitrise-build-cache",
 				},
 				Cache: CacheTemplateInventory{
 					Usage: UsageLevelNone,
@@ -305,6 +310,7 @@ func Test_activateGradleParams(t *testing.T) {
 					AppSlug:    "AppSlugValue",
 					CIProvider: "bitrise",
 					Version:    consts.GradleCommonPluginDepVersion,
+					CLIPath:    "bitrise-build-cache",
 				},
 				Cache: CacheTemplateInventory{
 					Usage: UsageLevelNone,

--- a/internal/config/gradle/gradle_init_template_inventory.go
+++ b/internal/config/gradle/gradle_init_template_inventory.go
@@ -43,6 +43,8 @@ type PluginCommonTemplateInventory struct {
 	AppSlug    string
 	CIProvider string
 	Version    string
+
+	CLIPath string
 }
 
 type TemplateInventory struct {

--- a/internal/config/gradle/gradleconfig_generate_test.go
+++ b/internal/config/gradle/gradleconfig_generate_test.go
@@ -152,9 +152,9 @@ const expectedAuthTokenResolver = `// Resolve the Bitrise auth token at build ti
 // consults env vars → OS keychain → multiplatform analytics config.
 // Wrapped in a ValueSource so it's safe under Gradle's configuration cache
 // (which forbids ad-hoc external processes during configuration). Any failure
-// (timeout, non-zero exit, missing binary) yields an empty token + stderr
-// warning rather than hard-failing; the cache plugin self-disables when it
-// hits the network with no token.
+// (non-zero exit, missing binary) yields an empty token + stderr warning
+// rather than hard-failing; the cache plugin self-disables when it hits the
+// network with no token.
 abstract class BitriseAuthTokenSource : org.gradle.api.provider.ValueSource<String, org.gradle.api.provider.ValueSourceParameters.None> {
     @get:javax.inject.Inject abstract val execOps: org.gradle.process.ExecOperations
     override fun obtain(): String {
@@ -174,7 +174,10 @@ abstract class BitriseAuthTokenSource : org.gradle.api.provider.ValueSource<Stri
     }
 }
 
-val bitriseBuildCacheAuthToken: String = gradle.providers.of(BitriseAuthTokenSource::class.java) {}.get()
+// Init-script scope does not expose ProviderFactory; resolve per-block where it is
+// available (Settings.providers inside settingsEvaluated, Project.providers inside rootProject).
+fun org.gradle.api.provider.ProviderFactory.bitriseAuthToken(): String =
+    of(BitriseAuthTokenSource::class.java) {}.get()
 `
 
 const expectedAllPlugins = expectedImports + "\n" +
@@ -192,7 +195,7 @@ settingsEvaluated {
         registerBuildCacheService(BitriseBuildCache::class.java, BitriseBuildCacheServiceFactory::class.java)
         remote(BitriseBuildCache::class.java) {
             endpoint = "CacheEndpointURLValue"
-            authToken = bitriseBuildCacheAuthToken
+            authToken = providers.bitriseAuthToken()
             isPush = true
             debug = true
             blobValidationLevel = "ValidationLevelValue"
@@ -209,7 +212,7 @@ settingsEvaluated {
             endpoint.set("AnalyticsEndpointURLValue:123")
             httpEndpoint.set("AnalyticsHttpEndpointValue")
             grpcEndpoint.set("AnalyticsGRPCEndpointValue")
-            authToken.set(bitriseBuildCacheAuthToken)
+            authToken.set(providers.bitriseAuthToken())
             dumpEventsToFiles.set(true)
             debug.set(true)
             enabled.set(true)
@@ -227,7 +230,7 @@ rootProject {
     extensions.create("rbe", io.bitrise.gradle.rbe.RBEPluginExtension::class.java).with {
         endpoint.set("TestDistroEndpointValue")
         kvEndpoint.set("TestDistroKvEndpointValue")
-        authToken.set(bitriseBuildCacheAuthToken)
+        authToken.set(providers.bitriseAuthToken())
         logLevel.set("TestDistroLogLevelValue")
         shardSize.set(50)
         testSearchDepth.set(3)

--- a/internal/config/gradle/gradleconfig_generate_test.go
+++ b/internal/config/gradle/gradleconfig_generate_test.go
@@ -64,7 +64,7 @@ func Test_GenerateInitGradle(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name: "Activated plugins gets values from inventory",
+			name: "Activated plugins gets values from inventory (CI bakes auth token literal)",
 			inventory: TemplateInventory{
 				Common: PluginCommonTemplateInventory{
 					AuthToken:  "AuthTokenValue",
@@ -100,7 +100,47 @@ func Test_GenerateInitGradle(t *testing.T) {
 					TestSearchDepth: 3,
 				},
 			},
-			want:    expectedAllPlugins,
+			want:    expectedAllPluginsCI,
+			wantErr: "",
+		},
+		{
+			name: "Activated plugins on local dev (empty CIProvider) shells out to CLI for auth token",
+			inventory: TemplateInventory{
+				Common: PluginCommonTemplateInventory{
+					AuthToken:  "AuthTokenValue",
+					Debug:      true,
+					AppSlug:    "AppSlugValue",
+					CIProvider: "",
+					Version:    "CommonVersionValue",
+					CLIPath:    "CLIPathValue",
+				},
+				Cache: CacheTemplateInventory{
+					Usage:               UsageLevelEnabled,
+					Version:             "CacheVersionValue",
+					EndpointURLWithPort: "CacheEndpointURLValue",
+					IsPushEnabled:       true,
+					ValidationLevel:     "ValidationLevelValue",
+				},
+				Analytics: AnalyticsTemplateInventory{
+					Usage:        UsageLevelEnabled,
+					Version:      "AnalyticsVersionValue",
+					Endpoint:     "AnalyticsEndpointURLValue",
+					Port:         123,
+					HTTPEndpoint: "AnalyticsHttpEndpointValue",
+					GRPCEndpoint: "AnalyticsGRPCEndpointValue",
+				},
+				TestDistro: TestDistroTemplateInventory{
+					Usage:           UsageLevelEnabled,
+					Version:         "TestDistroVersionValue",
+					Endpoint:        "TestDistroEndpointValue",
+					KvEndpoint:      "TestDistroKvEndpointValue",
+					Port:            321,
+					LogLevel:        "TestDistroLogLevelValue",
+					ShardSize:       50,
+					TestSearchDepth: 3,
+				},
+			},
+			want:    expectedAllPluginsLocal,
 			wantErr: "",
 		},
 	}
@@ -147,14 +187,11 @@ const expectedNoPluginActivated = "initscript {\n" + expectedRepositories + "\n}
 const expectedDepOnlyPlugins = "initscript {\n" + expectedRepositories + "\n" + expectedDependencies + "\n}"
 
 //nolint:gosec // expected snippet of generated kotlin script for test assertion, not credentials
-const expectedAuthTokenResolver = `// Resolve the Bitrise auth token at build time via the bitrise-build-cache CLI
-// so credentials never live in plain text inside this init script. The CLI
-// consults env vars → OS keychain → multiplatform analytics config.
-// Wrapped in a ValueSource so it's safe under Gradle's configuration cache
-// (which forbids ad-hoc external processes during configuration). Any failure
-// (non-zero exit, missing binary) yields an empty token + stderr warning
-// rather than hard-failing; the cache plugin self-disables when it hits the
-// network with no token.
+const expectedAuthTokenResolver = `// Local-dev only: resolve the auth token at build time via the bitrise-build-cache
+// CLI so credentials never live in plain text on disk. CI runs (CIProvider set)
+// bake the token literal instead — the same token is already in env vars on the
+// CI VM, and embedding it keeps the init.kts byte-stable across configuration-cache
+// save/restore VMs.
 abstract class BitriseAuthTokenSource : org.gradle.api.provider.ValueSource<String, org.gradle.api.provider.ValueSourceParameters.None> {
     @get:javax.inject.Inject abstract val execOps: org.gradle.process.ExecOperations
     override fun obtain(): String {
@@ -174,13 +211,74 @@ abstract class BitriseAuthTokenSource : org.gradle.api.provider.ValueSource<Stri
     }
 }
 
-// Init-script scope does not expose ProviderFactory; resolve per-block where it is
-// available (Settings.providers inside settingsEvaluated, Project.providers inside rootProject).
 fun org.gradle.api.provider.ProviderFactory.bitriseAuthToken(): String =
     of(BitriseAuthTokenSource::class.java) {}.get()
 `
 
-const expectedAllPlugins = expectedImports + "\n" +
+//nolint:gosec // expected snippet of generated kotlin script for test assertion, not credentials
+const expectedAllPluginsCI = expectedImports + "\n" +
+	"initscript {\n" +
+	expectedRepositories + "\n" +
+	expectedDependencies + "\n}" +
+	`
+settingsEvaluated {
+    buildCache {
+        local {
+            isEnabled = false
+        }
+
+        registerBuildCacheService(BitriseBuildCache::class.java, BitriseBuildCacheServiceFactory::class.java)
+        remote(BitriseBuildCache::class.java) {
+            endpoint = "CacheEndpointURLValue"
+            authToken = "AuthTokenValue"
+            isPush = true
+            debug = true
+            blobValidationLevel = "ValidationLevelValue"
+            cacheGradleVersion = gradle.gradleVersion
+            collectMetadata = false
+        }
+    }
+    rootProject {
+        apply<io.bitrise.gradle.cache.BitriseCCachePlugin>()
+    }
+    rootProject {
+        extensions.create("analytics", AnalyticsPluginExtension::class.java)
+        extensions.configure(AnalyticsPluginExtension::class.java) {
+            endpoint.set("AnalyticsEndpointURLValue:123")
+            httpEndpoint.set("AnalyticsHttpEndpointValue")
+            grpcEndpoint.set("AnalyticsGRPCEndpointValue")
+            authToken.set("AuthTokenValue")
+            dumpEventsToFiles.set(true)
+            debug.set(true)
+            enabled.set(true)
+
+            providerName.set("CIProviderValue")
+
+            bitrise {
+                appSlug.set("AppSlugValue")
+            }
+        }
+        apply<io.bitrise.gradle.analytics.AnalyticsPlugin>()
+    }
+}
+rootProject {
+    extensions.create("rbe", io.bitrise.gradle.rbe.RBEPluginExtension::class.java).with {
+        endpoint.set("TestDistroEndpointValue")
+        kvEndpoint.set("TestDistroKvEndpointValue")
+        authToken.set("AuthTokenValue")
+        logLevel.set("TestDistroLogLevelValue")
+        shardSize.set(50)
+        testSearchDepth.set(3)
+        bitrise {
+            appSlug.set("AppSlugValue")
+        }
+    }
+
+    apply<io.bitrise.gradle.rbe.RBEPlugin>()
+}`
+
+//nolint:gosec // expected snippet of generated kotlin script for test assertion, not credentials
+const expectedAllPluginsLocal = expectedImports + "\n" +
 	expectedAuthTokenResolver +
 	"initscript {\n" +
 	expectedRepositories + "\n" +
@@ -217,7 +315,7 @@ settingsEvaluated {
             debug.set(true)
             enabled.set(true)
 
-            providerName.set("CIProviderValue")
+            providerName.set("")
 
             bitrise {
                 appSlug.set("AppSlugValue")

--- a/internal/config/gradle/gradleconfig_generate_test.go
+++ b/internal/config/gradle/gradleconfig_generate_test.go
@@ -150,29 +150,31 @@ const expectedDepOnlyPlugins = "initscript {\n" + expectedRepositories + "\n" + 
 const expectedAuthTokenResolver = `// Resolve the Bitrise auth token at build time via the bitrise-build-cache CLI
 // so credentials never live in plain text inside this init script. The CLI
 // consults env vars → OS keychain → multiplatform analytics config.
-// On any failure (CLI hang, missing binary, missing token) the lookup returns
-// an empty string and Gradle init continues; the cache plugin self-disables
-// when it hits the network with no token rather than hard-failing the build.
-val bitriseBuildCacheAuthToken: String = run {
-    try {
-        val proc = ProcessBuilder("CLIPathValue", "auth", "token").redirectErrorStream(false).start()
-        val outText = proc.inputStream.bufferedReader().readText().trim()
-        val errText = proc.errorStream.bufferedReader().readText().trim()
-        if (!proc.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)) {
-            proc.destroyForcibly()
-            System.err.println("bitrise-build-cache auth token timed out after 30s; continuing with empty token")
-            return@run ""
+// Wrapped in a ValueSource so it's safe under Gradle's configuration cache
+// (which forbids ad-hoc external processes during configuration). Any failure
+// (timeout, non-zero exit, missing binary) yields an empty token + stderr
+// warning rather than hard-failing; the cache plugin self-disables when it
+// hits the network with no token.
+abstract class BitriseAuthTokenSource : org.gradle.api.provider.ValueSource<String, org.gradle.api.provider.ValueSourceParameters.None> {
+    @get:javax.inject.Inject abstract val execOps: org.gradle.process.ExecOperations
+    override fun obtain(): String {
+        val out = java.io.ByteArrayOutputStream()
+        val err = java.io.ByteArrayOutputStream()
+        val result = execOps.exec {
+            commandLine("CLIPathValue", "auth", "token")
+            standardOutput = out
+            errorOutput = err
+            isIgnoreExitValue = true
         }
-        if (proc.exitValue() != 0) {
-            System.err.println("bitrise-build-cache auth token exited ${proc.exitValue()}: $errText")
-            return@run ""
+        if (result.exitValue != 0) {
+            System.err.println("bitrise-build-cache auth token exited ${result.exitValue}: ${err.toString().trim()}")
+            return ""
         }
-        outText
-    } catch (e: Exception) {
-        System.err.println("bitrise-build-cache auth token failed: ${e.message}; continuing with empty token")
-        ""
+        return out.toString().trim()
     }
 }
+
+val bitriseBuildCacheAuthToken: String = gradle.providers.of(BitriseAuthTokenSource::class.java) {}.get()
 `
 
 const expectedAllPlugins = expectedImports + "\n" +

--- a/internal/config/gradle/gradleconfig_generate_test.go
+++ b/internal/config/gradle/gradleconfig_generate_test.go
@@ -72,6 +72,7 @@ func Test_GenerateInitGradle(t *testing.T) {
 					AppSlug:    "AppSlugValue",
 					CIProvider: "CIProviderValue",
 					Version:    "CommonVersionValue",
+					CLIPath:    "CLIPathValue",
 				},
 				Cache: CacheTemplateInventory{
 					Usage:               UsageLevelEnabled,
@@ -145,8 +146,38 @@ const expectedNoPluginActivated = "initscript {\n" + expectedRepositories + "\n}
 
 const expectedDepOnlyPlugins = "initscript {\n" + expectedRepositories + "\n" + expectedDependencies + "\n}"
 
-const expectedAllPlugins = expectedImports +
-	"\ninitscript {\n" +
+//nolint:gosec // expected snippet of generated kotlin script for test assertion, not credentials
+const expectedAuthTokenResolver = `// Resolve the Bitrise auth token at build time via the bitrise-build-cache CLI
+// so credentials never live in plain text inside this init script. The CLI
+// consults env vars → OS keychain → multiplatform analytics config.
+// On any failure (CLI hang, missing binary, missing token) the lookup returns
+// an empty string and Gradle init continues; the cache plugin self-disables
+// when it hits the network with no token rather than hard-failing the build.
+val bitriseBuildCacheAuthToken: String = run {
+    try {
+        val proc = ProcessBuilder("CLIPathValue", "auth", "token").redirectErrorStream(false).start()
+        val outText = proc.inputStream.bufferedReader().readText().trim()
+        val errText = proc.errorStream.bufferedReader().readText().trim()
+        if (!proc.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)) {
+            proc.destroyForcibly()
+            System.err.println("bitrise-build-cache auth token timed out after 30s; continuing with empty token")
+            return@run ""
+        }
+        if (proc.exitValue() != 0) {
+            System.err.println("bitrise-build-cache auth token exited ${proc.exitValue()}: $errText")
+            return@run ""
+        }
+        outText
+    } catch (e: Exception) {
+        System.err.println("bitrise-build-cache auth token failed: ${e.message}; continuing with empty token")
+        ""
+    }
+}
+`
+
+const expectedAllPlugins = expectedImports + "\n" +
+	expectedAuthTokenResolver +
+	"initscript {\n" +
 	expectedRepositories + "\n" +
 	expectedDependencies + "\n}" +
 	`
@@ -159,7 +190,7 @@ settingsEvaluated {
         registerBuildCacheService(BitriseBuildCache::class.java, BitriseBuildCacheServiceFactory::class.java)
         remote(BitriseBuildCache::class.java) {
             endpoint = "CacheEndpointURLValue"
-            authToken = "AuthTokenValue"
+            authToken = bitriseBuildCacheAuthToken
             isPush = true
             debug = true
             blobValidationLevel = "ValidationLevelValue"
@@ -176,7 +207,7 @@ settingsEvaluated {
             endpoint.set("AnalyticsEndpointURLValue:123")
             httpEndpoint.set("AnalyticsHttpEndpointValue")
             grpcEndpoint.set("AnalyticsGRPCEndpointValue")
-            authToken.set("AuthTokenValue")
+            authToken.set(bitriseBuildCacheAuthToken)
             dumpEventsToFiles.set(true)
             debug.set(true)
             enabled.set(true)
@@ -194,7 +225,7 @@ rootProject {
     extensions.create("rbe", io.bitrise.gradle.rbe.RBEPluginExtension::class.java).with {
         endpoint.set("TestDistroEndpointValue")
         kvEndpoint.set("TestDistroKvEndpointValue")
-        authToken.set("AuthTokenValue")
+        authToken.set(bitriseBuildCacheAuthToken)
         logLevel.set("TestDistroLogLevelValue")
         shardSize.set(50)
         testSearchDepth.set(3)

--- a/internal/config/gradle/initd.gradle.kts.gotemplate
+++ b/internal/config/gradle/initd.gradle.kts.gotemplate
@@ -3,6 +3,35 @@
 {{- if eq .Cache.Usage "enabled" -}}import io.bitrise.gradle.cache.BitriseBuildCache
 import io.bitrise.gradle.cache.BitriseBuildCacheServiceFactory
 {{ end -}}
+{{- if or (eq .Cache.Usage "enabled") (eq .Analytics.Usage "enabled") (eq .TestDistro.Usage "enabled") -}}
+// Resolve the Bitrise auth token at build time via the bitrise-build-cache CLI
+// so credentials never live in plain text inside this init script. The CLI
+// consults env vars → OS keychain → multiplatform analytics config.
+// On any failure (CLI hang, missing binary, missing token) the lookup returns
+// an empty string and Gradle init continues; the cache plugin self-disables
+// when it hits the network with no token rather than hard-failing the build.
+val bitriseBuildCacheAuthToken: String = run {
+    try {
+        val proc = ProcessBuilder("{{ .Common.CLIPath }}", "auth", "token").redirectErrorStream(false).start()
+        val outText = proc.inputStream.bufferedReader().readText().trim()
+        val errText = proc.errorStream.bufferedReader().readText().trim()
+        if (!proc.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)) {
+            proc.destroyForcibly()
+            System.err.println("bitrise-build-cache auth token timed out after 30s; continuing with empty token")
+            return@run ""
+        }
+        if (proc.exitValue() != 0) {
+            System.err.println("bitrise-build-cache auth token exited ${proc.exitValue()}: $errText")
+            return@run ""
+        }
+        outText
+    } catch (e: Exception) {
+        System.err.println("bitrise-build-cache auth token failed: ${e.message}; continuing with empty token")
+        ""
+    }
+}
+{{ end -}}
+
 initscript {
     repositories {
         mavenLocal()
@@ -49,7 +78,7 @@ settingsEvaluated {
         registerBuildCacheService(BitriseBuildCache::class.java, BitriseBuildCacheServiceFactory::class.java)
         remote(BitriseBuildCache::class.java) {
             endpoint = "{{ .Cache.EndpointURLWithPort }}"
-            authToken = "{{ .Common.AuthToken }}"
+            authToken = bitriseBuildCacheAuthToken
             isPush = {{ .Cache.IsPushEnabled }}
             debug = {{ .Common.Debug }}
             blobValidationLevel = "{{ .Cache.ValidationLevel }}"
@@ -70,7 +99,7 @@ settingsEvaluated {
             endpoint.set("{{ .Analytics.Endpoint }}:{{ .Analytics.Port }}")
             httpEndpoint.set("{{ .Analytics.HTTPEndpoint }}")
             grpcEndpoint.set("{{ .Analytics.GRPCEndpoint }}")
-            authToken.set("{{ .Common.AuthToken }}")
+            authToken.set(bitriseBuildCacheAuthToken)
             dumpEventsToFiles.set({{ .Common.Debug }})
             debug.set({{ .Common.Debug }})
             enabled.set(true)
@@ -93,7 +122,7 @@ rootProject {
     extensions.create("rbe", io.bitrise.gradle.rbe.RBEPluginExtension::class.java).with {
         endpoint.set("{{ .TestDistro.Endpoint }}")
         kvEndpoint.set("{{ .TestDistro.KvEndpoint }}")
-        authToken.set("{{ .Common.AuthToken }}")
+        authToken.set(bitriseBuildCacheAuthToken)
         logLevel.set("{{ .TestDistro.LogLevel }}")
         shardSize.set({{ .TestDistro.ShardSize }})
         testSearchDepth.set({{ .TestDistro.TestSearchDepth }})

--- a/internal/config/gradle/initd.gradle.kts.gotemplate
+++ b/internal/config/gradle/initd.gradle.kts.gotemplate
@@ -3,15 +3,12 @@
 {{- if eq .Cache.Usage "enabled" -}}import io.bitrise.gradle.cache.BitriseBuildCache
 import io.bitrise.gradle.cache.BitriseBuildCacheServiceFactory
 {{ end -}}
-{{- if or (eq .Cache.Usage "enabled") (eq .Analytics.Usage "enabled") (eq .TestDistro.Usage "enabled") -}}
-// Resolve the Bitrise auth token at build time via the bitrise-build-cache CLI
-// so credentials never live in plain text inside this init script. The CLI
-// consults env vars → OS keychain → multiplatform analytics config.
-// Wrapped in a ValueSource so it's safe under Gradle's configuration cache
-// (which forbids ad-hoc external processes during configuration). Any failure
-// (non-zero exit, missing binary) yields an empty token + stderr warning
-// rather than hard-failing; the cache plugin self-disables when it hits the
-// network with no token.
+{{- if and (not .Common.CIProvider) (or (eq .Cache.Usage "enabled") (eq .Analytics.Usage "enabled") (eq .TestDistro.Usage "enabled")) -}}
+// Local-dev only: resolve the auth token at build time via the bitrise-build-cache
+// CLI so credentials never live in plain text on disk. CI runs (CIProvider set)
+// bake the token literal instead — the same token is already in env vars on the
+// CI VM, and embedding it keeps the init.kts byte-stable across configuration-cache
+// save/restore VMs.
 abstract class BitriseAuthTokenSource : org.gradle.api.provider.ValueSource<String, org.gradle.api.provider.ValueSourceParameters.None> {
     @get:javax.inject.Inject abstract val execOps: org.gradle.process.ExecOperations
     override fun obtain(): String {
@@ -31,8 +28,6 @@ abstract class BitriseAuthTokenSource : org.gradle.api.provider.ValueSource<Stri
     }
 }
 
-// Init-script scope does not expose ProviderFactory; resolve per-block where it is
-// available (Settings.providers inside settingsEvaluated, Project.providers inside rootProject).
 fun org.gradle.api.provider.ProviderFactory.bitriseAuthToken(): String =
     of(BitriseAuthTokenSource::class.java) {}.get()
 {{ end -}}
@@ -83,7 +78,7 @@ settingsEvaluated {
         registerBuildCacheService(BitriseBuildCache::class.java, BitriseBuildCacheServiceFactory::class.java)
         remote(BitriseBuildCache::class.java) {
             endpoint = "{{ .Cache.EndpointURLWithPort }}"
-            authToken = providers.bitriseAuthToken()
+            authToken = {{ if .Common.CIProvider }}"{{ .Common.AuthToken }}"{{ else }}providers.bitriseAuthToken(){{ end }}
             isPush = {{ .Cache.IsPushEnabled }}
             debug = {{ .Common.Debug }}
             blobValidationLevel = "{{ .Cache.ValidationLevel }}"
@@ -104,7 +99,7 @@ settingsEvaluated {
             endpoint.set("{{ .Analytics.Endpoint }}:{{ .Analytics.Port }}")
             httpEndpoint.set("{{ .Analytics.HTTPEndpoint }}")
             grpcEndpoint.set("{{ .Analytics.GRPCEndpoint }}")
-            authToken.set(providers.bitriseAuthToken())
+            authToken.set({{ if .Common.CIProvider }}"{{ .Common.AuthToken }}"{{ else }}providers.bitriseAuthToken(){{ end }})
             dumpEventsToFiles.set({{ .Common.Debug }})
             debug.set({{ .Common.Debug }})
             enabled.set(true)
@@ -127,7 +122,7 @@ rootProject {
     extensions.create("rbe", io.bitrise.gradle.rbe.RBEPluginExtension::class.java).with {
         endpoint.set("{{ .TestDistro.Endpoint }}")
         kvEndpoint.set("{{ .TestDistro.KvEndpoint }}")
-        authToken.set(providers.bitriseAuthToken())
+        authToken.set({{ if .Common.CIProvider }}"{{ .Common.AuthToken }}"{{ else }}providers.bitriseAuthToken(){{ end }})
         logLevel.set("{{ .TestDistro.LogLevel }}")
         shardSize.set({{ .TestDistro.ShardSize }})
         testSearchDepth.set({{ .TestDistro.TestSearchDepth }})

--- a/internal/config/gradle/initd.gradle.kts.gotemplate
+++ b/internal/config/gradle/initd.gradle.kts.gotemplate
@@ -7,29 +7,31 @@ import io.bitrise.gradle.cache.BitriseBuildCacheServiceFactory
 // Resolve the Bitrise auth token at build time via the bitrise-build-cache CLI
 // so credentials never live in plain text inside this init script. The CLI
 // consults env vars → OS keychain → multiplatform analytics config.
-// On any failure (CLI hang, missing binary, missing token) the lookup returns
-// an empty string and Gradle init continues; the cache plugin self-disables
-// when it hits the network with no token rather than hard-failing the build.
-val bitriseBuildCacheAuthToken: String = run {
-    try {
-        val proc = ProcessBuilder("{{ .Common.CLIPath }}", "auth", "token").redirectErrorStream(false).start()
-        val outText = proc.inputStream.bufferedReader().readText().trim()
-        val errText = proc.errorStream.bufferedReader().readText().trim()
-        if (!proc.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)) {
-            proc.destroyForcibly()
-            System.err.println("bitrise-build-cache auth token timed out after 30s; continuing with empty token")
-            return@run ""
+// Wrapped in a ValueSource so it's safe under Gradle's configuration cache
+// (which forbids ad-hoc external processes during configuration). Any failure
+// (timeout, non-zero exit, missing binary) yields an empty token + stderr
+// warning rather than hard-failing; the cache plugin self-disables when it
+// hits the network with no token.
+abstract class BitriseAuthTokenSource : org.gradle.api.provider.ValueSource<String, org.gradle.api.provider.ValueSourceParameters.None> {
+    @get:javax.inject.Inject abstract val execOps: org.gradle.process.ExecOperations
+    override fun obtain(): String {
+        val out = java.io.ByteArrayOutputStream()
+        val err = java.io.ByteArrayOutputStream()
+        val result = execOps.exec {
+            commandLine("{{ .Common.CLIPath }}", "auth", "token")
+            standardOutput = out
+            errorOutput = err
+            isIgnoreExitValue = true
         }
-        if (proc.exitValue() != 0) {
-            System.err.println("bitrise-build-cache auth token exited ${proc.exitValue()}: $errText")
-            return@run ""
+        if (result.exitValue != 0) {
+            System.err.println("bitrise-build-cache auth token exited ${result.exitValue}: ${err.toString().trim()}")
+            return ""
         }
-        outText
-    } catch (e: Exception) {
-        System.err.println("bitrise-build-cache auth token failed: ${e.message}; continuing with empty token")
-        ""
+        return out.toString().trim()
     }
 }
+
+val bitriseBuildCacheAuthToken: String = gradle.providers.of(BitriseAuthTokenSource::class.java) {}.get()
 {{ end -}}
 
 initscript {

--- a/internal/config/gradle/initd.gradle.kts.gotemplate
+++ b/internal/config/gradle/initd.gradle.kts.gotemplate
@@ -9,9 +9,9 @@ import io.bitrise.gradle.cache.BitriseBuildCacheServiceFactory
 // consults env vars → OS keychain → multiplatform analytics config.
 // Wrapped in a ValueSource so it's safe under Gradle's configuration cache
 // (which forbids ad-hoc external processes during configuration). Any failure
-// (timeout, non-zero exit, missing binary) yields an empty token + stderr
-// warning rather than hard-failing; the cache plugin self-disables when it
-// hits the network with no token.
+// (non-zero exit, missing binary) yields an empty token + stderr warning
+// rather than hard-failing; the cache plugin self-disables when it hits the
+// network with no token.
 abstract class BitriseAuthTokenSource : org.gradle.api.provider.ValueSource<String, org.gradle.api.provider.ValueSourceParameters.None> {
     @get:javax.inject.Inject abstract val execOps: org.gradle.process.ExecOperations
     override fun obtain(): String {
@@ -31,7 +31,10 @@ abstract class BitriseAuthTokenSource : org.gradle.api.provider.ValueSource<Stri
     }
 }
 
-val bitriseBuildCacheAuthToken: String = gradle.providers.of(BitriseAuthTokenSource::class.java) {}.get()
+// Init-script scope does not expose ProviderFactory; resolve per-block where it is
+// available (Settings.providers inside settingsEvaluated, Project.providers inside rootProject).
+fun org.gradle.api.provider.ProviderFactory.bitriseAuthToken(): String =
+    of(BitriseAuthTokenSource::class.java) {}.get()
 {{ end -}}
 
 initscript {
@@ -80,7 +83,7 @@ settingsEvaluated {
         registerBuildCacheService(BitriseBuildCache::class.java, BitriseBuildCacheServiceFactory::class.java)
         remote(BitriseBuildCache::class.java) {
             endpoint = "{{ .Cache.EndpointURLWithPort }}"
-            authToken = bitriseBuildCacheAuthToken
+            authToken = providers.bitriseAuthToken()
             isPush = {{ .Cache.IsPushEnabled }}
             debug = {{ .Common.Debug }}
             blobValidationLevel = "{{ .Cache.ValidationLevel }}"
@@ -101,7 +104,7 @@ settingsEvaluated {
             endpoint.set("{{ .Analytics.Endpoint }}:{{ .Analytics.Port }}")
             httpEndpoint.set("{{ .Analytics.HTTPEndpoint }}")
             grpcEndpoint.set("{{ .Analytics.GRPCEndpoint }}")
-            authToken.set(bitriseBuildCacheAuthToken)
+            authToken.set(providers.bitriseAuthToken())
             dumpEventsToFiles.set({{ .Common.Debug }})
             debug.set({{ .Common.Debug }})
             enabled.set(true)
@@ -124,7 +127,7 @@ rootProject {
     extensions.create("rbe", io.bitrise.gradle.rbe.RBEPluginExtension::class.java).with {
         endpoint.set("{{ .TestDistro.Endpoint }}")
         kvEndpoint.set("{{ .TestDistro.KvEndpoint }}")
-        authToken.set(bitriseBuildCacheAuthToken)
+        authToken.set(providers.bitriseAuthToken())
         logLevel.set("{{ .TestDistro.LogLevel }}")
         shardSize.set({{ .TestDistro.ShardSize }})
         testSearchDepth.set({{ .TestDistro.TestSearchDepth }})

--- a/internal/config/multiplatform/config.go
+++ b/internal/config/multiplatform/config.go
@@ -39,7 +39,8 @@ func dirPath(osProxy utils.OsProxy) string {
 	return filepath.Join(".", configPath)
 }
 
-func filePath(osProxy utils.OsProxy) string {
+// FilePath returns the absolute path of the multiplatform analytics config file.
+func FilePath(osProxy utils.OsProxy) string {
 	return filepath.Join(dirPath(osProxy), configFile)
 }
 
@@ -50,7 +51,7 @@ func (c Config) Save(osProxy utils.OsProxy, encoderFactory utils.EncoderFactory)
 		return fmt.Errorf(ErrFmtCreateFolder, dir, err)
 	}
 
-	path := filePath(osProxy)
+	path := FilePath(osProxy)
 	f, err := osProxy.Create(path)
 	if err != nil {
 		return fmt.Errorf(ErrFmtCreateConfigFile, err)
@@ -73,7 +74,7 @@ func (c Config) Save(osProxy utils.OsProxy, encoderFactory utils.EncoderFactory)
 
 // ReadConfig loads the config from disk.
 func ReadConfig(osProxy utils.OsProxy, decoderFactory utils.DecoderFactory) (Config, error) {
-	path := filePath(osProxy)
+	path := FilePath(osProxy)
 
 	f, err := osProxy.OpenFile(path, 0, 0)
 	if err != nil {

--- a/internal/config/multiplatform/register.go
+++ b/internal/config/multiplatform/register.go
@@ -1,0 +1,19 @@
+package multiplatform
+
+import (
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+)
+
+func init() { //nolint:gochecknoinits
+	common.RegisterMultiplatformReader(readMultiplatformAuthConfig)
+}
+
+func readMultiplatformAuthConfig() (common.CacheAuthConfig, error) {
+	cfg, err := ReadConfig(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
+	if err != nil {
+		return common.CacheAuthConfig{}, err //nolint:wrapcheck // surfaced only as a fallback signal
+	}
+
+	return cfg.AuthConfig, nil
+}

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -65,7 +65,7 @@ func Activate(
 
 	authConfig, err := configcommon.ResolveAuthConfig(envs)
 	if err != nil {
-		return fmt.Errorf("read auth config from environment variables: %w", err)
+		return fmt.Errorf("resolve auth config: %w", err)
 	}
 
 	benchmarkClient := configcommon.NewBenchmarkPhaseClient(consts.BitriseWebsiteBaseURL, authConfig, logger)

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -63,7 +63,11 @@ func Activate(
 	overrideActivateXcodeParamsFromExistingConfig(
 		logger, osProxy, &activateXcodeParams, decoderFactory, envs)
 
-	authConfig, _ := configcommon.ResolveAuthConfig(envs)
+	authConfig, err := configcommon.ResolveAuthConfig(envs)
+	if err != nil {
+		return fmt.Errorf("read auth config from environment variables: %w", err)
+	}
+
 	benchmarkClient := configcommon.NewBenchmarkPhaseClient(consts.BitriseWebsiteBaseURL, authConfig, logger)
 
 	config, err := NewConfig(

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -63,7 +63,7 @@ func Activate(
 	overrideActivateXcodeParamsFromExistingConfig(
 		logger, osProxy, &activateXcodeParams, decoderFactory, envs)
 
-	authConfig, _ := configcommon.ReadAuthConfigFromEnvironments(envs)
+	authConfig, _ := configcommon.ResolveAuthConfig(envs)
 	benchmarkClient := configcommon.NewBenchmarkPhaseClient(consts.BitriseWebsiteBaseURL, authConfig, logger)
 
 	config, err := NewConfig(

--- a/internal/config/xcelerate/config.go
+++ b/internal/config/xcelerate/config.go
@@ -25,7 +25,7 @@ const (
 	ErrFmtCreateConfigFile = `failed to create xcelerate config file: %w`
 	ErrFmtEncodeConfigFile = `failed to encode xcelerate config file: %w`
 	ErrFmtCreateFolder     = `failed to create .xcelerate folder (%s): %w`
-	ErrNoAuthConfig        = "read auth config: %w"
+	ErrNoAuthConfig        = "resolve auth config: %w"
 )
 
 type Params struct {

--- a/internal/config/xcelerate/config.go
+++ b/internal/config/xcelerate/config.go
@@ -126,7 +126,7 @@ func NewConfig(ctx context.Context,
 	exporter EnvExporter,
 	benchmarkProvider common.BenchmarkPhaseProvider,
 ) (Config, error) {
-	authConfig, err := common.ReadAuthConfigFromEnvironments(envs)
+	authConfig, err := common.ResolveAuthConfig(envs)
 	if err != nil {
 		return Config{}, fmt.Errorf(ErrNoAuthConfig, err)
 	}

--- a/internal/config/xcelerate/config_test.go
+++ b/internal/config/xcelerate/config_test.go
@@ -250,7 +250,11 @@ func TestConfig_AuthBackwardsCompat(t *testing.T) {
 }
 
 func TestConfig_NewConfig(t *testing.T) {
-	t.Run("When auth env vars are not set, returns error", func(t *testing.T) {
+	t.Run("When no auth source is configured, returns error", func(t *testing.T) {
+		// Isolate from the dev machine's real keychain + multiplatform config
+		// so ResolveAuthConfig's fallback chain finds nothing.
+		t.Setenv("HOME", t.TempDir())
+
 		osProxyMock := &utilsMocks.OsProxyMock{}
 
 		_, err := xcelerate.NewConfig(context.Background(), nil, xcelerate.Params{}, map[string]string{}, osProxyMock, nil, nil, nil)

--- a/internal/config/xcelerate/paths.go
+++ b/internal/config/xcelerate/paths.go
@@ -35,3 +35,8 @@ func DirPath(osProxy utils.OsProxy) string {
 func PathFor(osProxy utils.OsProxy, subpath string) string {
 	return filepath.Join(DirPath(osProxy), subpath)
 }
+
+// ConfigFile returns the absolute path of the xcelerate config.json.
+func ConfigFile(osProxy utils.OsProxy) string {
+	return PathFor(osProxy, xcelerateConfigFileName)
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -44,6 +44,9 @@ const (
 
 	// xcelerateConfigFile is the JSON config file written by `activate xcode`.
 	xcelerateConfigFile = "config.json"
+
+	// gradleInitScriptRelative is the per-user gradle init script written by `activate gradle`.
+	gradleInitScriptRelative = ".gradle/init.d/bitrise-build-cache.init.gradle.kts"
 )
 
 // Paths resolves on-disk locations rooted at a single home directory.
@@ -159,4 +162,9 @@ func (p Paths) XcelerateBinFile(name string) string {
 // ProxySocketPath returns the xcelerate proxy unix-socket path under the supplied temp dir.
 func (p Paths) ProxySocketPath(tempDir string) string {
 	return filepath.Join(tempDir, ProxySocketName)
+}
+
+// GradleInitScriptFile returns the absolute path of the generated gradle init script.
+func (p Paths) GradleInitScriptFile() string {
+	return filepath.Join(p.Home, gradleInitScriptRelative)
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/auth"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/bazel"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/ccache"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"

--- a/pkg/file/helper.go
+++ b/pkg/file/helper.go
@@ -155,7 +155,7 @@ func (h *Helper) Restore(ctx context.Context, key, filePath string) error {
 func (h *Helper) newKVClient(ctx context.Context) (*kv.Client, error) {
 	authConfig, err := configcommon.ResolveAuthConfig(h.envs)
 	if err != nil {
-		return nil, fmt.Errorf("read auth config from environments: %w", err)
+		return nil, fmt.Errorf("resolve auth config: %w", err)
 	}
 
 	endpointURL := configcommon.SelectCacheEndpointURL(h.endpointURL, h.envs)

--- a/pkg/file/helper.go
+++ b/pkg/file/helper.go
@@ -153,7 +153,7 @@ func (h *Helper) Restore(ctx context.Context, key, filePath string) error {
 // ---------------------------------------------------------------------------
 
 func (h *Helper) newKVClient(ctx context.Context) (*kv.Client, error) {
-	authConfig, err := configcommon.ReadAuthConfigFromEnvironments(h.envs)
+	authConfig, err := configcommon.ResolveAuthConfig(h.envs)
 	if err != nil {
 		return nil, fmt.Errorf("read auth config from environments: %w", err)
 	}

--- a/pkg/file/helper.go
+++ b/pkg/file/helper.go
@@ -137,11 +137,10 @@ func (h *Helper) Restore(ctx context.Context, key, filePath string) error {
 	}
 
 	h.logger.TInfof("Downloading %s for key %s", filePath, key)
-	if err := kvClient.DownloadFileFromBuildCache(ctx, filePath, key); err != nil {
-		if errors.Is(err, kv.ErrCacheNotFound) {
-			return fmt.Errorf("no cache item found for key %q: %w", key, err)
-		}
-
+	switch err := kvClient.DownloadFileFromBuildCache(ctx, filePath, key); {
+	case errors.Is(err, kv.ErrCacheNotFound):
+		return fmt.Errorf("no cache item found for key %q: %w", key, err)
+	case err != nil:
 		return fmt.Errorf("download file from build cache: %w", err)
 	}
 

--- a/pkg/reactnative/activator.go
+++ b/pkg/reactnative/activator.go
@@ -350,7 +350,7 @@ func (s *storageHelperStarter) start() error {
 func saveMultiplatformConfig(debugLogging bool) error {
 	authConfig, err := configcommon.ResolveAuthConfig(utils.AllEnvs())
 	if err != nil {
-		return fmt.Errorf("read auth config for multiplatform analytics: %w", err)
+		return fmt.Errorf("resolve auth config for multiplatform analytics: %w", err)
 	}
 
 	cfg := multiplatformconfig.Config{

--- a/pkg/reactnative/activator.go
+++ b/pkg/reactnative/activator.go
@@ -348,7 +348,7 @@ func (s *storageHelperStarter) start() error {
 }
 
 func saveMultiplatformConfig(debugLogging bool) error {
-	authConfig, err := configcommon.ReadAuthConfigFromEnvironments(utils.AllEnvs())
+	authConfig, err := configcommon.ResolveAuthConfig(utils.AllEnvs())
 	if err != nil {
 		return fmt.Errorf("read auth config for multiplatform analytics: %w", err)
 	}


### PR DESCRIPTION
## Summary

- New package `internal/auth/keychain` — Get/Set/Delete credentials in the OS secret store (macOS Keychain on macOS, secret-service via D-Bus on Linux, credman on Windows). Uses `zalando/go-keyring` v0.2.8 (Go 1.18+, no CGO).
- New `bitrise-build-cache auth` command group: `set`, `get` (masked last-4), `clear`.
- New `configcommon.ResolveAuthConfig(envs)` — tries keychain first, falls back to existing env-var read on any error (ErrNotFound, missing D-Bus, partial creds, etc). The original `ReadAuthConfigFromEnvironments` is kept for callers that explicitly want env-only behavior.
- All 12 production auth-read call sites migrated to `ResolveAuthConfig`. Tests are unchanged where they exercise env-only logic.

## Why

Closes [ACI-5028](https://bitrise.atlassian.net/browse/ACI-5028). Customers shouldn't have to keep `BITRISE_BUILD_CACHE_AUTH_TOKEN` in their shell rc files. CI keeps working unchanged because keychain errors transparently fall through to env.

## What's intentionally NOT in this PR

- **Migration prompt** (env → keychain) is deferred to [ACI-5027 (A1 — `activate --interactive` wizard)](https://bitrise.atlassian.net/browse/ACI-5027), which is the natural surface for an interactive import flow. Per the spike-discussion decision (Q4 = c, only inside the wizard).
- Masked stdin prompt on `auth set`. Currently `--token` and `--workspace-id` are required flags. The masked-prompt UX belongs to the wizard ticket.

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` — 0 issues
- [x] `make test-unit` — all packages green
- [x] New unit tests:
  - `internal/auth/keychain/keychain_test.go` — round-trip, ErrNotFound, replace-value, clear, backend-error wrapping.
  - `internal/config/common/auth_test.go` — `ResolveAuthConfig` with fake loader: keychain hit, ErrNotFound fallthrough, backend-error fallthrough, empty-creds fallthrough, partial-creds fallthrough.
- [x] Smoke test on macOS: `auth set` → `auth get` shows workspace + `****<last4>` → `auth clear` → `auth get` reports "no credentials".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5028]: https://bitrise.atlassian.net/browse/ACI-5028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ