### PR TITLE
feat: ACI-5032 daemon up / down / restart subcommands

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1078,9 +1078,10 @@ workflows:
 
   e2e-daemon-install-macos:
     description: |
-      Validate `daemon install` / `uninstall` register the helper services
-      as LaunchAgents, that `daemon info` prints the proxy socket path, and
-      that an unwrapped xcodebuild call wired to that socket produces cache
+      Validate `daemon install` / `up` / `down` / `restart` / `uninstall`
+      register the helper services as LaunchAgents and control them via
+      launchctl. Also verifies `daemon info` prints the proxy socket path
+      and that an unwrapped xcodebuild against that socket produces cache
       metrics.
     meta:
       bitrise.io:
@@ -1189,6 +1190,56 @@ workflows:
               exit 0
             fi
             ../scripts/check_pattern.sh "$BITRISE_DEPLOY_DIR/xcodebuild.log" 'CompilationCacheMetrics'
+    - script:
+        title: daemon down / up / restart asserts
+        inputs:
+        - content: |-
+            set -exo pipefail
+            uid="$DAEMON_UID"
+
+            # ----- down: services stop, plist files stay -----
+            ../bitrise-build-cache-cli daemon down
+            for label in io.bitrise.build-cache.xcelerate-proxy io.bitrise.build-cache.ccache-helper; do
+              plist="$HOME/Library/LaunchAgents/${label}.plist"
+              [[ -f "$plist" ]] || { echo "FAIL: plist removed by down: $plist"; exit 1; }
+              ! /bin/launchctl print "gui/${uid}/${label}" >/dev/null 2>&1 \
+                || { echo "FAIL: ${label} still registered after down"; exit 1; }
+              echo "OK: ${label} stopped (plist retained)"
+            done
+
+            # ----- idempotency on down (already stopped) -----
+            ../bitrise-build-cache-cli daemon down
+            echo "OK: down is idempotent"
+
+            # ----- up: bring services back from existing plist files -----
+            ../bitrise-build-cache-cli daemon up
+            for label in io.bitrise.build-cache.xcelerate-proxy io.bitrise.build-cache.ccache-helper; do
+              /bin/launchctl print "gui/${uid}/${label}" >/dev/null \
+                || { echo "FAIL: ${label} not running after up"; exit 1; }
+              echo "OK: ${label} started by up"
+            done
+
+            # ----- restart: stop + start in one shot -----
+            ../bitrise-build-cache-cli daemon restart
+            for label in io.bitrise.build-cache.xcelerate-proxy io.bitrise.build-cache.ccache-helper; do
+              /bin/launchctl print "gui/${uid}/${label}" >/dev/null \
+                || { echo "FAIL: ${label} not running after restart"; exit 1; }
+              echo "OK: ${label} running after restart"
+            done
+
+            # ----- up without prior install errors with ErrNotInstalled -----
+            ../bitrise-build-cache-cli daemon uninstall >/dev/null
+            if ../bitrise-build-cache-cli daemon up 2>up_err.log; then
+              echo "FAIL: up should error when daemon is not installed"
+              cat up_err.log
+              exit 1
+            fi
+            grep -q "not installed" up_err.log \
+              || { echo "FAIL: expected 'not installed' hint in error output"; cat up_err.log; exit 1; }
+            echo "OK: up errors with hint when daemon is not installed"
+
+            # Reinstall so the uninstall step below has something to remove.
+            ../bitrise-build-cache-cli daemon install
     - script:
         title: daemon uninstall + cleanup asserts
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1207,6 +1207,31 @@ workflows:
               echo "OK: ${label} stopped (plist retained)"
             done
 
+            # ----- proxy socket must be gone after down -----
+            if [[ -S "$PROXY_SOCKET" ]]; then
+              echo "FAIL: proxy socket still listening after daemon down: $PROXY_SOCKET"
+              exit 1
+            fi
+            echo "OK: proxy socket gone after down"
+
+            # ----- xcodebuild against the gone socket must NOT emit cache metrics -----
+            xcb="/usr/bin/xcodebuild"
+            [[ -x "$xcb" ]] || xcb="$(/usr/bin/xcrun --find xcodebuild)"
+            "$xcb" build \
+              -workspace ComposableArchitecture.xcworkspace \
+              -scheme ComposableArchitecture \
+              -destination "generic/platform=iOS" \
+              -skipMacroValidation \
+              COMPILATION_CACHE_ENABLE_COMPILER=YES \
+              COMPILATION_CACHE_REMOTE_SERVICE_PATH="$PROXY_SOCKET" \
+              2> xcodebuild-postdown.err.log | tee xcodebuild-postdown.log | xcpretty || true
+            cp xcodebuild-postdown.log xcodebuild-postdown.err.log "$BITRISE_DEPLOY_DIR/"
+            if grep -q 'CompilationCacheMetrics' xcodebuild-postdown.log; then
+              echo "FAIL: cache metrics found in post-down xcodebuild — proxy should be unreachable"
+              exit 1
+            fi
+            echo "OK: no cache metrics after down"
+
             # ----- idempotency on down (already stopped) -----
             ../bitrise-build-cache-cli daemon down
             echo "OK: down is idempotent"

--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -4,7 +4,25 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
 )
+
+// resolveBackendAndPaths is the shared lookup used by the install / uninstall
+// / up / down / restart subcommands. Keeps each cobra RunE focused on its own
+// logic.
+func resolveBackendAndPaths() (daemonpkg.Backend, daemonpkg.Paths, error) {
+	backend, err := daemonpkg.DefaultBackend()
+	if err != nil {
+		return nil, daemonpkg.Paths{}, err //nolint:wrapcheck // sentinel
+	}
+
+	paths, err := daemonpkg.NewPaths()
+	if err != nil {
+		return nil, daemonpkg.Paths{}, err //nolint:wrapcheck // already context-rich
+	}
+
+	return backend, paths, nil
+}
 
 //nolint:gochecknoglobals
 var daemonCmd = &cobra.Command{

--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -7,9 +7,6 @@ import (
 	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
 )
 
-// resolveBackendAndPaths is the shared lookup used by the install / uninstall
-// / up / down / restart subcommands. Keeps each cobra RunE focused on its own
-// logic.
 func resolveBackendAndPaths() (daemonpkg.Backend, daemonpkg.Paths, error) {
 	backend, err := daemonpkg.DefaultBackend()
 	if err != nil {

--- a/cmd/daemon/down.go
+++ b/cmd/daemon/down.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
 	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
 )
 
@@ -21,7 +23,7 @@ Cross-platform note: on macOS down boots the service out (it won't auto-restart 
 		`On Linux down stops the unit but leaves it enabled, so it will come back on next login.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		out := cmd.OutOrStdout()
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
 		backend, paths, err := resolveBackendAndPaths()
 		if err != nil {
@@ -34,13 +36,13 @@ Cross-platform note: on macOS down boots the service out (it won't auto-restart 
 				return err //nolint:wrapcheck // sentinel
 			}
 
-			printPermissionHintIfApplicable(cmd.ErrOrStderr(), err)
+			printPermissionHintIfApplicable(logger, err)
 
 			return fmt.Errorf("daemon down: %w", err)
 		}
 
 		for _, st := range result.Statuses {
-			fmt.Fprintf(out, "✓ %s — stopped (%s)\n", st.Service.Name, result.BackendName)
+			logger.Donef("%s — stopped (%s)", st.Service.Name, result.BackendName)
 		}
 
 		return nil

--- a/cmd/daemon/down.go
+++ b/cmd/daemon/down.go
@@ -34,6 +34,8 @@ Cross-platform note: on macOS down boots the service out (it won't auto-restart 
 				return err //nolint:wrapcheck // sentinel
 			}
 
+			printPermissionHintIfApplicable(cmd.ErrOrStderr(), err)
+
 			return fmt.Errorf("daemon down: %w", err)
 		}
 

--- a/cmd/daemon/down.go
+++ b/cmd/daemon/down.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -18,10 +17,7 @@ var downCmd = &cobra.Command{
 	Short: "Stop the Bitrise Build Cache background services",
 	Long: `down stops the daemon services without removing their supervisor config. ` +
 		`Use ` + "`daemon up`" + ` to bring them back, or ` + "`daemon uninstall`" + ` to remove the config too. ` +
-		`Idempotent against not-loaded / never-started services.
-
-Cross-platform note: on macOS down boots the service out (it won't auto-restart on next login until ` + "`up`" + ` runs). ` +
-		`On Linux down stops the unit but leaves it enabled, so it will come back on next login.`,
+		`Idempotent against not-loaded / never-started services. Both platforms re-bootstrap services on the next login.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
@@ -33,10 +29,6 @@ Cross-platform note: on macOS down boots the service out (it won't auto-restart 
 
 		result, err := daemonpkg.Down(cmd.Context(), backend, paths, daemonpkg.DefaultServices())
 		if err != nil {
-			if errors.Is(err, daemonpkg.ErrUnsupportedPlatform) {
-				return err //nolint:wrapcheck // sentinel
-			}
-
 			permhint.PrintIfApplicable(logger, err)
 
 			return fmt.Errorf("daemon down: %w", err)

--- a/cmd/daemon/down.go
+++ b/cmd/daemon/down.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
 	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/permhint"
 )
 
 //nolint:gochecknoglobals
@@ -36,7 +37,7 @@ Cross-platform note: on macOS down boots the service out (it won't auto-restart 
 				return err //nolint:wrapcheck // sentinel
 			}
 
-			printPermissionHintIfApplicable(logger, err)
+			permhint.PrintIfApplicable(logger, err)
 
 			return fmt.Errorf("daemon down: %w", err)
 		}

--- a/cmd/daemon/down.go
+++ b/cmd/daemon/down.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+)
+
+//nolint:gochecknoglobals
+var downCmd = &cobra.Command{
+	Use:   "down",
+	Short: "Stop the Bitrise Build Cache background services",
+	Long: `down stops the daemon services without removing their supervisor config. ` +
+		`Use ` + "`daemon up`" + ` to bring them back, or ` + "`daemon uninstall`" + ` to remove the config too. ` +
+		`Idempotent against not-loaded / never-started services.
+
+Cross-platform note: on macOS down boots the service out (it won't auto-restart on next login until ` + "`up`" + ` runs). ` +
+		`On Linux down stops the unit but leaves it enabled, so it will come back on next login.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		out := cmd.OutOrStdout()
+
+		backend, paths, err := resolveBackendAndPaths()
+		if err != nil {
+			return err
+		}
+
+		result, err := daemonpkg.Down(cmd.Context(), backend, paths, daemonpkg.DefaultServices())
+		if err != nil {
+			if errors.Is(err, daemonpkg.ErrUnsupportedPlatform) {
+				return err //nolint:wrapcheck // sentinel
+			}
+
+			return fmt.Errorf("daemon down: %w", err)
+		}
+
+		for _, st := range result.Statuses {
+			fmt.Fprintf(out, "✓ %s — stopped (%s)\n", st.Service.Name, result.BackendName)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	daemonCmd.AddCommand(downCmd)
+}

--- a/cmd/daemon/install.go
+++ b/cmd/daemon/install.go
@@ -46,14 +46,9 @@ var installCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
-		backend, err := daemonpkg.DefaultBackend()
+		backend, paths, err := resolveBackendAndPaths()
 		if err != nil {
-			return err //nolint:wrapcheck // sentinel; preserve identity
-		}
-
-		paths, err := daemonpkg.NewPaths()
-		if err != nil {
-			return err //nolint:wrapcheck // already context-rich
+			return err
 		}
 
 		// Do NOT EvalSymlinks — embedding the symlinked path lets CLI upgrades land without rerunning install.

--- a/cmd/daemon/restart.go
+++ b/cmd/daemon/restart.go
@@ -28,7 +28,7 @@ var restartCmd = &cobra.Command{
 
 		result, err := daemonpkg.Restart(cmd.Context(), backend, paths, daemonpkg.DefaultServices())
 		if err != nil {
-			if errors.Is(err, daemonpkg.ErrUnsupportedPlatform) || errors.Is(err, daemonpkg.ErrNotInstalled) {
+			if errors.Is(err, daemonpkg.ErrNotInstalled) {
 				return err //nolint:wrapcheck // sentinel
 			}
 

--- a/cmd/daemon/restart.go
+++ b/cmd/daemon/restart.go
@@ -1,0 +1,45 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+)
+
+//nolint:gochecknoglobals
+var restartCmd = &cobra.Command{
+	Use:          "restart",
+	Short:        "Stop and start the Bitrise Build Cache background services",
+	Long:         `restart is shorthand for ` + "`daemon down`" + ` followed by ` + "`daemon up`" + `. Errors with a "run install first" hint if the supervisor config files are missing from disk.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		out := cmd.OutOrStdout()
+
+		backend, paths, err := resolveBackendAndPaths()
+		if err != nil {
+			return err
+		}
+
+		result, err := daemonpkg.Restart(cmd.Context(), backend, paths, daemonpkg.DefaultServices())
+		if err != nil {
+			if errors.Is(err, daemonpkg.ErrUnsupportedPlatform) || errors.Is(err, daemonpkg.ErrNotInstalled) {
+				return err //nolint:wrapcheck // sentinel
+			}
+
+			return fmt.Errorf("daemon restart: %w", err)
+		}
+
+		for _, st := range result.Statuses {
+			fmt.Fprintf(out, "✓ %s — restarted (%s)\n", st.Service.Name, result.BackendName)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	daemonCmd.AddCommand(restartCmd)
+}

--- a/cmd/daemon/restart.go
+++ b/cmd/daemon/restart.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
 	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/permhint"
 )
 
 //nolint:gochecknoglobals
@@ -31,7 +32,7 @@ var restartCmd = &cobra.Command{
 				return err //nolint:wrapcheck // sentinel
 			}
 
-			printPermissionHintIfApplicable(logger, err)
+			permhint.PrintIfApplicable(logger, err)
 
 			return fmt.Errorf("daemon restart: %w", err)
 		}

--- a/cmd/daemon/restart.go
+++ b/cmd/daemon/restart.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
 	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
 )
 
@@ -16,7 +18,7 @@ var restartCmd = &cobra.Command{
 	Long:         `restart is shorthand for ` + "`daemon down`" + ` followed by ` + "`daemon up`" + `. Errors with a "run install first" hint if the supervisor config files are missing from disk.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		out := cmd.OutOrStdout()
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
 		backend, paths, err := resolveBackendAndPaths()
 		if err != nil {
@@ -29,13 +31,13 @@ var restartCmd = &cobra.Command{
 				return err //nolint:wrapcheck // sentinel
 			}
 
-			printPermissionHintIfApplicable(cmd.ErrOrStderr(), err)
+			printPermissionHintIfApplicable(logger, err)
 
 			return fmt.Errorf("daemon restart: %w", err)
 		}
 
 		for _, st := range result.Statuses {
-			fmt.Fprintf(out, "✓ %s — restarted (%s)\n", st.Service.Name, result.BackendName)
+			logger.Donef("%s — restarted (%s)", st.Service.Name, result.BackendName)
 		}
 
 		return nil

--- a/cmd/daemon/restart.go
+++ b/cmd/daemon/restart.go
@@ -29,6 +29,8 @@ var restartCmd = &cobra.Command{
 				return err //nolint:wrapcheck // sentinel
 			}
 
+			printPermissionHintIfApplicable(cmd.ErrOrStderr(), err)
+
 			return fmt.Errorf("daemon restart: %w", err)
 		}
 

--- a/cmd/daemon/uninstall.go
+++ b/cmd/daemon/uninstall.go
@@ -22,14 +22,9 @@ var uninstallCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
-		backend, err := daemonpkg.DefaultBackend()
+		backend, paths, err := resolveBackendAndPaths()
 		if err != nil {
-			return err //nolint:wrapcheck // sentinel
-		}
-
-		paths, err := daemonpkg.NewPaths()
-		if err != nil {
-			return err //nolint:wrapcheck // already context-rich
+			return err
 		}
 
 		result, err := daemonpkg.Uninstall(cmd.Context(), backend, paths, daemonpkg.DefaultServices())

--- a/cmd/daemon/up.go
+++ b/cmd/daemon/up.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
 	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
 )
 
@@ -18,7 +20,7 @@ var upCmd = &cobra.Command{
 		`Errors with a "run install first" hint if the supervisor config files are missing from disk.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		out := cmd.OutOrStdout()
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
 		backend, paths, err := resolveBackendAndPaths()
 		if err != nil {
@@ -31,13 +33,13 @@ var upCmd = &cobra.Command{
 				return err //nolint:wrapcheck // sentinel
 			}
 
-			printPermissionHintIfApplicable(cmd.ErrOrStderr(), err)
+			printPermissionHintIfApplicable(logger, err)
 
 			return fmt.Errorf("daemon up: %w", err)
 		}
 
 		for _, st := range result.Statuses {
-			fmt.Fprintf(out, "✓ %s — started (%s)\n", st.Service.Name, result.BackendName)
+			logger.Donef("%s — started (%s)", st.Service.Name, result.BackendName)
 		}
 
 		return nil

--- a/cmd/daemon/up.go
+++ b/cmd/daemon/up.go
@@ -1,0 +1,47 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+)
+
+//nolint:gochecknoglobals
+var upCmd = &cobra.Command{
+	Use:   "up",
+	Short: "Start the Bitrise Build Cache background services",
+	Long: `up starts the daemon services that were registered by ` + "`daemon install`" + `. ` +
+		`Idempotent — running ` + "`up`" + ` against an already-running daemon is a no-op. ` +
+		`Errors with a "run install first" hint if the supervisor config files are missing from disk.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		out := cmd.OutOrStdout()
+
+		backend, paths, err := resolveBackendAndPaths()
+		if err != nil {
+			return err
+		}
+
+		result, err := daemonpkg.Up(cmd.Context(), backend, paths, daemonpkg.DefaultServices())
+		if err != nil {
+			if errors.Is(err, daemonpkg.ErrUnsupportedPlatform) || errors.Is(err, daemonpkg.ErrNotInstalled) {
+				return err //nolint:wrapcheck // sentinel
+			}
+
+			return fmt.Errorf("daemon up: %w", err)
+		}
+
+		for _, st := range result.Statuses {
+			fmt.Fprintf(out, "✓ %s — started (%s)\n", st.Service.Name, result.BackendName)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	daemonCmd.AddCommand(upCmd)
+}

--- a/cmd/daemon/up.go
+++ b/cmd/daemon/up.go
@@ -14,7 +14,7 @@ var upCmd = &cobra.Command{
 	Use:   "up",
 	Short: "Start the Bitrise Build Cache background services",
 	Long: `up starts the daemon services that were registered by ` + "`daemon install`" + `. ` +
-		`Idempotent — running ` + "`up`" + ` against an already-running daemon is a no-op. ` +
+		`Safe to rerun, but not a true no-op against an already-running daemon: on macOS the underlying ` + "`launchctl bootstrap`" + ` is preceded by a ` + "`launchctl bootout`" + `, which briefly stops + restarts each service (so a CLI binary upgrade is picked up). On Linux ` + "`systemctl --user enable --now`" + ` is a real no-op on an already-running unit. ` +
 		`Errors with a "run install first" hint if the supervisor config files are missing from disk.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/daemon/up.go
+++ b/cmd/daemon/up.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
 	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/permhint"
 )
 
 //nolint:gochecknoglobals
@@ -33,7 +34,7 @@ var upCmd = &cobra.Command{
 				return err //nolint:wrapcheck // sentinel
 			}
 
-			printPermissionHintIfApplicable(logger, err)
+			permhint.PrintIfApplicable(logger, err)
 
 			return fmt.Errorf("daemon up: %w", err)
 		}

--- a/cmd/daemon/up.go
+++ b/cmd/daemon/up.go
@@ -31,6 +31,8 @@ var upCmd = &cobra.Command{
 				return err //nolint:wrapcheck // sentinel
 			}
 
+			printPermissionHintIfApplicable(cmd.ErrOrStderr(), err)
+
 			return fmt.Errorf("daemon up: %w", err)
 		}
 

--- a/cmd/daemon/up.go
+++ b/cmd/daemon/up.go
@@ -30,7 +30,7 @@ var upCmd = &cobra.Command{
 
 		result, err := daemonpkg.Up(cmd.Context(), backend, paths, daemonpkg.DefaultServices())
 		if err != nil {
-			if errors.Is(err, daemonpkg.ErrUnsupportedPlatform) || errors.Is(err, daemonpkg.ErrNotInstalled) {
+			if errors.Is(err, daemonpkg.ErrNotInstalled) {
 				return err //nolint:wrapcheck // sentinel
 			}
 

--- a/cmd/xcode/xcelerate_start_proxy.go
+++ b/cmd/xcode/xcelerate_start_proxy.go
@@ -7,7 +7,9 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/google/uuid"
@@ -92,14 +94,22 @@ var (
 
 			initialLogger.TInfof("socketPath: %s", config.ProxySocketPath)
 
-			listener, err := (&net.ListenConfig{}).Listen(cmd.Context(), "unix", config.ProxySocketPath)
+			signalCtx, stopSignals := signal.NotifyContext(cmd.Context(), syscall.SIGTERM, syscall.SIGINT)
+			defer stopSignals()
+
+			listener, err := (&net.ListenConfig{}).Listen(signalCtx, "unix", config.ProxySocketPath)
 			if err != nil {
 				return fmt.Errorf("failed to listen on unix socket: %w", err)
 			}
 			defer listener.Close()
 
+			go func() {
+				<-signalCtx.Done()
+				_ = listener.Close()
+			}()
+
 			return StartXcodeCacheProxy(
-				cmd.Context(),
+				signalCtx,
 				config,
 				allEnvs,
 				func(name string, v ...string) (string, error) {

--- a/internal/daemon/backend.go
+++ b/internal/daemon/backend.go
@@ -10,9 +10,12 @@ import (
 
 var ErrUnsupportedPlatform = errors.New("daemon install is only supported on macOS (launchd) and Linux (systemd)")
 
+// Backend.Stop semantics: launchd unloads (service won't auto-restart until Start); systemd leaves it enabled (comes back on login).
 type Backend interface {
 	Install(ctx context.Context, paths Paths, svc Service, executable string) (configPath string, err error)
 	Uninstall(ctx context.Context, paths Paths, svc Service) (configPath string, removed bool, err error)
+	Start(ctx context.Context, paths Paths, svc Service) error
+	Stop(ctx context.Context, paths Paths, svc Service) error
 	Name() string
 }
 

--- a/internal/daemon/backend.go
+++ b/internal/daemon/backend.go
@@ -10,7 +10,6 @@ import (
 
 var ErrUnsupportedPlatform = errors.New("daemon install is only supported on macOS (launchd) and Linux (systemd)")
 
-// Backend.Stop semantics: launchd unloads (service won't auto-restart until Start); systemd leaves it enabled (comes back on login).
 type Backend interface {
 	Install(ctx context.Context, paths Paths, svc Service, executable string) (configPath string, err error)
 	Uninstall(ctx context.Context, paths Paths, svc Service) (configPath string, removed bool, err error)

--- a/internal/daemon/control.go
+++ b/internal/daemon/control.go
@@ -35,6 +35,16 @@ func Up(ctx context.Context, backend Backend, paths Paths, services []Service) (
 
 	for _, svc := range services {
 		path := configPath(backend, paths, svc)
+
+		// Stat-then-Start has a TOCTOU window — if a parallel `daemon
+		// uninstall` deletes the supervisor config between the Stat and
+		// the Start, Start will fail with a supervisor error
+		// ("plist not found" / "Unit file ... does not exist") that the
+		// caller will surface. We accept that small window because the
+		// alternative (skip the Stat and let Start error verbosely) loses
+		// the friendly ErrNotInstalled hint, which is the common case
+		// (user ran `daemon up` before any `daemon install`). Race window
+		// is bounded by `daemon uninstall` runtime, which is small.
 		if _, err := os.Stat(path); err != nil {
 			if os.IsNotExist(err) {
 				return result, fmt.Errorf("%w (missing %s)", ErrNotInstalled, path)

--- a/internal/daemon/control.go
+++ b/internal/daemon/control.go
@@ -1,0 +1,101 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// ErrNotInstalled is returned by Up when the supervisor config file is not on
+// disk. `daemon up` requires `daemon install` to have run at least once — Up
+// is for restoring the running state, not creating it.
+var ErrNotInstalled = errors.New("daemon is not installed; run `bitrise-build-cache daemon install` first")
+
+// ControlStatus describes the per-service outcome of Up/Down.
+type ControlStatus struct {
+	Service    Service
+	ConfigPath string
+}
+
+// ControlResult is the aggregate outcome.
+type ControlResult struct {
+	BackendName string
+	Statuses    []ControlStatus
+}
+
+// Up starts every service. Returns ErrNotInstalled if any service's
+// supervisor config is missing from disk — the caller is expected to run
+// `daemon install` first.
+func Up(ctx context.Context, backend Backend, paths Paths, services []Service) (ControlResult, error) {
+	result := ControlResult{
+		BackendName: backend.Name(),
+		Statuses:    make([]ControlStatus, 0, len(services)),
+	}
+
+	for _, svc := range services {
+		path := configPath(backend, paths, svc)
+		if _, err := os.Stat(path); err != nil {
+			if os.IsNotExist(err) {
+				return result, fmt.Errorf("%w (missing %s)", ErrNotInstalled, path)
+			}
+
+			return result, fmt.Errorf("stat %s: %w", path, err)
+		}
+
+		if err := backend.Start(ctx, paths, svc); err != nil {
+			return result, fmt.Errorf("%s start %s: %w", backend.Name(), svc.Name, err)
+		}
+
+		result.Statuses = append(result.Statuses, ControlStatus{Service: svc, ConfigPath: path})
+	}
+
+	return result, nil
+}
+
+// Down stops every service. Does not remove supervisor config files. Safe to
+// run when nothing is registered — Backend.Stop swallows the supervisor's
+// "not loaded" exit code.
+func Down(ctx context.Context, backend Backend, paths Paths, services []Service) (ControlResult, error) {
+	result := ControlResult{
+		BackendName: backend.Name(),
+		Statuses:    make([]ControlStatus, 0, len(services)),
+	}
+
+	for _, svc := range services {
+		if err := backend.Stop(ctx, paths, svc); err != nil {
+			return result, fmt.Errorf("%s stop %s: %w", backend.Name(), svc.Name, err)
+		}
+
+		result.Statuses = append(result.Statuses, ControlStatus{
+			Service:    svc,
+			ConfigPath: configPath(backend, paths, svc),
+		})
+	}
+
+	return result, nil
+}
+
+// Restart stops then starts. If Up fails because the daemon was never
+// installed, the error propagates with full context.
+func Restart(ctx context.Context, backend Backend, paths Paths, services []Service) (ControlResult, error) {
+	if _, err := Down(ctx, backend, paths, services); err != nil {
+		return ControlResult{}, err
+	}
+
+	return Up(ctx, backend, paths, services)
+}
+
+// configPath resolves the supervisor config file path for svc. The launchd
+// and systemd backends use different naming schemes (Label vs UnitName), so
+// we dispatch by backend name.
+func configPath(backend Backend, paths Paths, svc Service) string {
+	switch backend.Name() {
+	case "launchd":
+		return paths.PlistPath(svc.Label())
+	case "systemd":
+		return paths.UnitPath(svc.UnitName())
+	default:
+		return ""
+	}
+}

--- a/internal/daemon/control.go
+++ b/internal/daemon/control.go
@@ -76,14 +76,23 @@ func Down(ctx context.Context, backend Backend, paths Paths, services []Service)
 	return result, nil
 }
 
-// Restart stops then starts. If Up fails because the daemon was never
-// installed, the error propagates with full context.
+// Restart stops then starts. If Up fails after Down succeeded, the user is
+// left with stopped services — we wrap the Up error so the caller knows the
+// state isn't "as you found it" and includes the exact remediation command.
+//
+// If Down itself fails, the services are likely still running, so the error
+// surfaces as-is.
 func Restart(ctx context.Context, backend Backend, paths Paths, services []Service) (ControlResult, error) {
 	if _, err := Down(ctx, backend, paths, services); err != nil {
 		return ControlResult{}, err
 	}
 
-	return Up(ctx, backend, paths, services)
+	result, err := Up(ctx, backend, paths, services)
+	if err != nil {
+		return result, fmt.Errorf("restart left services stopped (Down succeeded, Up failed); run `bitrise-build-cache daemon up` after fixing: %w", err)
+	}
+
+	return result, nil
 }
 
 // configPath resolves the supervisor config file path for svc. The launchd

--- a/internal/daemon/control.go
+++ b/internal/daemon/control.go
@@ -28,7 +28,6 @@ func Up(ctx context.Context, backend Backend, paths Paths, services []Service) (
 	for _, svc := range services {
 		path := configPath(backend, paths, svc)
 
-		// Stat-then-Start has a small TOCTOU window with `daemon uninstall`; accepted to keep the friendly ErrNotInstalled.
 		if _, err := os.Stat(path); err != nil {
 			if os.IsNotExist(err) {
 				return result, fmt.Errorf("%w (missing %s)", ErrNotInstalled, path)

--- a/internal/daemon/control.go
+++ b/internal/daemon/control.go
@@ -7,26 +7,18 @@ import (
 	"os"
 )
 
-// ErrNotInstalled is returned by Up when the supervisor config file is not on
-// disk. `daemon up` requires `daemon install` to have run at least once — Up
-// is for restoring the running state, not creating it.
 var ErrNotInstalled = errors.New("daemon is not installed; run `bitrise-build-cache daemon install` first")
 
-// ControlStatus describes the per-service outcome of Up/Down.
 type ControlStatus struct {
 	Service    Service
 	ConfigPath string
 }
 
-// ControlResult is the aggregate outcome.
 type ControlResult struct {
 	BackendName string
 	Statuses    []ControlStatus
 }
 
-// Up starts every service. Returns ErrNotInstalled if any service's
-// supervisor config is missing from disk — the caller is expected to run
-// `daemon install` first.
 func Up(ctx context.Context, backend Backend, paths Paths, services []Service) (ControlResult, error) {
 	result := ControlResult{
 		BackendName: backend.Name(),
@@ -36,15 +28,7 @@ func Up(ctx context.Context, backend Backend, paths Paths, services []Service) (
 	for _, svc := range services {
 		path := configPath(backend, paths, svc)
 
-		// Stat-then-Start has a TOCTOU window — if a parallel `daemon
-		// uninstall` deletes the supervisor config between the Stat and
-		// the Start, Start will fail with a supervisor error
-		// ("plist not found" / "Unit file ... does not exist") that the
-		// caller will surface. We accept that small window because the
-		// alternative (skip the Stat and let Start error verbosely) loses
-		// the friendly ErrNotInstalled hint, which is the common case
-		// (user ran `daemon up` before any `daemon install`). Race window
-		// is bounded by `daemon uninstall` runtime, which is small.
+		// Stat-then-Start has a small TOCTOU window with `daemon uninstall`; accepted to keep the friendly ErrNotInstalled.
 		if _, err := os.Stat(path); err != nil {
 			if os.IsNotExist(err) {
 				return result, fmt.Errorf("%w (missing %s)", ErrNotInstalled, path)
@@ -63,9 +47,6 @@ func Up(ctx context.Context, backend Backend, paths Paths, services []Service) (
 	return result, nil
 }
 
-// Down stops every service. Does not remove supervisor config files. Safe to
-// run when nothing is registered — Backend.Stop swallows the supervisor's
-// "not loaded" exit code.
 func Down(ctx context.Context, backend Backend, paths Paths, services []Service) (ControlResult, error) {
 	result := ControlResult{
 		BackendName: backend.Name(),
@@ -86,12 +67,7 @@ func Down(ctx context.Context, backend Backend, paths Paths, services []Service)
 	return result, nil
 }
 
-// Restart stops then starts. If Up fails after Down succeeded, the user is
-// left with stopped services — we wrap the Up error so the caller knows the
-// state isn't "as you found it" and includes the exact remediation command.
-//
-// If Down itself fails, the services are likely still running, so the error
-// surfaces as-is.
+// Restart wraps an Up failure that follows a successful Down so the user knows services are left stopped.
 func Restart(ctx context.Context, backend Backend, paths Paths, services []Service) (ControlResult, error) {
 	if _, err := Down(ctx, backend, paths, services); err != nil {
 		return ControlResult{}, err
@@ -105,9 +81,6 @@ func Restart(ctx context.Context, backend Backend, paths Paths, services []Servi
 	return result, nil
 }
 
-// configPath resolves the supervisor config file path for svc. The launchd
-// and systemd backends use different naming schemes (Label vs UnitName), so
-// we dispatch by backend name.
 func configPath(backend Backend, paths Paths, svc Service) string {
 	switch backend.Name() {
 	case "launchd":

--- a/internal/daemon/control_test.go
+++ b/internal/daemon/control_test.go
@@ -176,3 +176,59 @@ func TestDown_systemd_treatsNotLoadedAsSuccess(t *testing.T) {
 	_, err := Down(context.Background(), SystemdBackend{Runner: runner}, paths, DefaultServices())
 	require.NoError(t, err)
 }
+
+func TestRestart_systemd_callsDownThenUp(t *testing.T) {
+	home := t.TempDir()
+	paths := NewPathsFromHome(home)
+
+	// Install first so the unit files exist (Up half of restart requires them).
+	installRunner := &recordingRunner{}
+	_, err := Install(context.Background(), SystemdBackend{Runner: installRunner}, paths, DefaultServices(), "/usr/local/bin/bitrise-build-cache")
+	require.NoError(t, err)
+
+	restartRunner := &recordingRunner{}
+	_, err = Restart(context.Background(), SystemdBackend{Runner: restartRunner}, paths, DefaultServices())
+	require.NoError(t, err)
+
+	// Down: 1 systemctl stop per service. Up: daemon-reload + enable --now
+	// per service = 2 calls each. 2 + 4 = 6 total. Assert the verb sequence.
+	require.Len(t, restartRunner.calls, 6)
+	assert.Equal(t, "stop", restartRunner.calls[0][2])
+	assert.Equal(t, "stop", restartRunner.calls[1][2])
+	assert.Equal(t, "daemon-reload", restartRunner.calls[2][2])
+	assert.Equal(t, "enable", restartRunner.calls[3][2])
+	assert.Equal(t, "daemon-reload", restartRunner.calls[4][2])
+	assert.Equal(t, "enable", restartRunner.calls[5][2])
+}
+
+// TestRestart_systemd_wrapsUpFailureWithStoppedHint locks the partial-
+// failure error wrap: when Down succeeds but Up fails (e.g. because
+// systemd is unreachable on the second call), the user is left with
+// stopped services, so the error message MUST surface that state and
+// the next remediation step.
+func TestRestart_systemd_wrapsUpFailureWithStoppedHint(t *testing.T) {
+	home := t.TempDir()
+	paths := NewPathsFromHome(home)
+
+	// Install so the Up half doesn't trip ErrNotInstalled (we want the
+	// failure to come from the runner, not config-presence checks).
+	installRunner := &recordingRunner{}
+	_, err := Install(context.Background(), SystemdBackend{Runner: installRunner}, paths, DefaultServices(), "/usr/local/bin/bitrise-build-cache")
+	require.NoError(t, err)
+
+	// stop succeeds, daemon-reload (Up's first call) fails.
+	runner := &recordingRunner{
+		reply: func(_ string, args []string) (string, string, int, error) {
+			if len(args) > 1 && args[1] == "daemon-reload" {
+				return "", "Failed to connect to bus: No such file or directory", 1, nil
+			}
+
+			return "", "", 0, nil
+		},
+	}
+
+	_, err = Restart(context.Background(), SystemdBackend{Runner: runner}, paths, DefaultServices())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stopped")
+	assert.Contains(t, err.Error(), "daemon up")
+}

--- a/internal/daemon/control_test.go
+++ b/internal/daemon/control_test.go
@@ -28,7 +28,6 @@ func TestUp_launchd_startsAllInstalledServices(t *testing.T) {
 	require.Len(t, result.Statuses, 2)
 	assert.Equal(t, "launchd", result.BackendName)
 
-	// Up == backend.Start == bootstrap helper (bootout + bootstrap). 2 services * 2 calls.
 	assert.Len(t, upRunner.calls, 4)
 	assert.Equal(t, "bootout", upRunner.calls[0][1])
 	assert.Equal(t, "bootstrap", upRunner.calls[1][1])
@@ -58,7 +57,6 @@ func TestDown_launchd_stopsWithoutRemovingConfig(t *testing.T) {
 	_, err = Down(context.Background(), LaunchdBackend{Runner: downRunner}, paths, DefaultServices())
 	require.NoError(t, err)
 
-	// Down should only bootout — 1 call per service.
 	require.Len(t, downRunner.calls, 2)
 	assert.Equal(t, "bootout", downRunner.calls[0][1])
 	assert.Equal(t, "bootout", downRunner.calls[1][1])
@@ -98,11 +96,9 @@ func TestRestart_launchd_callsDownThenUp(t *testing.T) {
 	_, err = Restart(context.Background(), LaunchdBackend{Runner: restartRunner}, paths, DefaultServices())
 	require.NoError(t, err)
 
-	// Down = 2 bootouts. Up = 2 (bootout + bootstrap) per service. 2 + 4 = 6 total.
 	require.Len(t, restartRunner.calls, 6)
 	assert.Equal(t, "bootout", restartRunner.calls[0][1])
 	assert.Equal(t, "bootout", restartRunner.calls[1][1])
-	// Up half of the restart: bootout-then-bootstrap per service.
 	assert.Equal(t, "bootout", restartRunner.calls[2][1])
 	assert.Equal(t, "bootstrap", restartRunner.calls[3][1])
 	assert.Equal(t, "bootout", restartRunner.calls[4][1])
@@ -123,7 +119,6 @@ func TestUp_systemd_startsAllInstalledServices(t *testing.T) {
 	require.Len(t, result.Statuses, 2)
 	assert.Equal(t, "systemd", result.BackendName)
 
-	// Up = daemon-reload + enable --now. 2 services * 2 calls.
 	require.Len(t, upRunner.calls, 4)
 	assert.Equal(t, "daemon-reload", upRunner.calls[0][2])
 	assert.Equal(t, "enable", upRunner.calls[1][2])
@@ -152,7 +147,6 @@ func TestDown_systemd_stopsButKeepsUnitFile(t *testing.T) {
 	_, err = Down(context.Background(), SystemdBackend{Runner: downRunner}, paths, DefaultServices())
 	require.NoError(t, err)
 
-	// Down = stop per service. 2 calls.
 	require.Len(t, downRunner.calls, 2)
 	assert.Equal(t, "stop", downRunner.calls[0][2])
 
@@ -190,8 +184,6 @@ func TestRestart_systemd_callsDownThenUp(t *testing.T) {
 	_, err = Restart(context.Background(), SystemdBackend{Runner: restartRunner}, paths, DefaultServices())
 	require.NoError(t, err)
 
-	// Down: 1 systemctl stop per service. Up: daemon-reload + enable --now
-	// per service = 2 calls each. 2 + 4 = 6 total. Assert the verb sequence.
 	require.Len(t, restartRunner.calls, 6)
 	assert.Equal(t, "stop", restartRunner.calls[0][2])
 	assert.Equal(t, "stop", restartRunner.calls[1][2])

--- a/internal/daemon/control_test.go
+++ b/internal/daemon/control_test.go
@@ -1,0 +1,178 @@
+//go:build unit
+
+package daemon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUp_launchd_startsAllInstalledServices(t *testing.T) {
+	home := t.TempDir()
+	paths := NewPathsFromHome(home)
+
+	// Install first so plist files exist on disk.
+	installRunner := &recordingRunner{}
+	_, err := Install(context.Background(), LaunchdBackend{Runner: installRunner}, paths, DefaultServices(), "/usr/local/bin/bitrise-build-cache")
+	require.NoError(t, err)
+
+	upRunner := &recordingRunner{}
+	result, err := Up(context.Background(), LaunchdBackend{Runner: upRunner}, paths, DefaultServices())
+	require.NoError(t, err)
+	require.Len(t, result.Statuses, 2)
+	assert.Equal(t, "launchd", result.BackendName)
+
+	// Up == backend.Start == bootstrap helper (bootout + bootstrap). 2 services * 2 calls.
+	assert.Len(t, upRunner.calls, 4)
+	assert.Equal(t, "bootout", upRunner.calls[0][1])
+	assert.Equal(t, "bootstrap", upRunner.calls[1][1])
+}
+
+func TestUp_launchd_errorsWhenNotInstalled(t *testing.T) {
+	home := t.TempDir()
+	paths := NewPathsFromHome(home)
+	runner := &recordingRunner{}
+
+	_, err := Up(context.Background(), LaunchdBackend{Runner: runner}, paths, DefaultServices())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotInstalled), "expected ErrNotInstalled, got %v", err)
+	assert.Empty(t, runner.calls, "Backend.Start must not be called when config is missing")
+}
+
+func TestDown_launchd_stopsWithoutRemovingConfig(t *testing.T) {
+	home := t.TempDir()
+	paths := NewPathsFromHome(home)
+
+	// Install so plist files are on disk.
+	installRunner := &recordingRunner{}
+	_, err := Install(context.Background(), LaunchdBackend{Runner: installRunner}, paths, DefaultServices(), "/usr/local/bin/bitrise-build-cache")
+	require.NoError(t, err)
+
+	downRunner := &recordingRunner{}
+	_, err = Down(context.Background(), LaunchdBackend{Runner: downRunner}, paths, DefaultServices())
+	require.NoError(t, err)
+
+	// Down should only bootout — 1 call per service.
+	require.Len(t, downRunner.calls, 2)
+	assert.Equal(t, "bootout", downRunner.calls[0][1])
+	assert.Equal(t, "bootout", downRunner.calls[1][1])
+
+	// Plist files must remain on disk so Up can bring services back.
+	for _, svc := range DefaultServices() {
+		_, statErr := os.Stat(filepath.Join(paths.LaunchAgentsDir(), svc.Label()+".plist"))
+		require.NoError(t, statErr, "plist file should still exist for %s", svc.Name)
+	}
+}
+
+func TestDown_launchd_idempotentOnUnregistered(t *testing.T) {
+	home := t.TempDir()
+	paths := NewPathsFromHome(home)
+
+	// Bootout reply: exit 5 = "service not loaded". Down must still succeed.
+	runner := &recordingRunner{
+		reply: func(_ string, _ []string) (string, string, int, error) {
+			return "", "Could not find specified service", 5, nil
+		},
+	}
+
+	_, err := Down(context.Background(), LaunchdBackend{Runner: runner}, paths, DefaultServices())
+	require.NoError(t, err)
+}
+
+func TestRestart_launchd_callsDownThenUp(t *testing.T) {
+	home := t.TempDir()
+	paths := NewPathsFromHome(home)
+
+	// Install first so config exists for the Up half of restart.
+	installRunner := &recordingRunner{}
+	_, err := Install(context.Background(), LaunchdBackend{Runner: installRunner}, paths, DefaultServices(), "/usr/local/bin/bitrise-build-cache")
+	require.NoError(t, err)
+
+	restartRunner := &recordingRunner{}
+	_, err = Restart(context.Background(), LaunchdBackend{Runner: restartRunner}, paths, DefaultServices())
+	require.NoError(t, err)
+
+	// Down = 2 bootouts. Up = 2 (bootout + bootstrap) per service. 2 + 4 = 6 total.
+	require.Len(t, restartRunner.calls, 6)
+	assert.Equal(t, "bootout", restartRunner.calls[0][1])
+	assert.Equal(t, "bootout", restartRunner.calls[1][1])
+	// Up half of the restart: bootout-then-bootstrap per service.
+	assert.Equal(t, "bootout", restartRunner.calls[2][1])
+	assert.Equal(t, "bootstrap", restartRunner.calls[3][1])
+	assert.Equal(t, "bootout", restartRunner.calls[4][1])
+	assert.Equal(t, "bootstrap", restartRunner.calls[5][1])
+}
+
+func TestUp_systemd_startsAllInstalledServices(t *testing.T) {
+	home := t.TempDir()
+	paths := NewPathsFromHome(home)
+
+	installRunner := &recordingRunner{}
+	_, err := Install(context.Background(), SystemdBackend{Runner: installRunner}, paths, DefaultServices(), "/usr/local/bin/bitrise-build-cache")
+	require.NoError(t, err)
+
+	upRunner := &recordingRunner{}
+	result, err := Up(context.Background(), SystemdBackend{Runner: upRunner}, paths, DefaultServices())
+	require.NoError(t, err)
+	require.Len(t, result.Statuses, 2)
+	assert.Equal(t, "systemd", result.BackendName)
+
+	// Up = daemon-reload + enable --now. 2 services * 2 calls.
+	require.Len(t, upRunner.calls, 4)
+	assert.Equal(t, "daemon-reload", upRunner.calls[0][2])
+	assert.Equal(t, "enable", upRunner.calls[1][2])
+}
+
+func TestUp_systemd_errorsWhenNotInstalled(t *testing.T) {
+	home := t.TempDir()
+	paths := NewPathsFromHome(home)
+	runner := &recordingRunner{}
+
+	_, err := Up(context.Background(), SystemdBackend{Runner: runner}, paths, DefaultServices())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotInstalled))
+	assert.Empty(t, runner.calls)
+}
+
+func TestDown_systemd_stopsButKeepsUnitFile(t *testing.T) {
+	home := t.TempDir()
+	paths := NewPathsFromHome(home)
+
+	installRunner := &recordingRunner{}
+	_, err := Install(context.Background(), SystemdBackend{Runner: installRunner}, paths, DefaultServices(), "/usr/local/bin/bitrise-build-cache")
+	require.NoError(t, err)
+
+	downRunner := &recordingRunner{}
+	_, err = Down(context.Background(), SystemdBackend{Runner: downRunner}, paths, DefaultServices())
+	require.NoError(t, err)
+
+	// Down = stop per service. 2 calls.
+	require.Len(t, downRunner.calls, 2)
+	assert.Equal(t, "stop", downRunner.calls[0][2])
+
+	// Unit files must remain so Up can re-enable them.
+	for _, svc := range DefaultServices() {
+		_, statErr := os.Stat(paths.UnitPath(svc.UnitName()))
+		require.NoError(t, statErr, "unit file should still exist for %s", svc.Name)
+	}
+}
+
+func TestDown_systemd_treatsNotLoadedAsSuccess(t *testing.T) {
+	home := t.TempDir()
+	paths := NewPathsFromHome(home)
+
+	runner := &recordingRunner{
+		reply: func(_ string, _ []string) (string, string, int, error) {
+			return "", "Failed to stop bitrise-build-cache-xcelerate-proxy.service: Unit bitrise-build-cache-xcelerate-proxy.service not loaded.", 5, nil
+		},
+	}
+
+	_, err := Down(context.Background(), SystemdBackend{Runner: runner}, paths, DefaultServices())
+	require.NoError(t, err)
+}

--- a/internal/daemon/launchd.go
+++ b/internal/daemon/launchd.go
@@ -42,6 +42,18 @@ func (b LaunchdBackend) Install(ctx context.Context, paths Paths, svc Service, e
 	return path, nil
 }
 
+func (b LaunchdBackend) Start(ctx context.Context, paths Paths, svc Service) error {
+	path := paths.PlistPath(svc.Label())
+
+	return b.bootstrap(ctx, path)
+}
+
+func (b LaunchdBackend) Stop(ctx context.Context, paths Paths, svc Service) error {
+	path := paths.PlistPath(svc.Label())
+
+	return b.bootout(ctx, path)
+}
+
 func (b LaunchdBackend) Uninstall(ctx context.Context, paths Paths, svc Service) (string, bool, error) {
 	path := paths.PlistPath(svc.Label())
 

--- a/internal/daemon/systemd.go
+++ b/internal/daemon/systemd.go
@@ -54,7 +54,6 @@ func (b SystemdBackend) Start(ctx context.Context, _ Paths, svc Service) error {
 	return b.enableNow(ctx, svc.UnitName())
 }
 
-// Stop leaves the unit enabled — Uninstall is for permanent removal.
 func (b SystemdBackend) Stop(ctx context.Context, _ Paths, svc Service) error {
 	return b.stop(ctx, svc.UnitName())
 }

--- a/internal/daemon/systemd.go
+++ b/internal/daemon/systemd.go
@@ -46,6 +46,19 @@ func (b SystemdBackend) Install(ctx context.Context, paths Paths, svc Service, e
 	return path, nil
 }
 
+func (b SystemdBackend) Start(ctx context.Context, _ Paths, svc Service) error {
+	if err := b.daemonReload(ctx); err != nil {
+		return err
+	}
+
+	return b.enableNow(ctx, svc.UnitName())
+}
+
+// Stop leaves the unit enabled — Uninstall is for permanent removal.
+func (b SystemdBackend) Stop(ctx context.Context, _ Paths, svc Service) error {
+	return b.stop(ctx, svc.UnitName())
+}
+
 func (b SystemdBackend) Uninstall(ctx context.Context, paths Paths, svc Service) (string, bool, error) {
 	path := paths.UnitPath(svc.UnitName())
 
@@ -91,6 +104,25 @@ func (b SystemdBackend) enableNow(ctx context.Context, unitName string) error {
 	}
 
 	return nil
+}
+
+// stop treats "Unit ... not loaded" stderr as success so Stop is idempotent.
+func (b SystemdBackend) stop(ctx context.Context, unitName string) error {
+	_, stderr, code, err := b.Runner.Run(ctx, systemctlBin, "--user", "stop", unitName+".service")
+	if err != nil {
+		return fmt.Errorf("systemctl --user stop %s: %w", unitName, err)
+	}
+
+	if code == 0 {
+		return nil
+	}
+
+	combined := strings.TrimSpace(stderr)
+	if strings.Contains(combined, "not loaded") || strings.Contains(combined, "does not exist") || strings.Contains(combined, "no such file") {
+		return nil
+	}
+
+	return fmt.Errorf("systemctl --user stop %s exited %d: %s", unitName, code, combined)
 }
 
 // disableNow treats "does not exist" stderr as success so uninstall is idempotent.

--- a/internal/daemon/systemd.go
+++ b/internal/daemon/systemd.go
@@ -106,7 +106,7 @@ func (b SystemdBackend) enableNow(ctx context.Context, unitName string) error {
 	return nil
 }
 
-// stop treats "Unit ... not loaded" stderr as success so Stop is idempotent.
+// stop treats "Unit ... not loaded" as success so Stop is idempotent.
 func (b SystemdBackend) stop(ctx context.Context, unitName string) error {
 	_, stderr, code, err := b.Runner.Run(ctx, systemctlBin, "--user", "stop", unitName+".service")
 	if err != nil {


### PR DESCRIPTION
**Stacked on #357 (B1+B2). GitHub will auto-retarget to main once #357 merges.**

## Summary

Adds three new subcommands that wrap the OS supervisor's start / stop verbs without touching the supervisor config files on disk:

- \`daemon up\` — start services (assumes \`daemon install\` ran first; errors with a "run install first" hint via \`ErrNotInstalled\` if the config file is missing).
- \`daemon down\` — stop services; supervisor config stays on disk so \`up\` can bring them back.
- \`daemon restart\` — \`down\` then \`up\`.

\`Backend\` gains \`Start\`/\`Stop\` methods that reuse the existing bootstrap / bootout (launchd) and enable-now / stop (systemd) helpers. New top-level \`Up\` / \`Down\` / \`Restart\` in \`internal/daemon/control.go\` drives the per-service loop and resolves the config-presence check.

## Cross-platform asymmetry (documented at CLI surface)

- launchd \`down\` is bootout — service won't auto-restart on next login until \`up\` runs.
- systemd \`down\` is \`stop\` — unit stays enabled, comes back on next login.

Each platform's natural verb; matches how \`brew services\` and similar tools behave.

## E2E

Extends the macOS \`e2e-daemon-install-macos\` workflow to exercise the full install → down → up → restart → uninstall cycle plus the \`ErrNotInstalled\` assertion (run \`daemon up\` after uninstall, expect error with "not installed" in the message).

## Test plan

- [x] \`make check\` passes (lint-fix + unit tests; new control_test.go covers both backends).
- [x] Mac e2e extended; will run automatically on this PR.
- [ ] Manual: real macOS host — install → down → up → restart → uninstall round-trip works.
- [ ] Manual: real Linux dev box with \`systemctl --user\` — same round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)