### PR TITLE
feat: ACI-5034 add bitrise-build-cache health subcommand

### DIFF
--- a/cmd/health/health.go
+++ b/cmd/health/health.go
@@ -1,0 +1,97 @@
+package health
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	healthpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/health"
+)
+
+const (
+	colorReset  = "\033[0m"
+	colorGreen  = "\033[32m"
+	colorYellow = "\033[33m"
+	colorRed    = "\033[31m"
+)
+
+//nolint:gochecknoglobals
+var jsonOutput bool
+
+//nolint:gochecknoglobals
+var healthCmd = &cobra.Command{
+	Use:          "health",
+	Short:        "Show the health of the local Bitrise Build Cache setup",
+	Long:         `Show the health of the local Bitrise Build Cache setup — proxy state, auth credentials, CLI version. Default output is human-readable. Use --json for tooling.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		runner := healthpkg.NewRunner()
+		s := runner.Run(cmd.Context())
+
+		if jsonOutput {
+			return writeJSON(os.Stdout, s)
+		}
+
+		writeHuman(os.Stdout, s)
+
+		if s.Overall() == healthpkg.StateError {
+			return fmt.Errorf("status reported errors")
+		}
+
+		return nil
+	},
+}
+
+func writeJSON(w *os.File, s healthpkg.Status) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(s); err != nil {
+		return fmt.Errorf("encode status as JSON: %w", err)
+	}
+
+	return nil
+}
+
+func writeHuman(w *os.File, s healthpkg.Status) {
+	fmt.Fprintf(w, "Bitrise Build Cache CLI %s\n\n", s.Version)
+	for _, c := range s.Checks {
+		fmt.Fprintf(w, "  %s %-18s %s\n", icon(c.State), c.Name, c.Detail)
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Overall: %s%s%s\n", overallColor(s.Overall()), s.Overall(), colorReset)
+}
+
+func icon(state healthpkg.State) string {
+	switch state {
+	case healthpkg.StateOK:
+		return colorGreen + "✓" + colorReset
+	case healthpkg.StateWarn:
+		return colorYellow + "!" + colorReset
+	case healthpkg.StateError:
+		return colorRed + "✗" + colorReset
+	default:
+		return "?"
+	}
+}
+
+func overallColor(state healthpkg.State) string {
+	switch state {
+	case healthpkg.StateOK:
+		return colorGreen
+	case healthpkg.StateWarn:
+		return colorYellow
+	case healthpkg.StateError:
+		return colorRed
+	default:
+		return ""
+	}
+}
+
+func init() {
+	healthCmd.Flags().BoolVar(&jsonOutput, "json", false, "Emit status as JSON instead of human-readable text")
+	common.RootCmd.AddCommand(healthCmd)
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,0 +1,303 @@
+// Package status implements the "is it working right now?" check that backs
+// the `bitrise-build-cache status` subcommand.
+//
+// Each check is a small function returning a Check value. The runner gathers
+// all checks into a Status struct that can be rendered human-readably or as
+// JSON. Individual check failures don't abort the run — partial results are
+// the point.
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+)
+
+// State is the severity of a single Check.
+type State string
+
+const (
+	StateOK    State = "ok"
+	StateWarn  State = "warn"
+	StateError State = "error"
+)
+
+// Check is a single status result.
+type Check struct {
+	Name   string `json:"name"`
+	State  State  `json:"state"`
+	Detail string `json:"detail"`
+}
+
+// Status is the aggregated result returned by Run.
+type Status struct {
+	Checks  []Check `json:"checks"`
+	Version string  `json:"cli_version"`
+}
+
+// Overall returns the worst state across all checks.
+func (s Status) Overall() State {
+	worst := StateOK
+	for _, c := range s.Checks {
+		switch c.State {
+		case StateError:
+			return StateError
+		case StateWarn:
+			worst = StateWarn
+		case StateOK:
+		}
+	}
+
+	return worst
+}
+
+// authLoader is the slice of *keychain.Keychain we depend on (DI for tests).
+type authLoader interface {
+	Load() (keychain.Credentials, error)
+}
+
+// Runner aggregates the individual checks. Each field can be overridden for
+// tests; nil means "use the default implementation".
+type Runner struct {
+	OsProxy    utils.OsProxy
+	AuthLoader authLoader
+	Envs       map[string]string
+	CLIVersion string
+	HTTPClient *http.Client
+	// LatestReleaseTag returns the latest released CLI tag (e.g. "v2.8.4"),
+	// or "" + nil error when the lookup is intentionally skipped. Errors bubble
+	// up to the check as a warn.
+	LatestReleaseTag func(ctx context.Context, c *http.Client) (string, error)
+	// XcelerateProxyDir returns the directory the xcelerate proxy writes its
+	// pid file into. Default uses xcelerate.DirPath.
+	XcelerateProxyDir func() string
+}
+
+// NewRunner returns a Runner with production defaults.
+func NewRunner() *Runner {
+	osProxy := utils.DefaultOsProxy{}
+
+	return &Runner{
+		OsProxy:           osProxy,
+		AuthLoader:        keychain.New(),
+		Envs:              utils.AllEnvs(),
+		CLIVersion:        common.GetCLIVersion(nil),
+		HTTPClient:        &http.Client{Timeout: 3 * time.Second},
+		LatestReleaseTag:  fetchLatestGitHubRelease,
+		XcelerateProxyDir: func() string { return xcelerate.DirPath(osProxy) },
+	}
+}
+
+// Run executes every check in order and returns the aggregated Status.
+func (r *Runner) Run(ctx context.Context) Status {
+	checks := []Check{
+		r.checkXcelerateProxy(),
+		r.checkCcacheHelper(ctx),
+		r.checkAuth(),
+		r.checkCLIVersion(ctx),
+	}
+
+	return Status{
+		Checks:  checks,
+		Version: r.CLIVersion,
+	}
+}
+
+func (r *Runner) checkCcacheHelper(ctx context.Context) Check {
+	const name = "ccache-helper"
+
+	socketPath := r.Envs["BITRISE_CCACHE_IPC_SOCKET_PATH"]
+	if socketPath == "" {
+		socketPath = os.TempDir() + "/ccache-ipc.sock"
+	}
+
+	if _, err := os.Stat(socketPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return Check{
+				Name:   name,
+				State:  StateWarn,
+				Detail: "not running (no socket file). Run `bitrise-build-cache ccache start-storage-helper` if you're using ccache.",
+			}
+		}
+
+		return Check{Name: name, State: StateError, Detail: "stat ccache socket: " + err.Error()}
+	}
+
+	// Probe the socket — proves a process is actually listening, not just a
+	// stale inode left after a crash.
+	dialer := &net.Dialer{Timeout: 500 * time.Millisecond}
+	probeCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	conn, err := dialer.DialContext(probeCtx, "unix", socketPath)
+	if err != nil {
+		return Check{
+			Name:   name,
+			State:  StateError,
+			Detail: fmt.Sprintf("socket %s present but not accepting connections (%v). Remove the socket or restart the helper.", socketPath, err),
+		}
+	}
+	_ = conn.Close()
+
+	return Check{Name: name, State: StateOK, Detail: "running (" + socketPath + ")"}
+}
+
+func (r *Runner) checkXcelerateProxy() Check {
+	const name = "xcelerate-proxy"
+
+	pidFile := r.XcelerateProxyDir() + "/proxy.pid"
+
+	content, err := os.ReadFile(pidFile) //nolint:gosec // we control the path
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return Check{
+				Name:   name,
+				State:  StateWarn,
+				Detail: "not running (no pid file). Run `bitrise-build-cache xcelerate start-proxy` or `auth set` + `activate` first.",
+			}
+		}
+
+		return Check{Name: name, State: StateError, Detail: "read pid file: " + err.Error()}
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(content)))
+	if err != nil {
+		return Check{Name: name, State: StateError, Detail: "pid file content invalid: " + err.Error()}
+	}
+
+	if err := syscall.Kill(pid, 0); err != nil {
+		return Check{
+			Name:   name,
+			State:  StateError,
+			Detail: fmt.Sprintf("pid %d in pid file but process not running. Stale pid file — remove %s or run start-proxy again.", pid, pidFile),
+		}
+	}
+
+	return Check{Name: name, State: StateOK, Detail: fmt.Sprintf("running (pid %d)", pid)}
+}
+
+func (r *Runner) checkAuth() Check {
+	const name = "auth"
+
+	if r.AuthLoader != nil {
+		creds, err := r.AuthLoader.Load()
+		if err == nil && creds.AuthToken != "" && creds.WorkspaceID != "" {
+			return Check{
+				Name:   name,
+				State:  StateOK,
+				Detail: fmt.Sprintf("OS keychain, workspace=%s", creds.WorkspaceID),
+			}
+		}
+	}
+
+	if cfg, err := common.ReadAuthConfigFromEnvironments(r.Envs); err == nil {
+		return Check{
+			Name:   name,
+			State:  StateOK,
+			Detail: fmt.Sprintf("environment variables, workspace=%s", cfg.WorkspaceID),
+		}
+	}
+
+	return Check{
+		Name:   name,
+		State:  StateError,
+		Detail: "no credentials found. Run `bitrise-build-cache auth set --token … --workspace-id …` or set BITRISE_BUILD_CACHE_AUTH_TOKEN + BITRISE_BUILD_CACHE_WORKSPACE_ID.",
+	}
+}
+
+func (r *Runner) checkCLIVersion(ctx context.Context) Check {
+	const name = "cli-version"
+
+	current := r.CLIVersion
+	if current == "" {
+		current = "devel"
+	}
+
+	// Local/devel builds are tagged with "+", "dirty" or "devel" and aren't
+	// meaningful to compare against released tags.
+	if isLocalBuild(current) {
+		return Check{Name: name, State: StateOK, Detail: fmt.Sprintf("current=%s (local build)", current)}
+	}
+
+	latest, err := r.LatestReleaseTag(ctx, r.HTTPClient)
+	if err != nil {
+		return Check{
+			Name:   name,
+			State:  StateWarn,
+			Detail: fmt.Sprintf("current=%s; could not check latest (%v)", current, err),
+		}
+	}
+	if latest == "" {
+		return Check{Name: name, State: StateOK, Detail: fmt.Sprintf("current=%s", current)}
+	}
+
+	if current == latest || strings.TrimPrefix(current, "v") == strings.TrimPrefix(latest, "v") {
+		return Check{Name: name, State: StateOK, Detail: fmt.Sprintf("current=%s (up to date)", current)}
+	}
+
+	return Check{
+		Name:   name,
+		State:  StateWarn,
+		Detail: fmt.Sprintf("current=%s, latest=%s — run `bitrise-build-cache update` or `brew upgrade`", current, latest),
+	}
+}
+
+func isLocalBuild(version string) bool {
+	return version == "devel" ||
+		strings.Contains(version, "+") ||
+		strings.Contains(version, "dirty")
+}
+
+// fetchLatestGitHubRelease returns the tag_name of the most recent CLI release
+// on GitHub. Network errors / 404s are returned to the caller so the check
+// renders as warn (not error).
+func fetchLatestGitHubRelease(ctx context.Context, client *http.Client) (string, error) {
+	if client == nil {
+		client = &http.Client{Timeout: 3 * time.Second}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"https://api.github.com/repos/bitrise-io/bitrise-build-cache-cli/releases/latest", nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// Distinguish offline / DNS from generic transport errors.
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return "", fmt.Errorf("timeout: %w", err)
+		}
+
+		return "", fmt.Errorf("http get: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github releases API returned %s", resp.Status)
+	}
+
+	var payload struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode release payload: %w", err)
+	}
+
+	return payload.TagName, nil
+}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,0 +1,215 @@
+//go:build unit
+
+package health
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+)
+
+type fakeAuthLoader struct {
+	creds keychain.Credentials
+	err   error
+}
+
+func (f fakeAuthLoader) Load() (keychain.Credentials, error) { return f.creds, f.err }
+
+func TestStatus_Overall(t *testing.T) {
+	tests := []struct {
+		name   string
+		checks []Check
+		want   State
+	}{
+		{"empty", nil, StateOK},
+		{"all ok", []Check{{State: StateOK}, {State: StateOK}}, StateOK},
+		{"warn beats ok", []Check{{State: StateOK}, {State: StateWarn}}, StateWarn},
+		{"error beats warn", []Check{{State: StateWarn}, {State: StateError}, {State: StateOK}}, StateError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Status{Checks: tt.checks}.Overall())
+		})
+	}
+}
+
+func TestIsLocalBuild(t *testing.T) {
+	tests := []struct {
+		v    string
+		want bool
+	}{
+		{"devel", true},
+		{"", false},
+		{"v2.8.3", false},
+		{"v2.8.4-0.20260603111341-4d0e865a220a+dirty", true},
+		{"v2.8.4+local", true},
+		{"v2.9.0-rc1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.v, func(t *testing.T) {
+			assert.Equal(t, tt.want, isLocalBuild(tt.v))
+		})
+	}
+}
+
+func TestRun_xcelerateProxyMissingPidIsWarn(t *testing.T) {
+	dir := t.TempDir() // empty: no proxy.pid → warn, not error
+
+	r := &Runner{
+		Envs:              map[string]string{},
+		AuthLoader:        fakeAuthLoader{creds: keychain.Credentials{AuthToken: "t", WorkspaceID: "w"}},
+		CLIVersion:        "devel",
+		HTTPClient:        &http.Client{},
+		LatestReleaseTag:  func(context.Context, *http.Client) (string, error) { return "", nil },
+		XcelerateProxyDir: func() string { return dir },
+	}
+
+	s := r.Run(context.Background())
+
+	require.Len(t, s.Checks, 4)
+	assert.Equal(t, "xcelerate-proxy", s.Checks[0].Name)
+	assert.Equal(t, StateWarn, s.Checks[0].State, "no pid file should be warn, not error")
+}
+
+func TestRun_xcelerateProxyStalePidIsError(t *testing.T) {
+	dir := t.TempDir()
+
+	// PID 1 always exists on POSIX but signal-0 may succeed; pick an
+	// implausibly-large PID instead so syscall.Kill returns ESRCH.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "proxy.pid"), []byte(strconv.Itoa(99999999)), 0o600))
+
+	r := &Runner{
+		Envs:              map[string]string{},
+		AuthLoader:        fakeAuthLoader{creds: keychain.Credentials{AuthToken: "t", WorkspaceID: "w"}},
+		CLIVersion:        "devel",
+		HTTPClient:        &http.Client{},
+		LatestReleaseTag:  func(context.Context, *http.Client) (string, error) { return "", nil },
+		XcelerateProxyDir: func() string { return dir },
+	}
+
+	s := r.Run(context.Background())
+	assert.Equal(t, "xcelerate-proxy", s.Checks[0].Name)
+	assert.Equal(t, StateError, s.Checks[0].State)
+}
+
+func TestRun_authFromKeychain(t *testing.T) {
+	r := &Runner{
+		Envs:              map[string]string{},
+		AuthLoader:        fakeAuthLoader{creds: keychain.Credentials{AuthToken: "tok", WorkspaceID: "ws-keychain"}},
+		CLIVersion:        "devel",
+		HTTPClient:        &http.Client{},
+		LatestReleaseTag:  func(context.Context, *http.Client) (string, error) { return "", nil },
+		XcelerateProxyDir: func() string { return t.TempDir() },
+	}
+
+	s := r.Run(context.Background())
+
+	auth := s.Checks[2]
+	assert.Equal(t, "auth", auth.Name)
+	assert.Equal(t, StateOK, auth.State)
+	assert.Contains(t, auth.Detail, "OS keychain")
+	assert.Contains(t, auth.Detail, "ws-keychain")
+}
+
+func TestRun_authFromEnvWhenKeychainEmpty(t *testing.T) {
+	r := &Runner{
+		Envs: map[string]string{
+			"BITRISE_BUILD_CACHE_AUTH_TOKEN":   "env-tok",
+			"BITRISE_BUILD_CACHE_WORKSPACE_ID": "ws-env",
+		},
+		AuthLoader:        fakeAuthLoader{err: keychain.ErrNotFound},
+		CLIVersion:        "devel",
+		HTTPClient:        &http.Client{},
+		LatestReleaseTag:  func(context.Context, *http.Client) (string, error) { return "", nil },
+		XcelerateProxyDir: func() string { return t.TempDir() },
+	}
+
+	auth := r.Run(context.Background()).Checks[2]
+	assert.Equal(t, StateOK, auth.State)
+	assert.Contains(t, auth.Detail, "environment variables")
+	assert.Contains(t, auth.Detail, "ws-env")
+}
+
+func TestRun_authMissingIsError(t *testing.T) {
+	r := &Runner{
+		Envs:              map[string]string{},
+		AuthLoader:        fakeAuthLoader{err: keychain.ErrNotFound},
+		CLIVersion:        "devel",
+		HTTPClient:        &http.Client{},
+		LatestReleaseTag:  func(context.Context, *http.Client) (string, error) { return "", nil },
+		XcelerateProxyDir: func() string { return t.TempDir() },
+	}
+
+	auth := r.Run(context.Background()).Checks[2]
+	assert.Equal(t, StateError, auth.State)
+}
+
+func TestRun_versionBehindLatestWarns(t *testing.T) {
+	r := &Runner{
+		Envs:              map[string]string{},
+		AuthLoader:        fakeAuthLoader{creds: keychain.Credentials{AuthToken: "t", WorkspaceID: "w"}},
+		CLIVersion:        "v2.8.0",
+		HTTPClient:        &http.Client{},
+		LatestReleaseTag:  func(context.Context, *http.Client) (string, error) { return "v2.8.3", nil },
+		XcelerateProxyDir: func() string { return t.TempDir() },
+	}
+
+	v := r.Run(context.Background()).Checks[3]
+	assert.Equal(t, "cli-version", v.Name)
+	assert.Equal(t, StateWarn, v.State)
+	assert.Contains(t, v.Detail, "latest=v2.8.3")
+}
+
+func TestRun_versionLatestUnreachableWarns(t *testing.T) {
+	r := &Runner{
+		Envs:              map[string]string{},
+		AuthLoader:        fakeAuthLoader{creds: keychain.Credentials{AuthToken: "t", WorkspaceID: "w"}},
+		CLIVersion:        "v2.8.3",
+		HTTPClient:        &http.Client{},
+		LatestReleaseTag:  func(context.Context, *http.Client) (string, error) { return "", errors.New("offline") },
+		XcelerateProxyDir: func() string { return t.TempDir() },
+	}
+
+	v := r.Run(context.Background()).Checks[3]
+	assert.Equal(t, StateWarn, v.State)
+	assert.Contains(t, v.Detail, "could not check latest")
+}
+
+func TestRun_versionDirtyTreatedAsLocal(t *testing.T) {
+	r := &Runner{
+		Envs:              map[string]string{},
+		AuthLoader:        fakeAuthLoader{creds: keychain.Credentials{AuthToken: "t", WorkspaceID: "w"}},
+		CLIVersion:        "v2.8.4-0.xxx+dirty",
+		HTTPClient:        &http.Client{},
+		LatestReleaseTag:  func(context.Context, *http.Client) (string, error) { return "v2.8.3", nil },
+		XcelerateProxyDir: func() string { return t.TempDir() },
+	}
+
+	v := r.Run(context.Background()).Checks[3]
+	assert.Equal(t, StateOK, v.State, "local builds shouldn't warn about being newer than a release")
+	assert.Contains(t, v.Detail, "local build")
+}
+
+func TestRun_ccacheNoSocketIsWarn(t *testing.T) {
+	r := &Runner{
+		Envs:              map[string]string{"BITRISE_CCACHE_IPC_SOCKET_PATH": filepath.Join(t.TempDir(), "missing.sock")},
+		AuthLoader:        fakeAuthLoader{creds: keychain.Credentials{AuthToken: "t", WorkspaceID: "w"}},
+		CLIVersion:        "devel",
+		HTTPClient:        &http.Client{},
+		LatestReleaseTag:  func(context.Context, *http.Client) (string, error) { return "", nil },
+		XcelerateProxyDir: func() string { return t.TempDir() },
+	}
+
+	cc := r.Run(context.Background()).Checks[1]
+	assert.Equal(t, "ccache-helper", cc.Name)
+	assert.Equal(t, StateWarn, cc.State)
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/file"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/gradle"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/health"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/reactnative"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode"
 )


### PR DESCRIPTION
> **Stacked on #350 (ACI-5028 keychain).** Branch sits on top of A2 so the auth check can use the new keychain package directly. Diff will compress once A2 merges.

## Summary

[ACI-5034](https://bitrise.atlassian.net/browse/ACI-5034) (C1). New top-level \`bitrise-build-cache health\` command — one-shot "is everything working?" view of the local setup. Solves P5 from the M1 plan.

\`\`\`
$ bitrise-build-cache health
Bitrise Build Cache CLI v2.8.3

  ✓ xcelerate-proxy    running (pid 87583)
  ! ccache-helper      not running (no socket file). Run \`bitrise-build-cache ccache start-storage-helper\` if you're using ccache.
  ✓ auth               OS keychain, workspace=322a005426441b60
  ✓ cli-version        current=v2.8.3 (up to date)

Overall: ok
\`\`\`

\`--json\` emits the same data machine-readable for tooling (lays groundwork for C3 self-check step + IDE pickup).

## Naming

The spec said \`status\` but \`bitrise-build-cache status\` already exists with different semantics (per-feature activation query used by step integrations). Renamed this one to \`health\` to keep both. Open to renaming back if you'd rather merge the two — say the word and I'll fold them.

## Checks today

| Check | Detection |
| --- | --- |
| xcelerate-proxy | \`~/.bitrise-xcelerate/proxy.pid\` exists + \`syscall.Kill(pid, 0)\` succeeds |
| ccache-helper | \`BITRISE_CCACHE_IPC_SOCKET_PATH\` or default \`\$TMPDIR/ccache-ipc.sock\` exists + accepts a unix dial |
| auth | keychain.Load → env-var fallback → missing |
| cli-version | github.com/bitrise-io/bitrise-build-cache-cli releases/latest, 3 s timeout. Local builds (\`devel\`/\`+dirty\`) skip the network call. |

Unreachable network → warn (not error). Missing creds / dead proxy pid → error. No-pid / no-socket → warn (the user might simply not be using that tool).

## Test plan

- [x] \`make lint\` 0 issues
- [x] \`make test-unit\` green
- [x] Unit tests cover Overall() severity, local-build detection, all xcelerate-proxy paths, auth keychain → env → missing fallthrough, version compare incl. dirty handling, ccache no-socket warn
- [x] Smoke test on macOS: defaults to colored output, \`--json\` emits valid JSON

## Out of scope (deferred)

- Last invocation timestamp (no clean local source yet — would need to read activity logs or hit the BuildCache invocations API). Add later if a local source materializes.
- C2 (\`doctor\`) — same idea, adds \`--fix\` for auto-repair; separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5034]: https://bitrise.atlassian.net/browse/ACI-5034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ