### PR TITLE
fix(cache): sanitize '/' in git branch when building config-cache keys

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -881,9 +881,6 @@ workflows:
         - content: |-
             set -exo pipefail
             ./gradlew $GRADLE_TASK --configuration-cache --stacktrace 2>&1 | tee "$BITRISE_DEPLOY_DIR/save.log"
-    # Use the CLI built from this PR ($CLI_BIN, set by config-cache-e2e-activate)
-    # instead of the released binary the steplib step bundles, so the e2e exercises
-    # the code under test.
     - script:
         title: Save Gradle configuration cache (CLI built from this PR)
         inputs:
@@ -903,8 +900,6 @@ workflows:
         stack: osx-xcode-edge
     steps:
     - bundle::config-cache-e2e-activate: {}
-    # Use the CLI built from this PR ($CLI_BIN); is_skippable mirrors the steplib
-    # step's default so the "Assert configuration cache reuse" step stays the gate.
     - script:
         title: Restore Gradle configuration cache (CLI built from this PR)
         is_skippable: true
@@ -948,9 +943,6 @@ workflows:
         - content: |-
             set -exo pipefail
             ./gradlew $GRADLE_TASK --configuration-cache --stacktrace 2>&1 | tee "$BITRISE_DEPLOY_DIR/save.log"
-    # Use the CLI built from this PR ($CLI_BIN, set by config-cache-e2e-activate)
-    # instead of the released binary the steplib step bundles, so the e2e exercises
-    # the code under test.
     - script:
         title: Save Gradle configuration cache (CLI built from this PR)
         inputs:
@@ -969,8 +961,6 @@ workflows:
         stack: linux-docker-android-22.04
     steps:
     - bundle::config-cache-e2e-activate: {}
-    # Use the CLI built from this PR ($CLI_BIN); is_skippable mirrors the steplib
-    # step's default so the "Assert configuration cache reuse" step stays the gate.
     - script:
         title: Restore Gradle configuration cache (CLI built from this PR)
         is_skippable: true

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -881,10 +881,15 @@ workflows:
         - content: |-
             set -exo pipefail
             ./gradlew $GRADLE_TASK --configuration-cache --stacktrace 2>&1 | tee "$BITRISE_DEPLOY_DIR/save.log"
-    - save-gradle-configuration-cache@1:
+    # Use the CLI built from this PR ($CLI_BIN, set by config-cache-e2e-activate)
+    # instead of the released binary the steplib step bundles, so the e2e exercises
+    # the code under test.
+    - script:
+        title: Save Gradle configuration cache (CLI built from this PR)
         inputs:
-        - verbose: "true"
-        - config_cache_dir: ./.gradle/configuration-cache
+        - content: |-
+            set -exo pipefail
+            "$CLI_BIN" save-gradle-configuration-cache -d --config-cache-dir ./.gradle/configuration-cache
     - save-gradle-cache@1:
         inputs:
         - save_transforms: "true"
@@ -898,9 +903,15 @@ workflows:
         stack: osx-xcode-edge
     steps:
     - bundle::config-cache-e2e-activate: {}
-    - restore-gradle-configuration-cache@1:
+    # Use the CLI built from this PR ($CLI_BIN); is_skippable mirrors the steplib
+    # step's default so the "Assert configuration cache reuse" step stays the gate.
+    - script:
+        title: Restore Gradle configuration cache (CLI built from this PR)
+        is_skippable: true
         inputs:
-        - verbose: "true"
+        - content: |-
+            set -exo pipefail
+            "$CLI_BIN" restore-gradle-configuration-cache -d
     - restore-gradle-cache@3:
         inputs:
         - verbose: "true"
@@ -937,10 +948,15 @@ workflows:
         - content: |-
             set -exo pipefail
             ./gradlew $GRADLE_TASK --configuration-cache --stacktrace 2>&1 | tee "$BITRISE_DEPLOY_DIR/save.log"
-    - save-gradle-configuration-cache@1:
+    # Use the CLI built from this PR ($CLI_BIN, set by config-cache-e2e-activate)
+    # instead of the released binary the steplib step bundles, so the e2e exercises
+    # the code under test.
+    - script:
+        title: Save Gradle configuration cache (CLI built from this PR)
         inputs:
-        - verbose: "true"
-        - config_cache_dir: ./.gradle/configuration-cache
+        - content: |-
+            set -exo pipefail
+            "$CLI_BIN" save-gradle-configuration-cache -d --config-cache-dir ./.gradle/configuration-cache
     - save-gradle-cache@1:
         inputs:
         - save_transforms: "true"
@@ -953,9 +969,15 @@ workflows:
         stack: linux-docker-android-22.04
     steps:
     - bundle::config-cache-e2e-activate: {}
-    - restore-gradle-configuration-cache@1:
+    # Use the CLI built from this PR ($CLI_BIN); is_skippable mirrors the steplib
+    # step's default so the "Assert configuration cache reuse" step stays the gate.
+    - script:
+        title: Restore Gradle configuration cache (CLI built from this PR)
+        is_skippable: true
         inputs:
-        - verbose: "true"
+        - content: |-
+            set -exo pipefail
+            "$CLI_BIN" restore-gradle-configuration-cache -d
     - restore-gradle-cache@3:
         inputs:
         - verbose: "true"

--- a/internal/config/common/cachekey.go
+++ b/internal/config/common/cachekey.go
@@ -2,23 +2,10 @@ package common
 
 import "strings"
 
-// SanitizeCacheKeyComponent makes a dynamic value safe to embed in a build
-// cache resource name.
-//
-// The KV backend addresses entries by a "kv/<key>" resource name and segments
-// that name on '/'. A key component that itself contains a slash — most
-// commonly a git branch such as "renovate/all-non-major-updates" — therefore
-// pushes everything after the slash (including the trailing per-OS suffix) into
-// a separate resource-name segment that the backend does not treat as part of
-// the key. The result is that the otherwise-distinct "...-linux" and
-// "...-darwin" keys collapse onto the same entry: whichever OS saves last wins,
-// and a restore on the other OS receives wrong-OS metadata (which then fails
-// with "no applicable metadata found with compatible OS"). Branches without a
-// slash (e.g. "main") never collide, which is why the symptom only appears on
-// feature/PR branches.
-//
-// Replacing '/' with '_' keeps each component inside a single resource-name
-// segment so branch- and OS-scoped keys stay distinct.
+// SanitizeCacheKeyComponent replaces '/' with '_' so the value stays within a
+// single segment of the "kv/<key>" cache resource name. The backend keys on one
+// segment, so a slash (e.g. a branch like "renovate/x") would drop the trailing
+// per-OS suffix and collide the linux/darwin entries.
 func SanitizeCacheKeyComponent(s string) string {
 	return strings.ReplaceAll(s, "/", "_")
 }

--- a/internal/config/common/cachekey.go
+++ b/internal/config/common/cachekey.go
@@ -1,0 +1,24 @@
+package common
+
+import "strings"
+
+// SanitizeCacheKeyComponent makes a dynamic value safe to embed in a build
+// cache resource name.
+//
+// The KV backend addresses entries by a "kv/<key>" resource name and segments
+// that name on '/'. A key component that itself contains a slash — most
+// commonly a git branch such as "renovate/all-non-major-updates" — therefore
+// pushes everything after the slash (including the trailing per-OS suffix) into
+// a separate resource-name segment that the backend does not treat as part of
+// the key. The result is that the otherwise-distinct "...-linux" and
+// "...-darwin" keys collapse onto the same entry: whichever OS saves last wins,
+// and a restore on the other OS receives wrong-OS metadata (which then fails
+// with "no applicable metadata found with compatible OS"). Branches without a
+// slash (e.g. "main") never collide, which is why the symptom only appears on
+// feature/PR branches.
+//
+// Replacing '/' with '_' keeps each component inside a single resource-name
+// segment so branch- and OS-scoped keys stay distinct.
+func SanitizeCacheKeyComponent(s string) string {
+	return strings.ReplaceAll(s, "/", "_")
+}

--- a/internal/config/common/cachekey_test.go
+++ b/internal/config/common/cachekey_test.go
@@ -2,7 +2,11 @@
 
 package common
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestSanitizeCacheKeyComponent(t *testing.T) {
 	tests := []struct {
@@ -18,9 +22,7 @@ func TestSanitizeCacheKeyComponent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SanitizeCacheKeyComponent(tt.in); got != tt.want {
-				t.Errorf("SanitizeCacheKeyComponent(%q) = %q, want %q", tt.in, got, tt.want)
-			}
+			assert.Equal(t, tt.want, SanitizeCacheKeyComponent(tt.in))
 		})
 	}
 }

--- a/internal/config/common/cachekey_test.go
+++ b/internal/config/common/cachekey_test.go
@@ -1,0 +1,26 @@
+//go:build unit
+
+package common
+
+import "testing"
+
+func TestSanitizeCacheKeyComponent(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "no slash is unchanged", in: "main", want: "main"},
+		{name: "single slash replaced", in: "renovate/all-non-major-updates", want: "renovate_all-non-major-updates"},
+		{name: "multiple slashes replaced", in: "feature/team/thing", want: "feature_team_thing"},
+		{name: "empty stays empty", in: "", want: ""},
+		{name: "other characters preserved", in: "fix-123.4_x", want: "fix-123.4_x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SanitizeCacheKeyComponent(tt.in); got != tt.want {
+				t.Errorf("SanitizeCacheKeyComponent(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/gradle/key.go
+++ b/internal/gradle/key.go
@@ -3,6 +3,8 @@ package gradle
 import (
 	"fmt"
 	"runtime"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 )
 
 type CacheKeyParams struct {
@@ -14,6 +16,9 @@ func (g *Cache) GetCacheKey(keyParams CacheKeyParams) (string, error) {
 	if branch == "" && !keyParams.IsFallback {
 		return "", fmt.Errorf("cache key is required if BITRISE_GIT_BRANCH env var is not set")
 	}
+	// Branches can contain '/', which would split the kv/<key> resource name
+	// into extra segments and collapse the per-OS keys onto one another.
+	branch = common.SanitizeCacheKeyComponent(branch)
 
 	appSlug := g.envProvider["BITRISE_APP_SLUG"]
 	if appSlug == "" {

--- a/internal/gradle/key_test.go
+++ b/internal/gradle/key_test.go
@@ -4,8 +4,9 @@ package gradle
 
 import (
 	"runtime"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetCacheKeySanitizesBranchSlash(t *testing.T) {
@@ -15,17 +16,10 @@ func TestGetCacheKeySanitizesBranchSlash(t *testing.T) {
 	}, nil)
 
 	key, err := c.GetCacheKey(CacheKeyParams{})
-	if err != nil {
-		t.Fatalf("GetCacheKey returned error: %v", err)
-	}
 
-	if strings.Contains(key, "/") {
-		t.Errorf("cache key must not contain '/', got %q", key)
-	}
-	want := "gradle-config-cache-metadata-app-slug-renovate_all-non-major-updates-" + runtime.GOOS
-	if key != want {
-		t.Errorf("GetCacheKey = %q, want %q", key, want)
-	}
+	assert.NoError(t, err)
+	assert.NotContains(t, key, "/", "cache key must not contain '/'")
+	assert.Equal(t, "gradle-config-cache-metadata-app-slug-renovate_all-non-major-updates-"+runtime.GOOS, key)
 }
 
 func TestGetCacheKeyFallbackHasNoBranch(t *testing.T) {
@@ -35,12 +29,7 @@ func TestGetCacheKeyFallbackHasNoBranch(t *testing.T) {
 	}, nil)
 
 	key, err := c.GetCacheKey(CacheKeyParams{IsFallback: true})
-	if err != nil {
-		t.Fatalf("GetCacheKey returned error: %v", err)
-	}
 
-	want := "gradle-config-cache-metadata-app-slug-" + runtime.GOOS
-	if key != want {
-		t.Errorf("fallback GetCacheKey = %q, want %q", key, want)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "gradle-config-cache-metadata-app-slug-"+runtime.GOOS, key)
 }

--- a/internal/gradle/key_test.go
+++ b/internal/gradle/key_test.go
@@ -1,0 +1,46 @@
+//go:build unit
+
+package gradle
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestGetCacheKeySanitizesBranchSlash(t *testing.T) {
+	c := NewCache(nil, map[string]string{
+		"BITRISE_APP_SLUG":   "app-slug",
+		"BITRISE_GIT_BRANCH": "renovate/all-non-major-updates",
+	}, nil)
+
+	key, err := c.GetCacheKey(CacheKeyParams{})
+	if err != nil {
+		t.Fatalf("GetCacheKey returned error: %v", err)
+	}
+
+	if strings.Contains(key, "/") {
+		t.Errorf("cache key must not contain '/', got %q", key)
+	}
+	want := "gradle-config-cache-metadata-app-slug-renovate_all-non-major-updates-" + runtime.GOOS
+	if key != want {
+		t.Errorf("GetCacheKey = %q, want %q", key, want)
+	}
+}
+
+func TestGetCacheKeyFallbackHasNoBranch(t *testing.T) {
+	c := NewCache(nil, map[string]string{
+		"BITRISE_APP_SLUG":   "app-slug",
+		"BITRISE_GIT_BRANCH": "renovate/all-non-major-updates",
+	}, nil)
+
+	key, err := c.GetCacheKey(CacheKeyParams{IsFallback: true})
+	if err != nil {
+		t.Fatalf("GetCacheKey returned error: %v", err)
+	}
+
+	want := "gradle-config-cache-metadata-app-slug-" + runtime.GOOS
+	if key != want {
+		t.Errorf("fallback GetCacheKey = %q, want %q", key, want)
+	}
+}

--- a/internal/xcelerate/deriveddata/cache_key.go
+++ b/internal/xcelerate/deriveddata/cache_key.go
@@ -3,6 +3,8 @@ package deriveddata
 import (
 	"fmt"
 	"runtime"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 )
 
 type CacheKeyParams struct {
@@ -14,6 +16,9 @@ func GetCacheKey(envs map[string]string, keyParams CacheKeyParams) (string, erro
 	if branch == "" && !keyParams.IsFallback {
 		return "", fmt.Errorf("cache key is required if BITRISE_GIT_BRANCH env var is not set")
 	}
+	// Branches can contain '/', which would split the kv/<key> resource name
+	// into extra segments and collapse the per-OS keys onto one another.
+	branch = common.SanitizeCacheKeyComponent(branch)
 
 	appSlug := envs["BITRISE_APP_SLUG"]
 	if appSlug == "" {

--- a/internal/xcelerate/deriveddata/cache_key_test.go
+++ b/internal/xcelerate/deriveddata/cache_key_test.go
@@ -27,3 +27,20 @@ func TestGetCacheKeySanitizesBranchSlash(t *testing.T) {
 		t.Errorf("GetCacheKey = %q, want %q", key, want)
 	}
 }
+
+func TestGetCacheKeyFallbackHasNoBranch(t *testing.T) {
+	envs := map[string]string{
+		"BITRISE_APP_SLUG":   "app-slug",
+		"BITRISE_GIT_BRANCH": "renovate/all-non-major-updates",
+	}
+
+	key, err := GetCacheKey(envs, CacheKeyParams{IsFallback: true})
+	if err != nil {
+		t.Fatalf("GetCacheKey returned error: %v", err)
+	}
+
+	want := "xcode-cache-metadata-app-slug-" + runtime.GOOS
+	if key != want {
+		t.Errorf("fallback GetCacheKey = %q, want %q", key, want)
+	}
+}

--- a/internal/xcelerate/deriveddata/cache_key_test.go
+++ b/internal/xcelerate/deriveddata/cache_key_test.go
@@ -1,0 +1,29 @@
+//go:build unit
+
+package deriveddata
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestGetCacheKeySanitizesBranchSlash(t *testing.T) {
+	envs := map[string]string{
+		"BITRISE_APP_SLUG":   "app-slug",
+		"BITRISE_GIT_BRANCH": "renovate/all-non-major-updates",
+	}
+
+	key, err := GetCacheKey(envs, CacheKeyParams{})
+	if err != nil {
+		t.Fatalf("GetCacheKey returned error: %v", err)
+	}
+
+	if strings.Contains(key, "/") {
+		t.Errorf("cache key must not contain '/', got %q", key)
+	}
+	want := "xcode-cache-metadata-app-slug-renovate_all-non-major-updates-" + runtime.GOOS
+	if key != want {
+		t.Errorf("GetCacheKey = %q, want %q", key, want)
+	}
+}

--- a/internal/xcelerate/deriveddata/cache_key_test.go
+++ b/internal/xcelerate/deriveddata/cache_key_test.go
@@ -4,8 +4,9 @@ package deriveddata
 
 import (
 	"runtime"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetCacheKeySanitizesBranchSlash(t *testing.T) {
@@ -15,17 +16,10 @@ func TestGetCacheKeySanitizesBranchSlash(t *testing.T) {
 	}
 
 	key, err := GetCacheKey(envs, CacheKeyParams{})
-	if err != nil {
-		t.Fatalf("GetCacheKey returned error: %v", err)
-	}
 
-	if strings.Contains(key, "/") {
-		t.Errorf("cache key must not contain '/', got %q", key)
-	}
-	want := "xcode-cache-metadata-app-slug-renovate_all-non-major-updates-" + runtime.GOOS
-	if key != want {
-		t.Errorf("GetCacheKey = %q, want %q", key, want)
-	}
+	assert.NoError(t, err)
+	assert.NotContains(t, key, "/", "cache key must not contain '/'")
+	assert.Equal(t, "xcode-cache-metadata-app-slug-renovate_all-non-major-updates-"+runtime.GOOS, key)
 }
 
 func TestGetCacheKeyFallbackHasNoBranch(t *testing.T) {
@@ -35,12 +29,7 @@ func TestGetCacheKeyFallbackHasNoBranch(t *testing.T) {
 	}
 
 	key, err := GetCacheKey(envs, CacheKeyParams{IsFallback: true})
-	if err != nil {
-		t.Fatalf("GetCacheKey returned error: %v", err)
-	}
 
-	want := "xcode-cache-metadata-app-slug-" + runtime.GOOS
-	if key != want {
-		t.Errorf("fallback GetCacheKey = %q, want %q", key, want)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "xcode-cache-metadata-app-slug-"+runtime.GOOS, key)
 }


### PR DESCRIPTION
## Problem

The `gradle-configuration-e2e-{linux,osx}-restore_*` shards fail on PR branches (but not on `main`) with:

```
Error: no applicable metadata found with compatible OS
```

### Root cause (confirmed from CI logs)

The Gradle config-cache key embeds the raw git branch:

```
gradle-config-cache-metadata-<appSlug>-<branch>-<os>
```

The KV backend addresses entries by a `kv/<key>` resource name and **segments it on `/`**. When the branch contains a slash (e.g. `renovate/all-non-major-updates`), the trailing `-<os>` suffix is pushed into a *separate* resource-name segment that the backend doesn't treat as part of the key. The `…-linux` and `…-darwin` keys then collapse onto the **same** entry — last writer wins — so a restore on the other OS downloads wrong-OS metadata and fails.

Evidence from PR #66's pipeline (`096f7fa1`), same branch, same pipeline:

- **linux save** wrote key `…-renovate/all-non-major-updates-linux` → checksum `87967e69…` (linux blob)
- **linux restore** read the *same* key but got `30a7f1d3…` → a blob whose `OS: darwin`, `Cache key: …-renovate/all-non-major-updates-darwin`

Slash-free branches like `main` produce a single-segment key and never collide — which is exactly why `main` is green and PR branches are red, and why the failing OS alternates (whichever OS saved last).

The same latent bug exists in the Xcode derived-data key builder (`xcode-cache-metadata-<app>-<branch>-<os>`).

## Fix

Add `common.SanitizeCacheKeyComponent` (replaces `/` with `_`) and apply it to the branch in both `internal/gradle/key.go` and `internal/xcelerate/deriveddata/cache_key.go`, so branch- and OS-scoped keys stay within a single resource-name segment and remain distinct. Save and restore both go through the same builder, so they stay consistent.

## Tests

- Unit tests for the sanitizer and for both key builders (slash-branch produces a slash-free, OS-suffixed key; fallback key omits branch).
- `go build ./...`, `go test -tags unit ./...` (touched packages), and `golangci-lint` all pass locally.

## CI: the config-cache e2e now runs the PR-built CLI

Originally the `gradle-configuration-e2e-*` save/restore shards did **not** exercise this fix: the `config-cache-e2e-activate` bundle builds the CLI (`$CLI_BIN`) but used it only for `activate gradle`, while save/restore ran the steplib steps `save-/restore-gradle-configuration-cache@1` — a **released** binary at `/tmp/bin/bitrise-build-cache` with the *unpatched* key logic. (Proof: an early run's `linux-restore_0` log still showed the unsanitized key `…-fix/config-cache-key-slash-collision-linux`.)

This PR therefore also **updates `bitrise.yml`** to drive save/restore through `$CLI_BIN` (the binary built from this branch) in all four config-cache e2e workflows (osx/linux save+restore), mirroring the existing `e2e-gradle-bitwarden` workflow. The restore script keeps `is_skippable: true` so the "Assert configuration cache reuse" step remains the gate.

As a result these shards now exercise — and validate — the fix end-to-end on this slash-containing branch. Once merged, re-running the stuck Renovate PRs (#47, #66) and any slash-branch PR will pass these shards.

## Notes

- One-time effect: existing cache entries under old (slashed) keys become a cold miss on first run after deploy and are repopulated. Harmless.
- `go.mod` left at 1.24 per the repo's hard requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
