### PR TITLE
feat: ACI-5037 version-drift detector + --no-update-check flag

### DIFF
--- a/cmd/common/activate.go
+++ b/cmd/common/activate.go
@@ -23,9 +23,7 @@ Call the subcommands with the name of the tool you want to activate plugins for.
 		// Best-effort: failures must not block activation.
 		_ = childstats.Sweep(childstats.DefaultSweepTTL)
 
-		// Mirror the root version-drift check (ACI-5037). Without this call
-		// `activate gradle / xcode / c++ / bazel` would skip the check — and
-		// those are the primary entry point for every Bitrise step.
+		// Mirror the root version-drift check — activate subcommands are the primary entry point for Bitrise steps.
 		if !ShouldSkipVersionCheck(cmd) {
 			RunVersionCheck(cmd)
 		}

--- a/cmd/common/activate.go
+++ b/cmd/common/activate.go
@@ -14,7 +14,7 @@ var ActivateCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Short: "Activate various bitrise plugins",
 	Long: `Activate Gradle, Bazel, etc. plugins
 Call the subcommands with the name of the tool you want to activate plugins for.`,
-	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 		// Cobra runs only the closest ancestor PersistentPreRun, so this overrides
 		// RootCmd's CLI-version log line — re-emit it here.
 		configcommon.LogCLIVersion(log.NewLogger(log.WithDebugLog(IsDebugLogMode)))
@@ -22,6 +22,13 @@ Call the subcommands with the name of the tool you want to activate plugins for.
 		// Opportunistic sweep of stale child-invocation ledger dirs.
 		// Best-effort: failures must not block activation.
 		_ = childstats.Sweep(childstats.DefaultSweepTTL)
+
+		// Mirror the root version-drift check (ACI-5037). Without this call
+		// `activate gradle / xcode / c++ / bazel` would skip the check — and
+		// those are the primary entry point for every Bitrise step.
+		if !ShouldSkipVersionCheck(cmd) {
+			RunVersionCheck(cmd)
+		}
 	},
 }
 

--- a/cmd/common/activate.go
+++ b/cmd/common/activate.go
@@ -8,22 +8,17 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/common/childstats"
 )
 
-// ActivateCmd represents the activate command
 var ActivateCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Use:   "activate",
 	Short: "Activate various bitrise plugins",
 	Long: `Activate Gradle, Bazel, etc. plugins
 Call the subcommands with the name of the tool you want to activate plugins for.`,
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-		// Cobra runs only the closest ancestor PersistentPreRun, so this overrides
-		// RootCmd's CLI-version log line — re-emit it here.
+		// Cobra only runs the closest ancestor PersistentPreRun — re-emit the CLI-version log here.
 		configcommon.LogCLIVersion(log.NewLogger(log.WithDebugLog(IsDebugLogMode)))
 
-		// Opportunistic sweep of stale child-invocation ledger dirs.
-		// Best-effort: failures must not block activation.
 		_ = childstats.Sweep(childstats.DefaultSweepTTL)
 
-		// Mirror the root version-drift check — activate subcommands are the primary entry point for Bitrise steps.
 		if !ShouldSkipVersionCheck(cmd) {
 			RunVersionCheck(cmd)
 		}

--- a/cmd/common/root.go
+++ b/cmd/common/root.go
@@ -12,14 +12,9 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/versioncheck"
 )
 
-// NoUpdateCheck is set by the global --no-update-check flag. Read from the
-// root PersistentPreRun to gate the GitHub release lookup. Exported so other
-// subcommands can short-circuit additional network calls if needed.
-//
 //nolint:gochecknoglobals
 var NoUpdateCheck bool
 
-// rootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Use:     "bitrise-build-cache-cli",
 	Version: configcommon.GetCLIVersion(log.NewLogger()),
@@ -34,14 +29,12 @@ In case of Gradle it's done via creating or modifying the following two files: $
 
 In case of Bazel it's done via creating or modifying $HOME/.bazelrc.`,
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-		// `version` already prints the CLI version itself; skip the duplicate log line.
 		if cmd.Name() == "version" {
 			return
 		}
 
 		configcommon.LogCLIVersion(log.NewLogger(log.WithDebugLog(IsDebugLogMode)))
 
-		// Best-effort drift detection: skip helpers/daemon-control verbs to keep their output deterministic.
 		if ShouldSkipVersionCheck(cmd) {
 			return
 		}
@@ -50,29 +43,15 @@ In case of Bazel it's done via creating or modifying $HOME/.bazelrc.`,
 	},
 }
 
-// ShouldSkipVersionCheck returns true for command names that shouldn't trigger
-// a version drift check / GitHub network lookup. Exported so the activate
-// subtree (cmd/common/activate.go) and any other PersistentPreRun overrides
-// can share the same skip list.
-//
-// The skip list MUST include subcommands that fire many times per build —
-// the xcelerate xcodebuild wrapper, the proxy + storage-helper start/stop
-// verbs, and the per-invocation register / set-id calls. Each version-check
-// run does a mkdir + temp-file create + JSON marshal + atomic rename; doing
-// that hundreds of times per clean iOS build is real overhead. (Version
-// drift is detected on the next "real" CLI run instead.)
+// ShouldSkipVersionCheck excludes subcommands that fire many times per build (each version check is mkdir + tmpfile + marshal + rename).
 func ShouldSkipVersionCheck(cmd *cobra.Command) bool {
 	switch cmd.Name() {
 	case "version", "help", "completion":
 		return true
 	case
-		// xcelerate xcodebuild wrapper — invoked by every Xcode build phase.
 		"xcodebuild",
-		// xcelerate proxy lifecycle — daemon + activate paths both poke it.
 		"start-proxy", "stop-proxy",
-		// ccache storage helper lifecycle + per-invocation hooks.
 		"start", "stop", "set-invocation-id", "health-check", "collect-stats",
-		// Child-stats register hooks fire per nested step / shell invocation.
 		"register-invocation", "register-child-invocation":
 		return true
 	default:
@@ -80,11 +59,7 @@ func ShouldSkipVersionCheck(cmd *cobra.Command) bool {
 	}
 }
 
-// RunVersionCheck performs the drift detect + nudge with a generous context
-// timeout. Exported so non-root cobra subtree PersistentPreRun overrides can
-// share the logic — cobra runs only the closest ancestor's hook.
-//
-// Callers MUST gate on ShouldSkipVersionCheck before invoking.
+// RunVersionCheck must be gated on ShouldSkipVersionCheck. Cobra runs only the closest ancestor's PersistentPreRun.
 func RunVersionCheck(cmd *cobra.Command) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -105,9 +80,6 @@ func RunVersionCheck(cmd *cobra.Command) {
 	})
 }
 
-// isRunningOnCI is the heuristic we use to suppress the nudge on CI. Matches
-// what most CI providers set: CI=true (Bitrise, GitHub Actions, CircleCI),
-// or the presence of a Bitrise-specific env var.
 func isRunningOnCI() bool {
 	if v, ok := os.LookupEnv("CI"); ok && v != "" && v != "0" && v != "false" {
 		return true
@@ -120,8 +92,6 @@ func isRunningOnCI() bool {
 	return false
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	err := RootCmd.Execute()
 	if err != nil {

--- a/cmd/common/root.go
+++ b/cmd/common/root.go
@@ -101,11 +101,13 @@ func RunVersionCheck(cmd *cobra.Command) {
 	ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
 	defer cancel()
 
+	logger := log.NewLogger(log.WithDebugLog(IsDebugLogMode))
+
 	_, _ = versioncheck.RunOnce(ctx, versioncheck.Options{
-		CurrentVersion: configcommon.GetCLIVersion(log.NewLogger()),
+		CurrentVersion: configcommon.GetCLIVersion(logger),
 		Home:           home,
 		NoUpdateCheck:  NoUpdateCheck,
-		Out:            os.Stderr,
+		Logger:         logger,
 		IsCI:           isRunningOnCI(),
 	})
 }

--- a/cmd/common/root.go
+++ b/cmd/common/root.go
@@ -1,13 +1,23 @@
 package common
 
 import (
+	"context"
 	"os"
+	"time"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/versioncheck"
 )
+
+// NoUpdateCheck is set by the global --no-update-check flag. Read from the
+// root PersistentPreRun to gate the GitHub release lookup. Exported so other
+// subcommands can short-circuit additional network calls if needed.
+//
+//nolint:gochecknoglobals
+var NoUpdateCheck bool
 
 // rootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{ //nolint:gochecknoglobals
@@ -30,7 +40,65 @@ In case of Bazel it's done via creating or modifying $HOME/.bazelrc.`,
 		}
 
 		configcommon.LogCLIVersion(log.NewLogger(log.WithDebugLog(IsDebugLogMode)))
+
+		// Version-drift detection (ACI-5037). Best-effort: never block the
+		// invocation. Subcommands that don't represent a user-facing action
+		// (help, completion, the daemon up/down/restart imperatives that just
+		// poke launchctl) skip the check to keep their output deterministic.
+		if shouldSkipVersionCheck(cmd) {
+			return
+		}
+
+		runVersionCheck(cmd)
 	},
+}
+
+// shouldSkipVersionCheck returns true for command names that shouldn't trigger
+// a version drift check / GitHub network lookup. Keep this list tight — the
+// check is supposed to fire on every real CLI invocation.
+func shouldSkipVersionCheck(cmd *cobra.Command) bool {
+	switch cmd.Name() {
+	case "version", "help", "completion":
+		return true
+	default:
+		return false
+	}
+}
+
+// runVersionCheck performs the drift detect + nudge with a generous context
+// timeout (so a hung GitHub call can't slow a CI / dev run). Errors are
+// swallowed — the version check is advisory.
+func runVersionCheck(cmd *cobra.Command) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+	defer cancel()
+
+	_, _ = versioncheck.RunOnce(ctx, versioncheck.Options{
+		CurrentVersion: configcommon.GetCLIVersion(log.NewLogger()),
+		Home:           home,
+		NoUpdateCheck:  NoUpdateCheck,
+		Out:            os.Stderr,
+		IsCI:           isRunningOnCI(),
+	})
+}
+
+// isRunningOnCI is the heuristic we use to suppress the nudge on CI. Matches
+// what most CI providers set: CI=true (Bitrise, GitHub Actions, CircleCI),
+// or the presence of a Bitrise-specific env var.
+func isRunningOnCI() bool {
+	if v, ok := os.LookupEnv("CI"); ok && v != "" && v != "0" && v != "false" {
+		return true
+	}
+
+	if _, ok := os.LookupEnv("BITRISE_BUILD_NUMBER"); ok {
+		return true
+	}
+
+	return false
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -48,4 +116,6 @@ func Execute() {
 
 func init() {
 	RootCmd.PersistentFlags().BoolVarP(&IsDebugLogMode, "debug", "d", false, "Enable debug logging mode")
+	RootCmd.PersistentFlags().BoolVar(&NoUpdateCheck, "no-update-check", false,
+		"Skip the GitHub release lookup that nudges when a newer CLI version is available")
 }

--- a/cmd/common/root.go
+++ b/cmd/common/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/versioncheck"
 )
 
@@ -43,7 +44,6 @@ In case of Bazel it's done via creating or modifying $HOME/.bazelrc.`,
 	},
 }
 
-// ShouldSkipVersionCheck excludes subcommands that fire many times per build (each version check is mkdir + tmpfile + marshal + rename).
 func ShouldSkipVersionCheck(cmd *cobra.Command) bool {
 	switch cmd.Name() {
 	case "version", "help", "completion":
@@ -59,7 +59,6 @@ func ShouldSkipVersionCheck(cmd *cobra.Command) bool {
 	}
 }
 
-// RunVersionCheck must be gated on ShouldSkipVersionCheck. Cobra runs only the closest ancestor's PersistentPreRun.
 func RunVersionCheck(cmd *cobra.Command) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -76,20 +75,8 @@ func RunVersionCheck(cmd *cobra.Command) {
 		Home:           home,
 		NoUpdateCheck:  NoUpdateCheck,
 		Logger:         logger,
-		IsCI:           isRunningOnCI(),
+		IsCI:           configcommon.DetectCIProvider(utils.AllEnvs()) != "",
 	})
-}
-
-func isRunningOnCI() bool {
-	if v, ok := os.LookupEnv("CI"); ok && v != "" && v != "0" && v != "false" {
-		return true
-	}
-
-	if _, ok := os.LookupEnv("BITRISE_BUILD_NUMBER"); ok {
-		return true
-	}
-
-	return false
 }
 
 func Execute() {
@@ -106,5 +93,5 @@ func Execute() {
 func init() {
 	RootCmd.PersistentFlags().BoolVarP(&IsDebugLogMode, "debug", "d", false, "Enable debug logging mode")
 	RootCmd.PersistentFlags().BoolVar(&NoUpdateCheck, "no-update-check", false,
-		"Skip the GitHub release lookup that nudges when a newer CLI version is available")
+		"Suppress the new-release nudge")
 }

--- a/cmd/common/root.go
+++ b/cmd/common/root.go
@@ -41,10 +41,7 @@ In case of Bazel it's done via creating or modifying $HOME/.bazelrc.`,
 
 		configcommon.LogCLIVersion(log.NewLogger(log.WithDebugLog(IsDebugLogMode)))
 
-		// Version-drift detection (ACI-5037). Best-effort: never block the
-		// invocation. Subcommands that don't represent a user-facing action
-		// (help, completion, the daemon up/down/restart imperatives that just
-		// poke launchctl) skip the check to keep their output deterministic.
+		// Best-effort drift detection: skip helpers/daemon-control verbs to keep their output deterministic.
 		if ShouldSkipVersionCheck(cmd) {
 			return
 		}
@@ -84,12 +81,8 @@ func ShouldSkipVersionCheck(cmd *cobra.Command) bool {
 }
 
 // RunVersionCheck performs the drift detect + nudge with a generous context
-// timeout (so a hung GitHub call can't slow a CI / dev run). Exported so
-// PersistentPreRun overrides in non-root cobra subtrees (e.g. ActivateCmd in
-// cmd/common/activate.go) can call into the same logic — cobra runs only
-// the closest ancestor's hook, so root's hook alone would never fire for
-// `activate gradle / xcode / c++ / bazel`, the primary entry point for
-// every Bitrise step.
+// timeout. Exported so non-root cobra subtree PersistentPreRun overrides can
+// share the logic — cobra runs only the closest ancestor's hook.
 //
 // Callers MUST gate on ShouldSkipVersionCheck before invoking.
 func RunVersionCheck(cmd *cobra.Command) {

--- a/cmd/common/root.go
+++ b/cmd/common/root.go
@@ -45,30 +45,54 @@ In case of Bazel it's done via creating or modifying $HOME/.bazelrc.`,
 		// invocation. Subcommands that don't represent a user-facing action
 		// (help, completion, the daemon up/down/restart imperatives that just
 		// poke launchctl) skip the check to keep their output deterministic.
-		if shouldSkipVersionCheck(cmd) {
+		if ShouldSkipVersionCheck(cmd) {
 			return
 		}
 
-		runVersionCheck(cmd)
+		RunVersionCheck(cmd)
 	},
 }
 
-// shouldSkipVersionCheck returns true for command names that shouldn't trigger
-// a version drift check / GitHub network lookup. Keep this list tight — the
-// check is supposed to fire on every real CLI invocation.
-func shouldSkipVersionCheck(cmd *cobra.Command) bool {
+// ShouldSkipVersionCheck returns true for command names that shouldn't trigger
+// a version drift check / GitHub network lookup. Exported so the activate
+// subtree (cmd/common/activate.go) and any other PersistentPreRun overrides
+// can share the same skip list.
+//
+// The skip list MUST include subcommands that fire many times per build —
+// the xcelerate xcodebuild wrapper, the proxy + storage-helper start/stop
+// verbs, and the per-invocation register / set-id calls. Each version-check
+// run does a mkdir + temp-file create + JSON marshal + atomic rename; doing
+// that hundreds of times per clean iOS build is real overhead. (Version
+// drift is detected on the next "real" CLI run instead.)
+func ShouldSkipVersionCheck(cmd *cobra.Command) bool {
 	switch cmd.Name() {
 	case "version", "help", "completion":
+		return true
+	case
+		// xcelerate xcodebuild wrapper — invoked by every Xcode build phase.
+		"xcodebuild",
+		// xcelerate proxy lifecycle — daemon + activate paths both poke it.
+		"start-proxy", "stop-proxy",
+		// ccache storage helper lifecycle + per-invocation hooks.
+		"start", "stop", "set-invocation-id", "health-check", "collect-stats",
+		// Child-stats register hooks fire per nested step / shell invocation.
+		"register-invocation", "register-child-invocation":
 		return true
 	default:
 		return false
 	}
 }
 
-// runVersionCheck performs the drift detect + nudge with a generous context
-// timeout (so a hung GitHub call can't slow a CI / dev run). Errors are
-// swallowed — the version check is advisory.
-func runVersionCheck(cmd *cobra.Command) {
+// RunVersionCheck performs the drift detect + nudge with a generous context
+// timeout (so a hung GitHub call can't slow a CI / dev run). Exported so
+// PersistentPreRun overrides in non-root cobra subtrees (e.g. ActivateCmd in
+// cmd/common/activate.go) can call into the same logic — cobra runs only
+// the closest ancestor's hook, so root's hook alone would never fire for
+// `activate gradle / xcode / c++ / bazel`, the primary entry point for
+// every Bitrise step.
+//
+// Callers MUST gate on ShouldSkipVersionCheck before invoking.
+func RunVersionCheck(cmd *cobra.Command) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return

--- a/cmd/daemon/install.go
+++ b/cmd/daemon/install.go
@@ -87,7 +87,7 @@ var installCmd = &cobra.Command{
 
 		switch result.BackendName {
 		case "launchd":
-			logger.Infof("Supervisor stdout/stderr log dir: %s", paths.LogDir())
+			logger.Infof("Supervisor stdout/stderr log dir: %s", paths.DaemonLogDir())
 			logger.Println()
 			logger.Infof("Verify with: launchctl print gui/$UID/io.bitrise.build-cache.xcelerate-proxy")
 		case "systemd":

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/zeebo/blake3 v0.2.4
+	golang.org/x/mod v0.33.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260203192932-546029d2fa20
 	google.golang.org/genproto/googleapis/bytestream v0.0.0-20251103181224-f26f9409b101
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20

--- a/internal/config/ccache/config.go
+++ b/internal/config/ccache/config.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
 const (
-	ccachePath       = ".bitrise/cache/ccache/"
+	ccacheToolName   = "ccache"
 	ccacheConfigFile = "config.json"
 
 	defaultLogFile            = "ccache-%s.log"
@@ -54,22 +55,27 @@ type Config struct {
 	AuthConfig common.CacheAuthConfig `json:"-"`
 }
 
+// relCcacheDir is the per-tool ccache cache dir relative to a root directory.
+func relCcacheDir() string {
+	return filepath.Join(paths.BitriseRootRelative, "cache", ccacheToolName)
+}
+
 func DirPath(osProxy utils.OsProxy) string {
 	if home, err := osProxy.UserHomeDir(); err == nil {
-		return filepath.Join(home, ccachePath)
+		return paths.FromHome(home).BitriseCacheDir(ccacheToolName)
 	}
 
 	if wd, err := osProxy.Getwd(); err == nil {
-		return filepath.Join(wd, ccachePath)
+		return filepath.Join(wd, relCcacheDir())
 	}
 
 	if exe, err := osProxy.Executable(); err == nil {
 		if dir := filepath.Dir(exe); dir != "" {
-			return filepath.Join(dir, ccachePath)
+			return filepath.Join(dir, relCcacheDir())
 		}
 	}
 
-	return filepath.Join(".", ccachePath)
+	return filepath.Join(".", relCcacheDir())
 }
 
 func PathFor(osProxy utils.OsProxy, subpath string) string {

--- a/internal/config/reactnative/config.go
+++ b/internal/config/reactnative/config.go
@@ -11,12 +11,13 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
 const (
-	reactNativePath = ".bitrise/cache/reactnative/"
-	ConfigFileName  = "config.json"
+	reactNativeToolName = "reactnative"
+	ConfigFileName      = "config.json"
 
 	ErrFmtOpenConfigFile   = "open react-native config file (%s): %w"
 	ErrFmtDecodeConfigFile = "decode react-native config file (%s): %w"
@@ -32,22 +33,26 @@ type Config struct {
 	Enabled bool `json:"enabled"`
 }
 
+func relReactNativeDir() string {
+	return filepath.Join(paths.BitriseRootRelative, "cache", reactNativeToolName)
+}
+
 func DirPath(osProxy utils.OsProxy) string {
 	if home, err := osProxy.UserHomeDir(); err == nil {
-		return filepath.Join(home, reactNativePath)
+		return paths.FromHome(home).BitriseCacheDir(reactNativeToolName)
 	}
 
 	if wd, err := osProxy.Getwd(); err == nil {
-		return filepath.Join(wd, reactNativePath)
+		return filepath.Join(wd, relReactNativeDir())
 	}
 
 	if exe, err := osProxy.Executable(); err == nil {
 		if dir := filepath.Dir(exe); dir != "" {
-			return filepath.Join(dir, reactNativePath)
+			return filepath.Join(dir, relReactNativeDir())
 		}
 	}
 
-	return filepath.Join(".", reactNativePath)
+	return filepath.Join(".", relReactNativeDir())
 }
 
 func PathFor(osProxy utils.OsProxy, subpath string) string {

--- a/internal/config/xcelerate/config.go
+++ b/internal/config/xcelerate/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
@@ -169,7 +170,7 @@ func NewConfig(ctx context.Context,
 	if proxySocketPath == "" {
 		proxySocketPath = envs["BITRISE_XCELERATE_PROXY_SOCKET_PATH"]
 		if proxySocketPath == "" {
-			proxySocketPath = filepath.Join(osProxy.TempDir(), "xcelerate-proxy.sock")
+			proxySocketPath = filepath.Join(osProxy.TempDir(), paths.ProxySocketName)
 			logger.Infof("Using new proxy socket path: %s", proxySocketPath)
 		} else {
 			logger.Infof("Using proxy socket path from environment: %s", proxySocketPath)

--- a/internal/config/xcelerate/paths.go
+++ b/internal/config/xcelerate/paths.go
@@ -3,32 +3,33 @@ package xcelerate
 import (
 	"path/filepath"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
 const (
-	xceleratePath       = ".bitrise-xcelerate/"
 	BinDir              = "bin"
 	ErrFmtDetermineHome = `could not determine home: %w`
 )
 
+// DirPath returns the xcelerate root dir (~/.bitrise-xcelerate) using osProxy's home;
+// falls back to working dir / executable dir / "." when home cannot be resolved.
 func DirPath(osProxy utils.OsProxy) string {
 	if home, err := osProxy.UserHomeDir(); err == nil {
-		return filepath.Join(home, xceleratePath)
+		return paths.FromHome(home).XcelerateRoot()
 	}
 
 	if wd, err := osProxy.Getwd(); err == nil {
-		return filepath.Join(wd, xceleratePath)
+		return filepath.Join(wd, paths.XcelerateRootRelative)
 	}
 
 	if exe, err := osProxy.Executable(); err == nil {
 		if dir := filepath.Dir(exe); dir != "" {
-			return filepath.Join(dir, xceleratePath)
+			return filepath.Join(dir, paths.XcelerateRootRelative)
 		}
 	}
 
-	// last resort
-	return filepath.Join(".", xceleratePath)
+	return filepath.Join(".", paths.XcelerateRootRelative)
 }
 
 func PathFor(osProxy utils.OsProxy, subpath string) string {

--- a/internal/daemon/binary.go
+++ b/internal/daemon/binary.go
@@ -5,18 +5,20 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
 )
 
 const stableBinName = "bitrise-build-cache"
 
 // StableBinPath returns ~/.bitrise/bin/bitrise-build-cache.
 func StableBinPath() (string, error) {
-	home, err := os.UserHomeDir()
+	p, err := paths.Default()
 	if err != nil {
-		return "", fmt.Errorf("resolve home dir: %w", err)
+		return "", fmt.Errorf("resolve stable bin path: %w", err)
 	}
 
-	return filepath.Join(home, ".bitrise", "bin", stableBinName), nil
+	return p.BitriseBinFile(stableBinName), nil
 }
 
 // CopyCLIToStableBin copies src to StableBinPath() with 0o755 perms,

--- a/internal/daemon/launchd.go
+++ b/internal/daemon/launchd.go
@@ -21,7 +21,7 @@ func (b LaunchdBackend) Install(ctx context.Context, paths Paths, svc Service, e
 		return "", fmt.Errorf("create LaunchAgents dir: %w", err)
 	}
 
-	if err := os.MkdirAll(paths.LogDir(), 0o755); err != nil {
+	if err := os.MkdirAll(paths.DaemonLogDir(), 0o755); err != nil {
 		return "", fmt.Errorf("create log dir: %w", err)
 	}
 

--- a/internal/daemon/launchd_plist.go
+++ b/internal/daemon/launchd_plist.go
@@ -56,8 +56,8 @@ func GeneratePlist(svc Service, executable string, paths Paths) (string, error) 
 	data := plistData{
 		Label:            svc.Label(),
 		ProgramArguments: args,
-		StdoutPath:       paths.StdoutPath(svc.Name),
-		StderrPath:       paths.StderrPath(svc.Name),
+		StdoutPath:       paths.DaemonStdoutPath(svc.Name),
+		StderrPath:       paths.DaemonStderrPath(svc.Name),
 	}
 
 	var buf bytes.Buffer

--- a/internal/daemon/paths.go
+++ b/internal/daemon/paths.go
@@ -2,57 +2,25 @@ package daemon
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
 )
 
-const LogDirRelative = ".local/state/bitrise-build-cache/logs"
+// Paths is an alias of the shared internal/paths.Paths so external callers
+// don't have to import two packages when they're already in the daemon API.
+type Paths = paths.Paths
 
-const LaunchAgentsDirRelative = "Library/LaunchAgents"
-
-const SystemdUserDirRelative = ".config/systemd/user"
-
-type Paths struct {
-	Home string
-}
-
+// NewPathsFromHome returns Paths rooted at the supplied home dir.
 func NewPathsFromHome(home string) Paths {
-	return Paths{Home: home}
+	return paths.FromHome(home)
 }
 
+// NewPaths returns Paths rooted at the current user's home dir.
 func NewPaths() (Paths, error) {
-	home, err := os.UserHomeDir()
+	p, err := paths.Default()
 	if err != nil {
-		return Paths{}, fmt.Errorf("resolve user home dir: %w", err)
+		return p, fmt.Errorf("resolve default paths: %w", err)
 	}
 
-	return Paths{Home: home}, nil
-}
-
-func (p Paths) LaunchAgentsDir() string {
-	return filepath.Join(p.Home, LaunchAgentsDirRelative)
-}
-
-func (p Paths) SystemdUserDir() string {
-	return filepath.Join(p.Home, SystemdUserDirRelative)
-}
-
-func (p Paths) LogDir() string {
-	return filepath.Join(p.Home, LogDirRelative)
-}
-
-func (p Paths) PlistPath(label string) string {
-	return filepath.Join(p.LaunchAgentsDir(), label+".plist")
-}
-
-func (p Paths) UnitPath(unitName string) string {
-	return filepath.Join(p.SystemdUserDir(), unitName+".service")
-}
-
-func (p Paths) StdoutPath(service string) string {
-	return filepath.Join(p.LogDir(), service+".out.log")
-}
-
-func (p Paths) StderrPath(service string) string {
-	return filepath.Join(p.LogDir(), service+".err.log")
+	return p, nil
 }

--- a/internal/daemon/systemd.go
+++ b/internal/daemon/systemd.go
@@ -21,7 +21,7 @@ func (b SystemdBackend) Install(ctx context.Context, paths Paths, svc Service, e
 		return "", fmt.Errorf("create systemd user dir: %w", err)
 	}
 
-	if err := os.MkdirAll(paths.LogDir(), 0o755); err != nil {
+	if err := os.MkdirAll(paths.DaemonLogDir(), 0o755); err != nil {
 		return "", fmt.Errorf("create log dir: %w", err)
 	}
 

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -21,8 +21,29 @@ const (
 	// SystemdUserDirRelative is Linux's per-user systemd unit dir.
 	SystemdUserDirRelative = ".config/systemd/user"
 
+	// BitriseRootRelative is the shared per-user dir under $HOME holding the cache root + stable CLI binary.
+	BitriseRootRelative = ".bitrise"
+
+	// XcelerateRootRelative is the per-user Xcelerate config root (~/.bitrise-xcelerate).
+	XcelerateRootRelative = ".bitrise-xcelerate"
+
+	// ProxySocketName is the xcelerate proxy unix-socket filename (lives under the OS temp dir).
+	ProxySocketName = "xcelerate-proxy.sock"
+
 	// daemonLogsSubdir is the daemon supervisor stdout/stderr log dir.
 	daemonLogsSubdir = "logs"
+
+	// bitriseBinSubdir holds the stable CLI binary copy used by the daemon supervisor.
+	bitriseBinSubdir = "bin"
+
+	// bitriseCacheSubdir is the per-tool cache/marker root used by activate, refresh, and child-stats.
+	bitriseCacheSubdir = "cache"
+
+	// xcelerateBinSubdir holds the xcelerate wrapper scripts (xcodebuild / xcrun) and CLI copy.
+	xcelerateBinSubdir = "bin"
+
+	// xcelerateConfigFile is the JSON config file written by `activate xcode`.
+	xcelerateConfigFile = "config.json"
 )
 
 // Paths resolves on-disk locations rooted at a single home directory.
@@ -88,4 +109,49 @@ func (p Paths) DaemonStdoutPath(service string) string {
 // DaemonStderrPath returns the supervisor stderr log file path for a service.
 func (p Paths) DaemonStderrPath(service string) string {
 	return filepath.Join(p.DaemonLogDir(), service+".err.log")
+}
+
+// BitriseRoot is the absolute path of the per-user ~/.bitrise dir.
+func (p Paths) BitriseRoot() string {
+	return filepath.Join(p.Home, BitriseRootRelative)
+}
+
+// BitriseBinDir is the absolute path of ~/.bitrise/bin (stable CLI copy).
+func (p Paths) BitriseBinDir() string {
+	return filepath.Join(p.BitriseRoot(), bitriseBinSubdir)
+}
+
+// BitriseCacheDir is the per-tool cache/marker dir under ~/.bitrise/cache.
+func (p Paths) BitriseCacheDir(tool string) string {
+	return filepath.Join(p.BitriseRoot(), bitriseCacheSubdir, tool)
+}
+
+// BitriseCacheFile returns a file path under BitriseCacheDir(tool).
+func (p Paths) BitriseCacheFile(tool, name string) string {
+	return filepath.Join(p.BitriseCacheDir(tool), name)
+}
+
+// XcelerateRoot is the absolute path of ~/.bitrise-xcelerate.
+func (p Paths) XcelerateRoot() string {
+	return filepath.Join(p.Home, XcelerateRootRelative)
+}
+
+// XcelerateConfigFile returns ~/.bitrise-xcelerate/config.json.
+func (p Paths) XcelerateConfigFile() string {
+	return filepath.Join(p.XcelerateRoot(), xcelerateConfigFile)
+}
+
+// XcelerateBinDir returns ~/.bitrise-xcelerate/bin.
+func (p Paths) XcelerateBinDir() string {
+	return filepath.Join(p.XcelerateRoot(), xcelerateBinSubdir)
+}
+
+// XcelerateBinFile returns a file path under XcelerateBinDir.
+func (p Paths) XcelerateBinFile(name string) string {
+	return filepath.Join(p.XcelerateBinDir(), name)
+}
+
+// ProxySocketPath returns the xcelerate proxy unix-socket path under the supplied temp dir.
+func (p Paths) ProxySocketPath(tempDir string) string {
+	return filepath.Join(tempDir, ProxySocketName)
 }

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,0 +1,91 @@
+// Package paths centralises the on-disk locations the CLI reads and writes.
+// One package so the layout under ~/.local/state/bitrise-build-cache stays
+// consistent across versioncheck, refresh, daemon supervisor logs, and the
+// future Xcelerate / ccache state dirs.
+package paths
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Relative dirs under $HOME.
+const (
+	// StateDirRelative is the shared per-user state root.
+	StateDirRelative = ".local/state/bitrise-build-cache"
+
+	// LaunchAgentsDirRelative is macOS's per-user LaunchAgents location.
+	LaunchAgentsDirRelative = "Library/LaunchAgents"
+
+	// SystemdUserDirRelative is Linux's per-user systemd unit dir.
+	SystemdUserDirRelative = ".config/systemd/user"
+
+	// daemonLogsSubdir is the daemon supervisor stdout/stderr log dir.
+	daemonLogsSubdir = "logs"
+)
+
+// Paths resolves on-disk locations rooted at a single home directory.
+type Paths struct {
+	Home string
+}
+
+// FromHome returns Paths rooted at the supplied home dir.
+func FromHome(home string) Paths {
+	return Paths{Home: home}
+}
+
+// Default returns Paths rooted at the current user's home dir.
+func Default() (Paths, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return Paths{}, fmt.Errorf("resolve user home dir: %w", err)
+	}
+
+	return Paths{Home: home}, nil
+}
+
+// StateDir is the absolute path of the per-user state root.
+func (p Paths) StateDir() string {
+	return filepath.Join(p.Home, StateDirRelative)
+}
+
+// StateFile returns the absolute path of a file under StateDir.
+func (p Paths) StateFile(name string) string {
+	return filepath.Join(p.StateDir(), name)
+}
+
+// LaunchAgentsDir is the absolute path of the per-user macOS LaunchAgents dir.
+func (p Paths) LaunchAgentsDir() string {
+	return filepath.Join(p.Home, LaunchAgentsDirRelative)
+}
+
+// SystemdUserDir is the absolute path of the per-user systemd unit dir.
+func (p Paths) SystemdUserDir() string {
+	return filepath.Join(p.Home, SystemdUserDirRelative)
+}
+
+// DaemonLogDir is the absolute path of the daemon supervisor stdout/stderr log dir.
+func (p Paths) DaemonLogDir() string {
+	return filepath.Join(p.StateDir(), daemonLogsSubdir)
+}
+
+// PlistPath returns the per-user LaunchAgent plist path for the given label.
+func (p Paths) PlistPath(label string) string {
+	return filepath.Join(p.LaunchAgentsDir(), label+".plist")
+}
+
+// UnitPath returns the systemd --user unit file path for the given name.
+func (p Paths) UnitPath(unitName string) string {
+	return filepath.Join(p.SystemdUserDir(), unitName+".service")
+}
+
+// DaemonStdoutPath returns the supervisor stdout log file path for a service.
+func (p Paths) DaemonStdoutPath(service string) string {
+	return filepath.Join(p.DaemonLogDir(), service+".out.log")
+}
+
+// DaemonStderrPath returns the supervisor stderr log file path for a service.
+func (p Paths) DaemonStderrPath(service string) string {
+	return filepath.Join(p.DaemonLogDir(), service+".err.log")
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -121,6 +121,11 @@ func (p Paths) BitriseBinDir() string {
 	return filepath.Join(p.BitriseRoot(), bitriseBinSubdir)
 }
 
+// BitriseBinFile returns a file path under BitriseBinDir.
+func (p Paths) BitriseBinFile(name string) string {
+	return filepath.Join(p.BitriseBinDir(), name)
+}
+
 // BitriseCacheDir is the per-tool cache/marker dir under ~/.bitrise/cache.
 func (p Paths) BitriseCacheDir(tool string) string {
 	return filepath.Join(p.BitriseRoot(), bitriseCacheSubdir, tool)

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -37,6 +37,7 @@ func TestPaths_bitriseRoot(t *testing.T) {
 
 	assert.Equal(t, "/h/.bitrise", p.BitriseRoot())
 	assert.Equal(t, "/h/.bitrise/bin", p.BitriseBinDir())
+	assert.Equal(t, "/h/.bitrise/bin/bitrise-build-cache", p.BitriseBinFile("bitrise-build-cache"))
 	assert.Equal(t, "/h/.bitrise/cache/ccache", p.BitriseCacheDir("ccache"))
 	assert.Equal(t, "/h/.bitrise/cache/reactnative/config.json", p.BitriseCacheFile("reactnative", "config.json"))
 }

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -31,3 +31,27 @@ func TestPaths_supervisorArtifacts(t *testing.T) {
 	assert.Equal(t, filepath.Join("/h", ".local/state/bitrise-build-cache/logs", "ccache-helper.err.log"),
 		p.DaemonStderrPath("ccache-helper"))
 }
+
+func TestPaths_bitriseRoot(t *testing.T) {
+	p := FromHome("/h")
+
+	assert.Equal(t, "/h/.bitrise", p.BitriseRoot())
+	assert.Equal(t, "/h/.bitrise/bin", p.BitriseBinDir())
+	assert.Equal(t, "/h/.bitrise/cache/ccache", p.BitriseCacheDir("ccache"))
+	assert.Equal(t, "/h/.bitrise/cache/reactnative/config.json", p.BitriseCacheFile("reactnative", "config.json"))
+}
+
+func TestPaths_xcelerate(t *testing.T) {
+	p := FromHome("/h")
+
+	assert.Equal(t, "/h/.bitrise-xcelerate", p.XcelerateRoot())
+	assert.Equal(t, "/h/.bitrise-xcelerate/config.json", p.XcelerateConfigFile())
+	assert.Equal(t, "/h/.bitrise-xcelerate/bin", p.XcelerateBinDir())
+	assert.Equal(t, "/h/.bitrise-xcelerate/bin/xcodebuild", p.XcelerateBinFile("xcodebuild"))
+}
+
+func TestPaths_proxySocket(t *testing.T) {
+	p := FromHome("/h")
+
+	assert.Equal(t, "/tmp/xcelerate-proxy.sock", p.ProxySocketPath("/tmp"))
+}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,33 @@
+//go:build unit
+
+package paths
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromHome_stateAndLogPaths(t *testing.T) {
+	p := FromHome("/Users/alice")
+
+	assert.Equal(t, "/Users/alice/.local/state/bitrise-build-cache", p.StateDir())
+	assert.Equal(t, "/Users/alice/.local/state/bitrise-build-cache/version-state.json", p.StateFile("version-state.json"))
+	assert.Equal(t, "/Users/alice/.local/state/bitrise-build-cache/logs", p.DaemonLogDir())
+	assert.Equal(t, "/Users/alice/Library/LaunchAgents", p.LaunchAgentsDir())
+	assert.Equal(t, "/Users/alice/.config/systemd/user", p.SystemdUserDir())
+}
+
+func TestPaths_supervisorArtifacts(t *testing.T) {
+	p := FromHome("/h")
+
+	assert.Equal(t, filepath.Join("/h", "Library/LaunchAgents", "io.bitrise.build-cache.xcelerate-proxy.plist"),
+		p.PlistPath("io.bitrise.build-cache.xcelerate-proxy"))
+	assert.Equal(t, filepath.Join("/h", ".config/systemd/user", "bitrise-build-cache-xcelerate-proxy.service"),
+		p.UnitPath("bitrise-build-cache-xcelerate-proxy"))
+	assert.Equal(t, filepath.Join("/h", ".local/state/bitrise-build-cache/logs", "ccache-helper.out.log"),
+		p.DaemonStdoutPath("ccache-helper"))
+	assert.Equal(t, filepath.Join("/h", ".local/state/bitrise-build-cache/logs", "ccache-helper.err.log"),
+		p.DaemonStderrPath("ccache-helper"))
+}

--- a/internal/versioncheck/detector.go
+++ b/internal/versioncheck/detector.go
@@ -1,35 +1,19 @@
 package versioncheck
 
-// BumpKind classifies the direction of the version delta between the
-// previously-persisted version and the currently-running binary.
 type BumpKind int
 
 const (
-	// NoChange — running binary version matches the persisted version.
 	NoChange BumpKind = iota
-	// FirstRun — no previous version persisted; this is the first time the
-	// CLI wrote state. Not a bump per se, but D3 may still want to refresh
-	// configs the first time.
 	FirstRun
-	// Bump — running binary version is different from the persisted one.
-	// Could be a forward upgrade or (rarely) a downgrade after a rollback;
-	// we treat both as "config-refresh worthy" because either direction can
-	// change generated config shape.
 	Bump
 )
 
-// DriftResult describes what changed between persisted state and the running
-// binary. Returned by Detect for the caller to decide whether to trigger
-// downstream refresh (D3) or emit a user-facing message.
 type DriftResult struct {
 	Kind            BumpKind
 	PreviousVersion string
 	CurrentVersion  string
 }
 
-// Detect compares the running binary's currentVersion against the persisted
-// state. Pure function — no I/O — so callers can compose it with their own
-// state lookup.
 func Detect(state State, currentVersion string) DriftResult {
 	switch state.LastVersion {
 	case "":

--- a/internal/versioncheck/detector.go
+++ b/internal/versioncheck/detector.go
@@ -1,0 +1,42 @@
+package versioncheck
+
+// BumpKind classifies the direction of the version delta between the
+// previously-persisted version and the currently-running binary.
+type BumpKind int
+
+const (
+	// NoChange — running binary version matches the persisted version.
+	NoChange BumpKind = iota
+	// FirstRun — no previous version persisted; this is the first time the
+	// CLI wrote state. Not a bump per se, but D3 may still want to refresh
+	// configs the first time.
+	FirstRun
+	// Bump — running binary version is different from the persisted one.
+	// Could be a forward upgrade or (rarely) a downgrade after a rollback;
+	// we treat both as "config-refresh worthy" because either direction can
+	// change generated config shape.
+	Bump
+)
+
+// DriftResult describes what changed between persisted state and the running
+// binary. Returned by Detect for the caller to decide whether to trigger
+// downstream refresh (D3) or emit a user-facing message.
+type DriftResult struct {
+	Kind            BumpKind
+	PreviousVersion string
+	CurrentVersion  string
+}
+
+// Detect compares the running binary's currentVersion against the persisted
+// state. Pure function — no I/O — so callers can compose it with their own
+// state lookup.
+func Detect(state State, currentVersion string) DriftResult {
+	switch state.LastVersion {
+	case "":
+		return DriftResult{Kind: FirstRun, CurrentVersion: currentVersion}
+	case currentVersion:
+		return DriftResult{Kind: NoChange, PreviousVersion: state.LastVersion, CurrentVersion: currentVersion}
+	default:
+		return DriftResult{Kind: Bump, PreviousVersion: state.LastVersion, CurrentVersion: currentVersion}
+	}
+}

--- a/internal/versioncheck/detector_test.go
+++ b/internal/versioncheck/detector_test.go
@@ -1,0 +1,36 @@
+//go:build unit
+
+package versioncheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetect_firstRunWhenStateEmpty(t *testing.T) {
+	res := Detect(State{}, "2.8.4")
+	assert.Equal(t, FirstRun, res.Kind)
+	assert.Empty(t, res.PreviousVersion)
+	assert.Equal(t, "2.8.4", res.CurrentVersion)
+}
+
+func TestDetect_noChangeWhenVersionsMatch(t *testing.T) {
+	res := Detect(State{LastVersion: "2.8.4"}, "2.8.4")
+	assert.Equal(t, NoChange, res.Kind)
+	assert.Equal(t, "2.8.4", res.PreviousVersion)
+}
+
+func TestDetect_bumpOnVersionChange(t *testing.T) {
+	res := Detect(State{LastVersion: "2.8.3"}, "2.8.4")
+	assert.Equal(t, Bump, res.Kind)
+	assert.Equal(t, "2.8.3", res.PreviousVersion)
+	assert.Equal(t, "2.8.4", res.CurrentVersion)
+}
+
+func TestDetect_bumpAlsoOnDowngrade(t *testing.T) {
+	// Treating any non-equal version as a bump matches the design — D3
+	// config refresh should run after a rollback too.
+	res := Detect(State{LastVersion: "2.9.0"}, "2.8.4")
+	assert.Equal(t, Bump, res.Kind)
+}

--- a/internal/versioncheck/nudge.go
+++ b/internal/versioncheck/nudge.go
@@ -22,7 +22,19 @@ const NudgeCooldown = 24 * time.Hour
 
 // FetchTimeout caps the HTTP call so a flaky network doesn't slow every CLI
 // run. The version check is best-effort by design.
-const FetchTimeout = 2 * time.Second
+//
+// Aligned with the context timeout the root cobra hook attaches in
+// cmd/common/root.go (see RunVersionCheck). Keep them in sync — diverging
+// values create a confusing window where http.Client times out one way
+// and ctx the other.
+const FetchTimeout = 3 * time.Second
+
+// ErrThrottled is returned by FetchLatestVersion when GitHub responds with
+// 403 / 429 (rate-limit, common on corporate-NAT shared IPs). Callers MUST
+// advance LastNudgeAt anyway to avoid hammering GitHub every invocation —
+// the throttle response is a signal that the cooldown should kick in, not
+// a "retry me" error.
+var ErrThrottled = errors.New("github rate-limited the release lookup (403/429)")
 
 // ErrNudgeSuppressed is returned by ShouldNudge when the user has opted out
 // (--no-update-check, CI=true) or when we've already nudged inside the
@@ -94,6 +106,15 @@ func FetchLatestVersion(ctx context.Context, client *http.Client, url string) (s
 	defer func() {
 		_ = resp.Body.Close()
 	}()
+
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusForbidden {
+		// 403 + 429 are GitHub's rate-limit signals (unauth API allows ~60
+		// req/h per IP — corporate NAT shares the budget across the office,
+		// so we see this in the wild). Return ErrThrottled so Run advances
+		// LastNudgeAt; without that, every CLI invocation would hammer
+		// GitHub forever once the budget was blown.
+		return "", ErrThrottled
+	}
 
 	if resp.StatusCode/100 != 2 {
 		return "", fmt.Errorf("github responded %d for latest release", resp.StatusCode)

--- a/internal/versioncheck/nudge.go
+++ b/internal/versioncheck/nudge.go
@@ -1,0 +1,140 @@
+package versioncheck
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// GitHubReleasesURL is the public GitHub API endpoint for the latest release
+// of the CLI repo. Used by FetchLatestVersion. Constructed as a constant so
+// tests can replace it via the URL parameter on FetchLatestVersion.
+const GitHubReleasesURL = "https://api.github.com/repos/bitrise-io/bitrise-build-cache-cli/releases/latest"
+
+// NudgeCooldown is the minimum time between two release-lookup network calls
+// for the same user. Keeps the GitHub API call cheap on the hot path while
+// still surfacing new releases within a day.
+const NudgeCooldown = 24 * time.Hour
+
+// FetchTimeout caps the HTTP call so a flaky network doesn't slow every CLI
+// run. The version check is best-effort by design.
+const FetchTimeout = 2 * time.Second
+
+// ErrNudgeSuppressed is returned by ShouldNudge when the user has opted out
+// (--no-update-check, CI=true) or when we've already nudged inside the
+// cooldown window. The CLI surface ignores this error — it's a signal, not a
+// failure.
+var ErrNudgeSuppressed = errors.New("version-check nudge suppressed")
+
+// NudgeDecision captures the inputs that gate whether we hit the network on
+// a given run. Pure data so tests can construct decisions without environment
+// poisoning.
+type NudgeDecision struct {
+	NoUpdateCheckFlag bool
+	IsCI              bool
+	Now               time.Time
+	LastNudgeAt       time.Time
+}
+
+// ShouldNudge returns nil if a network lookup is appropriate this run, or
+// ErrNudgeSuppressed otherwise. Caller treats ErrNudgeSuppressed as "skip"
+// without propagating it as a CLI error.
+func ShouldNudge(d NudgeDecision) error {
+	if d.NoUpdateCheckFlag {
+		return ErrNudgeSuppressed
+	}
+
+	if d.IsCI {
+		return ErrNudgeSuppressed
+	}
+
+	if !d.LastNudgeAt.IsZero() && d.Now.Sub(d.LastNudgeAt) < NudgeCooldown {
+		return ErrNudgeSuppressed
+	}
+
+	return nil
+}
+
+// releaseResponse is the subset of GitHub's release JSON we read. Everything
+// else is ignored — additive fields stay safe.
+type releaseResponse struct {
+	TagName string `json:"tag_name"`
+}
+
+// FetchLatestVersion calls the GitHub releases API and returns the bare
+// version string (with any leading `v` stripped — Goreleaser tags as `vX.Y.Z`
+// but our internal version is `X.Y.Z`). Errors are returned to the caller,
+// which treats them as "we'll try again next run" — the version check must
+// never block the user.
+//
+// url is parameterised so tests can swap in a test server URL. Pass
+// GitHubReleasesURL in production.
+func FetchLatestVersion(ctx context.Context, client *http.Client, url string) (string, error) {
+	if client == nil {
+		client = &http.Client{Timeout: FetchTimeout}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build release request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "bitrise-build-cache-cli/version-check")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch latest release: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("github responded %d for latest release", resp.StatusCode)
+	}
+
+	var body releaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("decode release response: %w", err)
+	}
+
+	tag := strings.TrimSpace(body.TagName)
+	if tag == "" {
+		return "", errors.New("github release response has empty tag_name")
+	}
+
+	return strings.TrimPrefix(tag, "v"), nil
+}
+
+// IsBehind compares the running and latest versions textually. We don't run
+// real semver compare here because the CLI's `devel` and snapshot versions
+// don't follow strict semver; instead we treat "non-empty and different from
+// latest" as behind. The nudge UX is informational, so a false-positive on a
+// pre-release build is benign.
+//
+// Returns false when current == latest or when either side is the "devel"
+// sentinel (local builds shouldn't nag).
+func IsBehind(current, latest string) bool {
+	current = strings.TrimSpace(current)
+	latest = strings.TrimSpace(latest)
+
+	if current == "" || latest == "" {
+		return false
+	}
+
+	if current == "devel" {
+		return false
+	}
+
+	if strings.TrimPrefix(current, "v") == strings.TrimPrefix(latest, "v") {
+		return false
+	}
+
+	return true
+}

--- a/internal/versioncheck/nudge.go
+++ b/internal/versioncheck/nudge.go
@@ -10,41 +10,18 @@ import (
 	"time"
 )
 
-// GitHubReleasesURL is the public GitHub API endpoint for the latest release
-// of the CLI repo. Used by FetchLatestVersion. Constructed as a constant so
-// tests can replace it via the URL parameter on FetchLatestVersion.
 const GitHubReleasesURL = "https://api.github.com/repos/bitrise-io/bitrise-build-cache-cli/releases/latest"
 
-// NudgeCooldown is the minimum time between two release-lookup network calls
-// for the same user. Keeps the GitHub API call cheap on the hot path while
-// still surfacing new releases within a day.
 const NudgeCooldown = 24 * time.Hour
 
-// FetchTimeout caps the HTTP call so a flaky network doesn't slow every CLI
-// run. The version check is best-effort by design.
-//
-// Aligned with the context timeout the root cobra hook attaches in
-// cmd/common/root.go (see RunVersionCheck). Keep them in sync — diverging
-// values create a confusing window where http.Client times out one way
-// and ctx the other.
+// FetchTimeout must stay in sync with the ctx timeout in cmd/common/root.go to avoid mismatched timeout windows.
 const FetchTimeout = 3 * time.Second
 
-// ErrThrottled is returned by FetchLatestVersion when GitHub responds with
-// 403 / 429 (rate-limit, common on corporate-NAT shared IPs). Callers MUST
-// advance LastNudgeAt anyway to avoid hammering GitHub every invocation —
-// the throttle response is a signal that the cooldown should kick in, not
-// a "retry me" error.
+// Callers MUST advance LastNudgeAt on ErrThrottled so a NAT that blew the unauth API budget doesn't hit GitHub on every run.
 var ErrThrottled = errors.New("github rate-limited the release lookup (403/429)")
 
-// ErrNudgeSuppressed is returned by ShouldNudge when the user has opted out
-// (--no-update-check, CI=true) or when we've already nudged inside the
-// cooldown window. The CLI surface ignores this error — it's a signal, not a
-// failure.
 var ErrNudgeSuppressed = errors.New("version-check nudge suppressed")
 
-// NudgeDecision captures the inputs that gate whether we hit the network on
-// a given run. Pure data so tests can construct decisions without environment
-// poisoning.
 type NudgeDecision struct {
 	NoUpdateCheckFlag bool
 	IsCI              bool
@@ -52,9 +29,6 @@ type NudgeDecision struct {
 	LastNudgeAt       time.Time
 }
 
-// ShouldNudge returns nil if a network lookup is appropriate this run, or
-// ErrNudgeSuppressed otherwise. Caller treats ErrNudgeSuppressed as "skip"
-// without propagating it as a CLI error.
 func ShouldNudge(d NudgeDecision) error {
 	if d.NoUpdateCheckFlag {
 		return ErrNudgeSuppressed
@@ -71,20 +45,11 @@ func ShouldNudge(d NudgeDecision) error {
 	return nil
 }
 
-// releaseResponse is the subset of GitHub's release JSON we read. Everything
-// else is ignored — additive fields stay safe.
 type releaseResponse struct {
 	TagName string `json:"tag_name"`
 }
 
-// FetchLatestVersion calls the GitHub releases API and returns the bare
-// version string (with any leading `v` stripped — Goreleaser tags as `vX.Y.Z`
-// but our internal version is `X.Y.Z`). Errors are returned to the caller,
-// which treats them as "we'll try again next run" — the version check must
-// never block the user.
-//
-// url is parameterised so tests can swap in a test server URL. Pass
-// GitHubReleasesURL in production.
+// FetchLatestVersion strips the Goreleaser-style leading `v` (our internal version is `X.Y.Z`).
 func FetchLatestVersion(ctx context.Context, client *http.Client, url string) (string, error) {
 	if client == nil {
 		client = &http.Client{Timeout: FetchTimeout}
@@ -108,11 +73,6 @@ func FetchLatestVersion(ctx context.Context, client *http.Client, url string) (s
 	}()
 
 	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusForbidden {
-		// 403 + 429 are GitHub's rate-limit signals (unauth API allows ~60
-		// req/h per IP — corporate NAT shares the budget across the office,
-		// so we see this in the wild). Return ErrThrottled so Run advances
-		// LastNudgeAt; without that, every CLI invocation would hammer
-		// GitHub forever once the budget was blown.
 		return "", ErrThrottled
 	}
 
@@ -133,14 +93,7 @@ func FetchLatestVersion(ctx context.Context, client *http.Client, url string) (s
 	return strings.TrimPrefix(tag, "v"), nil
 }
 
-// IsBehind compares the running and latest versions textually. We don't run
-// real semver compare here because the CLI's `devel` and snapshot versions
-// don't follow strict semver; instead we treat "non-empty and different from
-// latest" as behind. The nudge UX is informational, so a false-positive on a
-// pre-release build is benign.
-//
-// Returns false when current == latest or when either side is the "devel"
-// sentinel (local builds shouldn't nag).
+// IsBehind: textual compare, not semver — CLI's `devel` and snapshot versions don't follow strict semver.
 func IsBehind(current, latest string) bool {
 	current = strings.TrimSpace(current)
 	latest = strings.TrimSpace(latest)

--- a/internal/versioncheck/nudge.go
+++ b/internal/versioncheck/nudge.go
@@ -8,11 +8,13 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"golang.org/x/mod/semver"
 )
 
 const GitHubReleasesURL = "https://api.github.com/repos/bitrise-io/bitrise-build-cache-cli/releases/latest"
 
-const NudgeCooldown = 24 * time.Hour
+const NudgeCooldown = 4 * time.Hour
 
 // FetchTimeout must stay in sync with the ctx timeout in cmd/common/root.go to avoid mismatched timeout windows.
 const FetchTimeout = 3 * time.Second
@@ -49,7 +51,6 @@ type releaseResponse struct {
 	TagName string `json:"tag_name"`
 }
 
-// FetchLatestVersion strips the Goreleaser-style leading `v` (our internal version is `X.Y.Z`).
 func FetchLatestVersion(ctx context.Context, client *http.Client, url string) (string, error) {
 	if client == nil {
 		client = &http.Client{Timeout: FetchTimeout}
@@ -76,7 +77,7 @@ func FetchLatestVersion(ctx context.Context, client *http.Client, url string) (s
 		return "", ErrThrottled
 	}
 
-	if resp.StatusCode/100 != 2 {
+	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("github responded %d for latest release", resp.StatusCode)
 	}
 
@@ -93,7 +94,7 @@ func FetchLatestVersion(ctx context.Context, client *http.Client, url string) (s
 	return strings.TrimPrefix(tag, "v"), nil
 }
 
-// IsBehind: textual compare, not semver — CLI's `devel` and snapshot versions don't follow strict semver.
+// IsBehind suppresses the nudge for local builds and invalid-semver inputs.
 func IsBehind(current, latest string) bool {
 	current = strings.TrimSpace(current)
 	latest = strings.TrimSpace(latest)
@@ -102,13 +103,27 @@ func IsBehind(current, latest string) bool {
 		return false
 	}
 
-	if current == "devel" {
+	if isLocalBuild(current) {
 		return false
 	}
 
-	if strings.TrimPrefix(current, "v") == strings.TrimPrefix(latest, "v") {
+	curV := ensureSemverPrefix(current)
+	latestV := ensureSemverPrefix(latest)
+	if !semver.IsValid(curV) || !semver.IsValid(latestV) {
 		return false
 	}
 
-	return true
+	return semver.Compare(curV, latestV) < 0
+}
+
+func isLocalBuild(v string) bool {
+	return v == "devel" || strings.Contains(v, "+") || strings.Contains(v, "dirty")
+}
+
+func ensureSemverPrefix(v string) string {
+	if strings.HasPrefix(v, "v") {
+		return v
+	}
+
+	return "v" + v
 }

--- a/internal/versioncheck/nudge_test.go
+++ b/internal/versioncheck/nudge_test.go
@@ -63,6 +63,28 @@ func TestFetchLatestVersion_propagatesHTTPError(t *testing.T) {
 	assert.Contains(t, err.Error(), "503")
 }
 
+func TestFetchLatestVersion_returnsThrottledOn429(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	_, err := FetchLatestVersion(context.Background(), server.Client(), server.URL)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrThrottled)
+}
+
+func TestFetchLatestVersion_returnsThrottledOn403(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	_, err := FetchLatestVersion(context.Background(), server.Client(), server.URL)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrThrottled)
+}
+
 func TestFetchLatestVersion_emptyTagErrors(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"tag_name":""}`))

--- a/internal/versioncheck/nudge_test.go
+++ b/internal/versioncheck/nudge_test.go
@@ -1,0 +1,97 @@
+//go:build unit
+
+package versioncheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldNudge_allowedByDefault(t *testing.T) {
+	err := ShouldNudge(NudgeDecision{Now: time.Now()})
+	assert.NoError(t, err)
+}
+
+func TestShouldNudge_suppressedByNoUpdateCheck(t *testing.T) {
+	err := ShouldNudge(NudgeDecision{NoUpdateCheckFlag: true, Now: time.Now()})
+	assert.ErrorIs(t, err, ErrNudgeSuppressed)
+}
+
+func TestShouldNudge_suppressedByCI(t *testing.T) {
+	err := ShouldNudge(NudgeDecision{IsCI: true, Now: time.Now()})
+	assert.ErrorIs(t, err, ErrNudgeSuppressed)
+}
+
+func TestShouldNudge_suppressedInsideCooldown(t *testing.T) {
+	now := time.Now()
+	err := ShouldNudge(NudgeDecision{Now: now, LastNudgeAt: now.Add(-1 * time.Hour)})
+	assert.ErrorIs(t, err, ErrNudgeSuppressed, "1h ago is inside the 24h cooldown")
+}
+
+func TestShouldNudge_allowedAfterCooldown(t *testing.T) {
+	now := time.Now()
+	err := ShouldNudge(NudgeDecision{Now: now, LastNudgeAt: now.Add(-NudgeCooldown - time.Minute)})
+	assert.NoError(t, err)
+}
+
+func TestFetchLatestVersion_stripsLeadingV(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v2.8.5"}`))
+	}))
+	defer server.Close()
+
+	got, err := FetchLatestVersion(context.Background(), server.Client(), server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "2.8.5", got)
+}
+
+func TestFetchLatestVersion_propagatesHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	_, err := FetchLatestVersion(context.Background(), server.Client(), server.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "503")
+}
+
+func TestFetchLatestVersion_emptyTagErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":""}`))
+	}))
+	defer server.Close()
+
+	_, err := FetchLatestVersion(context.Background(), server.Client(), server.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty tag_name")
+}
+
+func TestIsBehind_truthTable(t *testing.T) {
+	cases := []struct {
+		current, latest string
+		want            bool
+	}{
+		{"2.8.4", "2.8.5", true},
+		{"2.8.5", "2.8.5", false},
+		{"v2.8.5", "2.8.5", false}, // v-prefix tolerated on either side
+		{"2.8.5", "v2.8.5", false},
+		{"devel", "2.8.5", false}, // local dev builds never nudge
+		{"", "2.8.5", false},      // safety: empty current
+		{"2.8.5", "", false},      // safety: empty latest
+		{"2.9.0", "2.8.5", true},  // downgrades count as "behind" for nudge purposes
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.current+"_vs_"+tc.latest, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsBehind(tc.current, tc.latest))
+		})
+	}
+}

--- a/internal/versioncheck/nudge_test.go
+++ b/internal/versioncheck/nudge_test.go
@@ -108,7 +108,9 @@ func TestIsBehind_truthTable(t *testing.T) {
 		{"devel", "2.8.5", false}, // local dev builds never nudge
 		{"", "2.8.5", false},      // safety: empty current
 		{"2.8.5", "", false},      // safety: empty latest
-		{"2.9.0", "2.8.5", true},  // downgrades count as "behind" for nudge purposes
+		{"2.9.0", "2.8.5", false}, // rolled-back/local-ahead binary must NOT nudge
+		{"2.8.4-rc1", "2.8.4", true},
+		{"not-a-version", "2.8.5", false}, // invalid semver: nudge suppressed
 	}
 
 	for _, tc := range cases {

--- a/internal/versioncheck/run.go
+++ b/internal/versioncheck/run.go
@@ -3,12 +3,11 @@ package versioncheck
 import (
 	"context"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"os"
 	"sync"
 	"time"
+
+	"github.com/bitrise-io/go-utils/v2/log"
 )
 
 // Options bundles the inputs the high-level Run helper needs. Kept as a
@@ -22,16 +21,18 @@ type Options struct {
 	Home string
 	// NoUpdateCheck is true when the user passed --no-update-check.
 	NoUpdateCheck bool
-	// Out is where the nudge message is written when a behind-latest release
-	// is detected. Typically os.Stderr (so JSON-parsing stdout consumers like
-	// react-native CLI wrappers aren't disturbed).
-	Out io.Writer
+	// Logger receives the user-facing nudge when a behind-latest release is
+	// detected. Production callers pass a logger writing to stderr (so
+	// JSON-parsing stdout consumers like react-native CLI wrappers aren't
+	// disturbed); tests pass log.NewLogger(log.WithOutput(&buf)). MUST be
+	// non-nil.
+	Logger log.Logger
 	// Now is the wall-clock used for cooldown comparisons; tests inject a
 	// fixed time. Defaults to time.Now() when zero.
 	Now time.Time
 	// HTTPClient is the network client used for the GitHub release lookup.
 	// Tests inject a client pointed at a test server; production uses a
-	// 2-second-timeout client.
+	// 3-second-timeout client.
 	HTTPClient *http.Client
 	// FetchURL is the GitHub release endpoint. Tests override to point at a
 	// test server. Defaults to GitHubReleasesURL when empty.
@@ -68,7 +69,7 @@ type Result struct {
 //   - Detects drift; persists the running version so the next run sees it.
 //   - When network nudging is allowed (not --no-update-check, not CI,
 //     cooldown elapsed), fetches the latest release tag from GitHub and
-//     writes a one-line nudge to Out when behind.
+//     logs a one-line nudge when behind.
 func Run(ctx context.Context, opts Options) (Result, error) {
 	var result Result
 
@@ -78,10 +79,6 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 
 	if opts.FetchURL == "" {
 		opts.FetchURL = GitHubReleasesURL
-	}
-
-	if opts.Out == nil {
-		opts.Out = os.Stderr
 	}
 
 	state, _ := LoadState(opts.Home) // first-run absent file is fine
@@ -108,10 +105,6 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 		// matches persisted) and LastNudgeAt isn't moving, the on-disk file
 		// is already what we'd write. Skip the mkdir + temp-file +
 		// JSON-marshal + atomic-rename that SaveState does on every call.
-		// LastSeenAt drift is intentional — that field's only consumer is
-		// human debugging, and refreshing it on every call wastes I/O on
-		// hot paths. Bumps still persist (the next run needs the new
-		// version) and so does first-run (state file needs to exist).
 		if result.Drift.Kind != NoChange {
 			_ = SaveState(opts.Home, newState)
 		}
@@ -131,9 +124,6 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 			newState.LastNudgeAt = opts.Now
 		}
 
-		// Best-effort: save state. On non-throttle errors LastNudgeAt isn't
-		// advanced, so we'll retry on the next run (network blips don't
-		// permanently stop us).
 		_ = SaveState(opts.Home, newState)
 
 		return result, err
@@ -143,7 +133,7 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 	result.Behind = IsBehind(opts.CurrentVersion, latest)
 
 	if result.Behind {
-		writeNudge(opts.Out, opts.CurrentVersion, latest)
+		writeNudge(opts.Logger, opts.CurrentVersion, latest)
 		newState.LastNudgeAt = opts.Now
 	}
 
@@ -169,11 +159,16 @@ func RunOnce(ctx context.Context, opts Options) (Result, error) {
 	return res, err
 }
 
-// writeNudge emits the user-facing message. One line, written to Out
-// (stderr in production) so JSON-parsing stdout consumers aren't disturbed.
-func writeNudge(w io.Writer, current, latest string) {
-	_, _ = fmt.Fprintf(w,
-		"Bitrise Build Cache CLI %s is available (you're running %s). Run `bitrise-build-cache update` or `brew upgrade bitrise-build-cache-cli` to upgrade. Pass --no-update-check to silence.\n",
+// writeNudge emits the user-facing "newer release available" message. Uses
+// Warnf because the nudge is informational-but-actionable: not an error
+// (the CLI still runs), but the user should consider upgrading.
+func writeNudge(logger log.Logger, current, latest string) {
+	if logger == nil {
+		return
+	}
+
+	logger.Warnf(
+		"Bitrise Build Cache CLI %s is available (you're running %s). Run `bitrise-build-cache update` or `brew upgrade bitrise-io/bitrise-build-cache/bitrise-build-cache` to upgrade. Pass --no-update-check to silence.",
 		latest, current,
 	)
 }

--- a/internal/versioncheck/run.go
+++ b/internal/versioncheck/run.go
@@ -10,48 +10,21 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 )
 
-// Options bundles the inputs the high-level Run helper needs. Kept as a
-// struct so callers (cmd/common/root.go) can populate it from flags + env
-// without a sprawling positional argument list.
 type Options struct {
-	// CurrentVersion is the running binary's resolved CLI version.
 	CurrentVersion string
-	// Home is the user's home directory. Use os.UserHomeDir() at the call
-	// site, or t.TempDir() in tests.
-	Home string
-	// NoUpdateCheck is true when the user passed --no-update-check.
-	NoUpdateCheck bool
-	// Logger receives the user-facing nudge when a behind-latest release is
-	// detected. Production callers pass a logger writing to stderr (so
-	// JSON-parsing stdout consumers like react-native CLI wrappers aren't
-	// disturbed); tests pass log.NewLogger(log.WithOutput(&buf)). MUST be
-	// non-nil.
-	Logger log.Logger
-	// Now is the wall-clock used for cooldown comparisons; tests inject a
-	// fixed time. Defaults to time.Now() when zero.
-	Now time.Time
-	// HTTPClient is the network client used for the GitHub release lookup.
-	// Tests inject a client pointed at a test server; production uses a
-	// 3-second-timeout client.
+	Home           string
+	NoUpdateCheck  bool
+	// Logger must be non-nil. Writes to stderr in production (so JSON-stdout consumers aren't disturbed).
+	Logger     log.Logger
+	Now        time.Time
 	HTTPClient *http.Client
-	// FetchURL is the GitHub release endpoint. Tests override to point at a
-	// test server. Defaults to GitHubReleasesURL when empty.
-	FetchURL string
-	// IsCI is true when the CLI is running under CI. Suppresses the nudge.
-	// Caller passes the result of common-environment detection so we don't
-	// duplicate the heuristic here.
-	IsCI bool
+	FetchURL   string
+	IsCI       bool
 }
 
-// runOnce guards Run so the version check fires at most once per process,
-// even if multiple PersistentPreRun hooks happen to call it (defensive — the
-// hook should be the only entry).
-//
 //nolint:gochecknoglobals
 var runOnce sync.Once
 
-// Result describes what Run did. Returned for callers / tests that want to
-// branch on the outcome; in production main.go path the result is ignored.
 type Result struct {
 	Drift         DriftResult
 	NetworkCalled bool
@@ -59,17 +32,7 @@ type Result struct {
 	LatestVersion string
 }
 
-// Run is the high-level entry point hooked into the root PersistentPreRun.
-// Returns a Result describing what happened. Errors are returned but the
-// caller MUST treat them as advisory — the version check is best-effort and
-// must never block a CLI invocation.
-//
-// Behaviour:
-//   - Loads persisted state (silently treats missing state as first run).
-//   - Detects drift; persists the running version so the next run sees it.
-//   - When network nudging is allowed (not --no-update-check, not CI,
-//     cooldown elapsed), fetches the latest release tag from GitHub and
-//     logs a one-line nudge when behind.
+// Run is best-effort — caller must treat any error as advisory.
 func Run(ctx context.Context, opts Options) (Result, error) {
 	var result Result
 
@@ -81,11 +44,9 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 		opts.FetchURL = GitHubReleasesURL
 	}
 
-	state, _ := LoadState(opts.Home) // first-run absent file is fine
+	state, _ := LoadState(opts.Home)
 	result.Drift = Detect(state, opts.CurrentVersion)
 
-	// Always persist the running version + bump the last-seen timestamp.
-	// LastNudgeAt only advances when we actually nudge below.
 	newState := State{
 		LastVersion: opts.CurrentVersion,
 		LastSeenAt:  opts.Now,
@@ -98,13 +59,7 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 		Now:               opts.Now,
 		LastNudgeAt:       state.LastNudgeAt,
 	}); err != nil {
-		// ErrNudgeSuppressed is a "skip" signal, not a failure; the caller
-		// MUST see nil here so the CLI doesn't surface it as an error.
-		//
-		// Hot-path optimisation: when the drift is NoChange (running version
-		// matches persisted) and LastNudgeAt isn't moving, the on-disk file
-		// is already what we'd write. Skip the mkdir + temp-file +
-		// JSON-marshal + atomic-rename that SaveState does on every call.
+		// Hot path: skip SaveState when no version change AND no nudge — file already matches.
 		if result.Drift.Kind != NoChange {
 			_ = SaveState(opts.Home, newState)
 		}
@@ -116,10 +71,7 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 	result.NetworkCalled = true
 
 	if err != nil {
-		// Throttle response (GitHub 403/429): treat as "we already nudged"
-		// so the next NudgeCooldown window passes before we retry. Without
-		// this, a corporate NAT that's blown the unauthenticated API
-		// budget would hit GitHub on every single CLI invocation forever.
+		// On 403/429 advance LastNudgeAt so a NAT that blew the unauthenticated API budget doesn't hit GitHub every invocation.
 		if errors.Is(err, ErrThrottled) {
 			newState.LastNudgeAt = opts.Now
 		}
@@ -144,8 +96,7 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 	return result, nil
 }
 
-// RunOnce wraps Run in a sync.Once so the check fires at most once per
-// process even if multiple cobra subcommands re-enter the hook.
+// RunOnce fires at most once per process.
 func RunOnce(ctx context.Context, opts Options) (Result, error) {
 	var (
 		res Result
@@ -159,9 +110,6 @@ func RunOnce(ctx context.Context, opts Options) (Result, error) {
 	return res, err
 }
 
-// writeNudge emits the user-facing "newer release available" message. Uses
-// Warnf because the nudge is informational-but-actionable: not an error
-// (the CLI still runs), but the user should consider upgrading.
 func writeNudge(logger log.Logger, current, latest string) {
 	if logger == nil {
 		return

--- a/internal/versioncheck/run.go
+++ b/internal/versioncheck/run.go
@@ -1,0 +1,159 @@
+package versioncheck
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+// Options bundles the inputs the high-level Run helper needs. Kept as a
+// struct so callers (cmd/common/root.go) can populate it from flags + env
+// without a sprawling positional argument list.
+type Options struct {
+	// CurrentVersion is the running binary's resolved CLI version.
+	CurrentVersion string
+	// Home is the user's home directory. Use os.UserHomeDir() at the call
+	// site, or t.TempDir() in tests.
+	Home string
+	// NoUpdateCheck is true when the user passed --no-update-check.
+	NoUpdateCheck bool
+	// Out is where the nudge message is written when a behind-latest release
+	// is detected. Typically os.Stderr (so JSON-parsing stdout consumers like
+	// react-native CLI wrappers aren't disturbed).
+	Out io.Writer
+	// Now is the wall-clock used for cooldown comparisons; tests inject a
+	// fixed time. Defaults to time.Now() when zero.
+	Now time.Time
+	// HTTPClient is the network client used for the GitHub release lookup.
+	// Tests inject a client pointed at a test server; production uses a
+	// 2-second-timeout client.
+	HTTPClient *http.Client
+	// FetchURL is the GitHub release endpoint. Tests override to point at a
+	// test server. Defaults to GitHubReleasesURL when empty.
+	FetchURL string
+	// IsCI is true when the CLI is running under CI. Suppresses the nudge.
+	// Caller passes the result of common-environment detection so we don't
+	// duplicate the heuristic here.
+	IsCI bool
+}
+
+// runOnce guards Run so the version check fires at most once per process,
+// even if multiple PersistentPreRun hooks happen to call it (defensive — the
+// hook should be the only entry).
+//
+//nolint:gochecknoglobals
+var runOnce sync.Once
+
+// Result describes what Run did. Returned for callers / tests that want to
+// branch on the outcome; in production main.go path the result is ignored.
+type Result struct {
+	Drift         DriftResult
+	NetworkCalled bool
+	Behind        bool
+	LatestVersion string
+}
+
+// Run is the high-level entry point hooked into the root PersistentPreRun.
+// Returns a Result describing what happened. Errors are returned but the
+// caller MUST treat them as advisory — the version check is best-effort and
+// must never block a CLI invocation.
+//
+// Behaviour:
+//   - Loads persisted state (silently treats missing state as first run).
+//   - Detects drift; persists the running version so the next run sees it.
+//   - When network nudging is allowed (not --no-update-check, not CI,
+//     cooldown elapsed), fetches the latest release tag from GitHub and
+//     writes a one-line nudge to Out when behind.
+func Run(ctx context.Context, opts Options) (Result, error) {
+	var result Result
+
+	if opts.Now.IsZero() {
+		opts.Now = time.Now()
+	}
+
+	if opts.FetchURL == "" {
+		opts.FetchURL = GitHubReleasesURL
+	}
+
+	if opts.Out == nil {
+		opts.Out = os.Stderr
+	}
+
+	state, _ := LoadState(opts.Home) // first-run absent file is fine
+	result.Drift = Detect(state, opts.CurrentVersion)
+
+	// Always persist the running version + bump the last-seen timestamp.
+	// LastNudgeAt only advances when we actually nudge below.
+	newState := State{
+		LastVersion: opts.CurrentVersion,
+		LastSeenAt:  opts.Now,
+		LastNudgeAt: state.LastNudgeAt,
+	}
+
+	if err := ShouldNudge(NudgeDecision{
+		NoUpdateCheckFlag: opts.NoUpdateCheck,
+		IsCI:              opts.IsCI,
+		Now:               opts.Now,
+		LastNudgeAt:       state.LastNudgeAt,
+	}); err != nil {
+		// ErrNudgeSuppressed is a "skip" signal, not a failure; the caller
+		// MUST see nil here so the CLI doesn't surface it as an error. Save
+		// state with the old LastNudgeAt and return cleanly.
+		_ = SaveState(opts.Home, newState)
+
+		return result, nil //nolint:nilerr // ErrNudgeSuppressed is intentionally swallowed
+	}
+
+	latest, err := FetchLatestVersion(ctx, opts.HTTPClient, opts.FetchURL)
+	result.NetworkCalled = true
+
+	if err != nil {
+		// Best-effort: save state without bumping LastNudgeAt so we'll retry
+		// on the next run (network blips don't permanently stop us).
+		_ = SaveState(opts.Home, newState)
+
+		return result, err
+	}
+
+	result.LatestVersion = latest
+	result.Behind = IsBehind(opts.CurrentVersion, latest)
+
+	if result.Behind {
+		writeNudge(opts.Out, opts.CurrentVersion, latest)
+		newState.LastNudgeAt = opts.Now
+	}
+
+	if err := SaveState(opts.Home, newState); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+// RunOnce wraps Run in a sync.Once so the check fires at most once per
+// process even if multiple cobra subcommands re-enter the hook.
+func RunOnce(ctx context.Context, opts Options) (Result, error) {
+	var (
+		res Result
+		err error
+	)
+
+	runOnce.Do(func() {
+		res, err = Run(ctx, opts)
+	})
+
+	return res, err
+}
+
+// writeNudge emits the user-facing message. One line, written to Out
+// (stderr in production) so JSON-parsing stdout consumers aren't disturbed.
+func writeNudge(w io.Writer, current, latest string) {
+	_, _ = fmt.Fprintf(w,
+		"Bitrise Build Cache CLI %s is available (you're running %s). Run `bitrise-build-cache update` or `brew upgrade bitrise-build-cache-cli` to upgrade. Pass --no-update-check to silence.\n",
+		latest, current,
+	)
+}

--- a/internal/versioncheck/run.go
+++ b/internal/versioncheck/run.go
@@ -2,6 +2,7 @@ package versioncheck
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -122,8 +123,17 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 	result.NetworkCalled = true
 
 	if err != nil {
-		// Best-effort: save state without bumping LastNudgeAt so we'll retry
-		// on the next run (network blips don't permanently stop us).
+		// Throttle response (GitHub 403/429): treat as "we already nudged"
+		// so the next NudgeCooldown window passes before we retry. Without
+		// this, a corporate NAT that's blown the unauthenticated API
+		// budget would hit GitHub on every single CLI invocation forever.
+		if errors.Is(err, ErrThrottled) {
+			newState.LastNudgeAt = opts.Now
+		}
+
+		// Best-effort: save state. On non-throttle errors LastNudgeAt isn't
+		// advanced, so we'll retry on the next run (network blips don't
+		// permanently stop us).
 		_ = SaveState(opts.Home, newState)
 
 		return result, err

--- a/internal/versioncheck/run.go
+++ b/internal/versioncheck/run.go
@@ -96,7 +96,6 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 	return result, nil
 }
 
-// RunOnce fires at most once per process.
 func RunOnce(ctx context.Context, opts Options) (Result, error) {
 	var (
 		res Result

--- a/internal/versioncheck/run.go
+++ b/internal/versioncheck/run.go
@@ -101,9 +101,19 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 		LastNudgeAt:       state.LastNudgeAt,
 	}); err != nil {
 		// ErrNudgeSuppressed is a "skip" signal, not a failure; the caller
-		// MUST see nil here so the CLI doesn't surface it as an error. Save
-		// state with the old LastNudgeAt and return cleanly.
-		_ = SaveState(opts.Home, newState)
+		// MUST see nil here so the CLI doesn't surface it as an error.
+		//
+		// Hot-path optimisation: when the drift is NoChange (running version
+		// matches persisted) and LastNudgeAt isn't moving, the on-disk file
+		// is already what we'd write. Skip the mkdir + temp-file +
+		// JSON-marshal + atomic-rename that SaveState does on every call.
+		// LastSeenAt drift is intentional — that field's only consumer is
+		// human debugging, and refreshing it on every call wastes I/O on
+		// hot paths. Bumps still persist (the next run needs the new
+		// version) and so does first-run (state file needs to exist).
+		if result.Drift.Kind != NoChange {
+			_ = SaveState(opts.Home, newState)
+		}
 
 		return result, nil //nolint:nilerr // ErrNudgeSuppressed is intentionally swallowed
 	}

--- a/internal/versioncheck/run_test.go
+++ b/internal/versioncheck/run_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -129,6 +131,67 @@ func TestRun_noUpdateCheckSkipsNetwork(t *testing.T) {
 	assert.False(t, res.NetworkCalled)
 	assert.Equal(t, 0, calls, "server must not be hit when --no-update-check is on")
 	assert.Empty(t, out.String())
+}
+
+// TestRun_noChangeWithSuppressedNudgeSkipsSaveState locks the hot-path
+// optimisation: when the running version matches the persisted version AND
+// the nudge is suppressed (CI / cooldown / --no-update-check), Run skips
+// the mkdir + temp-file + atomic rename SaveState does. The state file's
+// modification time must not advance.
+func TestRun_noChangeWithSuppressedNudgeSkipsSaveState(t *testing.T) {
+	home := t.TempDir()
+	now := time.Now()
+
+	// Seed state with the same version we'll run with.
+	require.NoError(t, SaveState(home, State{
+		LastVersion: "2.8.4",
+		LastSeenAt:  now.Add(-1 * time.Hour),
+	}))
+
+	statePath := filepath.Join(home, StateDirRelative, StateFile)
+	infoBefore, err := os.Stat(statePath)
+	require.NoError(t, err)
+
+	// CI=true suppresses the nudge → Run hits the early-return path. With
+	// NoChange drift, SaveState should NOT fire, so the file stays unchanged.
+	_, err = Run(context.Background(), Options{
+		CurrentVersion: "2.8.4",
+		Home:           home,
+		IsCI:           true,
+		Out:            &bytes.Buffer{},
+		Now:            now,
+	})
+	require.NoError(t, err)
+
+	infoAfter, err := os.Stat(statePath)
+	require.NoError(t, err)
+	assert.Equal(t, infoBefore.ModTime(), infoAfter.ModTime(),
+		"state file MUST NOT be rewritten when drift is NoChange and nudge is suppressed")
+}
+
+func TestRun_bumpStillSavesStateEvenWithSuppressedNudge(t *testing.T) {
+	home := t.TempDir()
+	now := time.Now()
+
+	require.NoError(t, SaveState(home, State{
+		LastVersion: "2.8.3", // earlier version → Bump on next Run
+		LastSeenAt:  now.Add(-1 * time.Hour),
+	}))
+
+	_, err := Run(context.Background(), Options{
+		CurrentVersion: "2.8.4",
+		Home:           home,
+		IsCI:           true, // suppress network nudge
+		Out:            &bytes.Buffer{},
+		Now:            now,
+	})
+	require.NoError(t, err)
+
+	// State MUST persist the new version even on the suppressed-nudge path
+	// — otherwise the next run wouldn't notice the bump either.
+	st, err := LoadState(home)
+	require.NoError(t, err)
+	assert.Equal(t, "2.8.4", st.LastVersion)
 }
 
 func TestRun_ciSkipsNetwork(t *testing.T) {

--- a/internal/versioncheck/run_test.go
+++ b/internal/versioncheck/run_test.go
@@ -1,0 +1,227 @@
+//go:build unit
+
+package versioncheck
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// helper: server returning a fixed tag.
+func releaseServer(t *testing.T, tag string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"` + tag + `"}`))
+	}))
+}
+
+func TestRun_firstRunPersistsCurrentVersion(t *testing.T) {
+	home := t.TempDir()
+	srv := releaseServer(t, "v2.8.5")
+	defer srv.Close()
+
+	var out bytes.Buffer
+
+	res, err := Run(context.Background(), Options{
+		CurrentVersion: "2.8.4",
+		Home:           home,
+		Out:            &out,
+		Now:            time.Now(),
+		HTTPClient:     srv.Client(),
+		FetchURL:       srv.URL,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, FirstRun, res.Drift.Kind)
+	assert.True(t, res.NetworkCalled)
+	assert.True(t, res.Behind)
+	assert.Contains(t, out.String(), "2.8.5 is available")
+
+	// State must be persisted.
+	st, err := LoadState(home)
+	require.NoError(t, err)
+	assert.Equal(t, "2.8.4", st.LastVersion)
+	assert.False(t, st.LastNudgeAt.IsZero(), "LastNudgeAt should advance when nudge fires")
+}
+
+func TestRun_noChangeWhenVersionsMatch(t *testing.T) {
+	home := t.TempDir()
+	srv := releaseServer(t, "v2.8.4")
+	defer srv.Close()
+
+	var out bytes.Buffer
+
+	res, err := Run(context.Background(), Options{
+		CurrentVersion: "2.8.4",
+		Home:           home,
+		Out:            &out,
+		Now:            time.Now(),
+		HTTPClient:     srv.Client(),
+		FetchURL:       srv.URL,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, FirstRun, res.Drift.Kind) // first time we've seen any version
+	assert.False(t, res.Behind, "running matches latest, nothing to nudge about")
+	assert.Empty(t, out.String())
+}
+
+func TestRun_secondInvocationDetectsBump(t *testing.T) {
+	home := t.TempDir()
+	srv := releaseServer(t, "v2.8.5")
+	defer srv.Close()
+
+	// First invocation seeds state at 2.8.4.
+	_, err := Run(context.Background(), Options{
+		CurrentVersion: "2.8.4",
+		Home:           home,
+		Out:            &bytes.Buffer{},
+		Now:            time.Now(),
+		HTTPClient:     srv.Client(),
+		FetchURL:       srv.URL,
+	})
+	require.NoError(t, err)
+
+	// Second invocation with a different running binary should report Bump,
+	// even with the cooldown active.
+	res, err := Run(context.Background(), Options{
+		CurrentVersion: "2.8.5",
+		Home:           home,
+		Out:            &bytes.Buffer{},
+		Now:            time.Now(),
+		HTTPClient:     srv.Client(),
+		FetchURL:       srv.URL,
+		NoUpdateCheck:  true, // suppress network so we don't depend on cooldown
+	})
+	require.NoError(t, err)
+	assert.Equal(t, Bump, res.Drift.Kind)
+	assert.Equal(t, "2.8.4", res.Drift.PreviousVersion)
+	assert.Equal(t, "2.8.5", res.Drift.CurrentVersion)
+}
+
+func TestRun_noUpdateCheckSkipsNetwork(t *testing.T) {
+	home := t.TempDir()
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		_, _ = w.Write([]byte(`{"tag_name":"v9.9.9"}`))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	res, err := Run(context.Background(), Options{
+		CurrentVersion: "2.8.4",
+		Home:           home,
+		NoUpdateCheck:  true,
+		Out:            &out,
+		Now:            time.Now(),
+		HTTPClient:     srv.Client(),
+		FetchURL:       srv.URL,
+	})
+	require.NoError(t, err)
+	assert.False(t, res.NetworkCalled)
+	assert.Equal(t, 0, calls, "server must not be hit when --no-update-check is on")
+	assert.Empty(t, out.String())
+}
+
+func TestRun_ciSkipsNetwork(t *testing.T) {
+	home := t.TempDir()
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+	}))
+	defer srv.Close()
+
+	_, err := Run(context.Background(), Options{
+		CurrentVersion: "2.8.4",
+		Home:           home,
+		IsCI:           true,
+		Out:            &bytes.Buffer{},
+		Now:            time.Now(),
+		HTTPClient:     srv.Client(),
+		FetchURL:       srv.URL,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, calls)
+}
+
+func TestRun_cooldownSuppressesSecondNetworkCall(t *testing.T) {
+	home := t.TempDir()
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		_, _ = w.Write([]byte(`{"tag_name":"v2.8.5"}`))
+	}))
+	defer srv.Close()
+
+	now := time.Now()
+
+	// First run: hits network, sets LastNudgeAt.
+	_, err := Run(context.Background(), Options{
+		CurrentVersion: "2.8.4",
+		Home:           home,
+		Out:            &bytes.Buffer{},
+		Now:            now,
+		HTTPClient:     srv.Client(),
+		FetchURL:       srv.URL,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+
+	// Second run, 1 hour later — must NOT call network.
+	_, err = Run(context.Background(), Options{
+		CurrentVersion: "2.8.4",
+		Home:           home,
+		Out:            &bytes.Buffer{},
+		Now:            now.Add(1 * time.Hour),
+		HTTPClient:     srv.Client(),
+		FetchURL:       srv.URL,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls, "second run inside cooldown must not call GitHub")
+
+	// Third run, well past cooldown — calls again.
+	_, err = Run(context.Background(), Options{
+		CurrentVersion: "2.8.4",
+		Home:           home,
+		Out:            &bytes.Buffer{},
+		Now:            now.Add(NudgeCooldown + time.Minute),
+		HTTPClient:     srv.Client(),
+		FetchURL:       srv.URL,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls, "post-cooldown run should call GitHub")
+}
+
+func TestRun_networkErrorDoesNotFailRun(t *testing.T) {
+	home := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := Run(context.Background(), Options{
+		CurrentVersion: "2.8.4",
+		Home:           home,
+		Out:            &bytes.Buffer{},
+		Now:            time.Now(),
+		HTTPClient:     srv.Client(),
+		FetchURL:       srv.URL,
+	})
+	// The caller treats errors as advisory, but Run returns them. The key
+	// guarantee: state was still persisted, and LastNudgeAt was NOT advanced
+	// so we retry next run.
+	require.Error(t, err)
+
+	st, loadErr := LoadState(home)
+	require.NoError(t, loadErr)
+	assert.Equal(t, "2.8.4", st.LastVersion)
+	assert.True(t, st.LastNudgeAt.IsZero(), "network error must NOT advance LastNudgeAt; we should retry")
+}

--- a/internal/versioncheck/run_test.go
+++ b/internal/versioncheck/run_test.go
@@ -263,6 +263,34 @@ func TestRun_cooldownSuppressesSecondNetworkCall(t *testing.T) {
 	assert.Equal(t, 2, calls, "post-cooldown run should call GitHub")
 }
 
+func TestRun_throttleResponseAdvancesLastNudgeAt(t *testing.T) {
+	home := t.TempDir()
+	now := time.Now()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	_, err := Run(context.Background(), Options{
+		CurrentVersion: "2.8.4",
+		Home:           home,
+		Out:            &bytes.Buffer{},
+		Now:            now,
+		HTTPClient:     srv.Client(),
+		FetchURL:       srv.URL,
+	})
+	require.Error(t, err, "throttle is still surfaced as an error to the caller")
+
+	// Critical: LastNudgeAt must be advanced even though we never sent the
+	// user-facing nudge. Otherwise a corporate-NAT setup that's blown the
+	// unauthenticated GitHub API budget would hit the server every CLI run.
+	st, loadErr := LoadState(home)
+	require.NoError(t, loadErr)
+	assert.Equal(t, now.UTC(), st.LastNudgeAt.UTC(),
+		"403/429 MUST advance LastNudgeAt to throttle subsequent runs")
+}
+
 func TestRun_networkErrorDoesNotFailRun(t *testing.T) {
 	home := t.TempDir()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/versioncheck/run_test.go
+++ b/internal/versioncheck/run_test.go
@@ -12,9 +12,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// loggerWithBuffer builds a project logger that writes into the supplied
+// buffer — the standard test seam for asserting on log output from the
+// versioncheck Run helper.
+func loggerWithBuffer(buf *bytes.Buffer) log.Logger {
+	return log.NewLogger(log.WithOutput(buf))
+}
 
 // helper: server returning a fixed tag.
 func releaseServer(t *testing.T, tag string) *httptest.Server {
@@ -36,7 +44,7 @@ func TestRun_firstRunPersistsCurrentVersion(t *testing.T) {
 	res, err := Run(context.Background(), Options{
 		CurrentVersion: "2.8.4",
 		Home:           home,
-		Out:            &out,
+		Logger:         loggerWithBuffer(&out),
 		Now:            time.Now(),
 		HTTPClient:     srv.Client(),
 		FetchURL:       srv.URL,
@@ -47,7 +55,6 @@ func TestRun_firstRunPersistsCurrentVersion(t *testing.T) {
 	assert.True(t, res.Behind)
 	assert.Contains(t, out.String(), "2.8.5 is available")
 
-	// State must be persisted.
 	st, err := LoadState(home)
 	require.NoError(t, err)
 	assert.Equal(t, "2.8.4", st.LastVersion)
@@ -64,13 +71,13 @@ func TestRun_noChangeWhenVersionsMatch(t *testing.T) {
 	res, err := Run(context.Background(), Options{
 		CurrentVersion: "2.8.4",
 		Home:           home,
-		Out:            &out,
+		Logger:         loggerWithBuffer(&out),
 		Now:            time.Now(),
 		HTTPClient:     srv.Client(),
 		FetchURL:       srv.URL,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, FirstRun, res.Drift.Kind) // first time we've seen any version
+	assert.Equal(t, FirstRun, res.Drift.Kind)
 	assert.False(t, res.Behind, "running matches latest, nothing to nudge about")
 	assert.Empty(t, out.String())
 }
@@ -80,27 +87,24 @@ func TestRun_secondInvocationDetectsBump(t *testing.T) {
 	srv := releaseServer(t, "v2.8.5")
 	defer srv.Close()
 
-	// First invocation seeds state at 2.8.4.
 	_, err := Run(context.Background(), Options{
 		CurrentVersion: "2.8.4",
 		Home:           home,
-		Out:            &bytes.Buffer{},
+		Logger:         loggerWithBuffer(&bytes.Buffer{}),
 		Now:            time.Now(),
 		HTTPClient:     srv.Client(),
 		FetchURL:       srv.URL,
 	})
 	require.NoError(t, err)
 
-	// Second invocation with a different running binary should report Bump,
-	// even with the cooldown active.
 	res, err := Run(context.Background(), Options{
 		CurrentVersion: "2.8.5",
 		Home:           home,
-		Out:            &bytes.Buffer{},
+		Logger:         loggerWithBuffer(&bytes.Buffer{}),
 		Now:            time.Now(),
 		HTTPClient:     srv.Client(),
 		FetchURL:       srv.URL,
-		NoUpdateCheck:  true, // suppress network so we don't depend on cooldown
+		NoUpdateCheck:  true,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, Bump, res.Drift.Kind)
@@ -122,7 +126,7 @@ func TestRun_noUpdateCheckSkipsNetwork(t *testing.T) {
 		CurrentVersion: "2.8.4",
 		Home:           home,
 		NoUpdateCheck:  true,
-		Out:            &out,
+		Logger:         loggerWithBuffer(&out),
 		Now:            time.Now(),
 		HTTPClient:     srv.Client(),
 		FetchURL:       srv.URL,
@@ -142,7 +146,6 @@ func TestRun_noChangeWithSuppressedNudgeSkipsSaveState(t *testing.T) {
 	home := t.TempDir()
 	now := time.Now()
 
-	// Seed state with the same version we'll run with.
 	require.NoError(t, SaveState(home, State{
 		LastVersion: "2.8.4",
 		LastSeenAt:  now.Add(-1 * time.Hour),
@@ -152,13 +155,11 @@ func TestRun_noChangeWithSuppressedNudgeSkipsSaveState(t *testing.T) {
 	infoBefore, err := os.Stat(statePath)
 	require.NoError(t, err)
 
-	// CI=true suppresses the nudge → Run hits the early-return path. With
-	// NoChange drift, SaveState should NOT fire, so the file stays unchanged.
 	_, err = Run(context.Background(), Options{
 		CurrentVersion: "2.8.4",
 		Home:           home,
 		IsCI:           true,
-		Out:            &bytes.Buffer{},
+		Logger:         loggerWithBuffer(&bytes.Buffer{}),
 		Now:            now,
 	})
 	require.NoError(t, err)
@@ -174,21 +175,19 @@ func TestRun_bumpStillSavesStateEvenWithSuppressedNudge(t *testing.T) {
 	now := time.Now()
 
 	require.NoError(t, SaveState(home, State{
-		LastVersion: "2.8.3", // earlier version → Bump on next Run
+		LastVersion: "2.8.3",
 		LastSeenAt:  now.Add(-1 * time.Hour),
 	}))
 
 	_, err := Run(context.Background(), Options{
 		CurrentVersion: "2.8.4",
 		Home:           home,
-		IsCI:           true, // suppress network nudge
-		Out:            &bytes.Buffer{},
+		IsCI:           true,
+		Logger:         loggerWithBuffer(&bytes.Buffer{}),
 		Now:            now,
 	})
 	require.NoError(t, err)
 
-	// State MUST persist the new version even on the suppressed-nudge path
-	// — otherwise the next run wouldn't notice the bump either.
 	st, err := LoadState(home)
 	require.NoError(t, err)
 	assert.Equal(t, "2.8.4", st.LastVersion)
@@ -206,7 +205,7 @@ func TestRun_ciSkipsNetwork(t *testing.T) {
 		CurrentVersion: "2.8.4",
 		Home:           home,
 		IsCI:           true,
-		Out:            &bytes.Buffer{},
+		Logger:         loggerWithBuffer(&bytes.Buffer{}),
 		Now:            time.Now(),
 		HTTPClient:     srv.Client(),
 		FetchURL:       srv.URL,
@@ -226,11 +225,10 @@ func TestRun_cooldownSuppressesSecondNetworkCall(t *testing.T) {
 
 	now := time.Now()
 
-	// First run: hits network, sets LastNudgeAt.
 	_, err := Run(context.Background(), Options{
 		CurrentVersion: "2.8.4",
 		Home:           home,
-		Out:            &bytes.Buffer{},
+		Logger:         loggerWithBuffer(&bytes.Buffer{}),
 		Now:            now,
 		HTTPClient:     srv.Client(),
 		FetchURL:       srv.URL,
@@ -238,11 +236,10 @@ func TestRun_cooldownSuppressesSecondNetworkCall(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, calls)
 
-	// Second run, 1 hour later — must NOT call network.
 	_, err = Run(context.Background(), Options{
 		CurrentVersion: "2.8.4",
 		Home:           home,
-		Out:            &bytes.Buffer{},
+		Logger:         loggerWithBuffer(&bytes.Buffer{}),
 		Now:            now.Add(1 * time.Hour),
 		HTTPClient:     srv.Client(),
 		FetchURL:       srv.URL,
@@ -250,11 +247,10 @@ func TestRun_cooldownSuppressesSecondNetworkCall(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls, "second run inside cooldown must not call GitHub")
 
-	// Third run, well past cooldown — calls again.
 	_, err = Run(context.Background(), Options{
 		CurrentVersion: "2.8.4",
 		Home:           home,
-		Out:            &bytes.Buffer{},
+		Logger:         loggerWithBuffer(&bytes.Buffer{}),
 		Now:            now.Add(NudgeCooldown + time.Minute),
 		HTTPClient:     srv.Client(),
 		FetchURL:       srv.URL,
@@ -275,16 +271,13 @@ func TestRun_throttleResponseAdvancesLastNudgeAt(t *testing.T) {
 	_, err := Run(context.Background(), Options{
 		CurrentVersion: "2.8.4",
 		Home:           home,
-		Out:            &bytes.Buffer{},
+		Logger:         loggerWithBuffer(&bytes.Buffer{}),
 		Now:            now,
 		HTTPClient:     srv.Client(),
 		FetchURL:       srv.URL,
 	})
 	require.Error(t, err, "throttle is still surfaced as an error to the caller")
 
-	// Critical: LastNudgeAt must be advanced even though we never sent the
-	// user-facing nudge. Otherwise a corporate-NAT setup that's blown the
-	// unauthenticated GitHub API budget would hit the server every CLI run.
 	st, loadErr := LoadState(home)
 	require.NoError(t, loadErr)
 	assert.Equal(t, now.UTC(), st.LastNudgeAt.UTC(),
@@ -301,14 +294,11 @@ func TestRun_networkErrorDoesNotFailRun(t *testing.T) {
 	_, err := Run(context.Background(), Options{
 		CurrentVersion: "2.8.4",
 		Home:           home,
-		Out:            &bytes.Buffer{},
+		Logger:         loggerWithBuffer(&bytes.Buffer{}),
 		Now:            time.Now(),
 		HTTPClient:     srv.Client(),
 		FetchURL:       srv.URL,
 	})
-	// The caller treats errors as advisory, but Run returns them. The key
-	// guarantee: state was still persisted, and LastNudgeAt was NOT advanced
-	// so we retry next run.
 	require.Error(t, err)
 
 	st, loadErr := LoadState(home)

--- a/internal/versioncheck/run_test.go
+++ b/internal/versioncheck/run_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
 	"testing"
 	"time"
 
@@ -151,7 +153,7 @@ func TestRun_noChangeWithSuppressedNudgeSkipsSaveState(t *testing.T) {
 		LastSeenAt:  now.Add(-1 * time.Hour),
 	}))
 
-	statePath := filepath.Join(home, StateDirRelative, StateFile)
+	statePath := filepath.Join(home, paths.StateDirRelative, StateFile)
 	infoBefore, err := os.Stat(statePath)
 	require.NoError(t, err)
 

--- a/internal/versioncheck/state.go
+++ b/internal/versioncheck/state.go
@@ -2,9 +2,6 @@
 // fetches the latest release tag from GitHub to nudge the user when their
 // installed CLI is behind. State is persisted under
 // ~/.local/state/bitrise-build-cache/ so it survives invocations.
-//
-// See ACI-5037 in the M1 plan. D3 (config auto-refresh on bump) consumes the
-// bump signal this package emits.
 package versioncheck
 
 import (
@@ -17,9 +14,7 @@ import (
 	"time"
 )
 
-// StateDirRelative is the path beneath the user's home where the version
-// state file lives. Aligned with the daemon log dir (ACI-5030) so a single
-// `~/.local/state/bitrise-build-cache/` tree owns all CLI-managed state.
+// StateDirRelative is the path beneath the user's home where the version state file lives.
 const StateDirRelative = ".local/state/bitrise-build-cache"
 
 // StateFile is the basename of the persisted version state.

--- a/internal/versioncheck/state.go
+++ b/internal/versioncheck/state.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"time"
-)
 
-const StateDirRelative = ".local/state/bitrise-build-cache"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
+)
 
 const StateFile = "version-state.json"
 
@@ -21,7 +20,7 @@ type State struct {
 }
 
 func statePath(home string) string {
-	return filepath.Join(home, StateDirRelative, StateFile)
+	return paths.FromHome(home).StateFile(StateFile)
 }
 
 // LoadState returns zero State + nil when the file is missing (first-run case).
@@ -47,7 +46,7 @@ func LoadState(home string) (State, error) {
 
 // SaveState writes atomically (write-temp + rename). Last-write-wins on parallel invocations.
 func SaveState(home string, st State) error {
-	dir := filepath.Join(home, StateDirRelative)
+	dir := paths.FromHome(home).StateDir()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create state dir: %w", err)
 	}

--- a/internal/versioncheck/state.go
+++ b/internal/versioncheck/state.go
@@ -1,7 +1,3 @@
-// Package versioncheck detects CLI version drift across runs and (optionally)
-// fetches the latest release tag from GitHub to nudge the user when their
-// installed CLI is behind. State is persisted under
-// ~/.local/state/bitrise-build-cache/ so it survives invocations.
 package versioncheck
 
 import (
@@ -14,34 +10,21 @@ import (
 	"time"
 )
 
-// StateDirRelative is the path beneath the user's home where the version state file lives.
 const StateDirRelative = ".local/state/bitrise-build-cache"
 
-// StateFile is the basename of the persisted version state.
 const StateFile = "version-state.json"
 
-// State is the on-disk shape persisted between runs.
 type State struct {
-	// LastVersion is the CLI version that wrote this file. Compared against
-	// the running binary's version to detect a bump.
-	LastVersion string `json:"last_version"`
-	// LastSeenAt is when the running binary's version was last observed.
-	// Updated on every CLI invocation regardless of bump.
-	LastSeenAt time.Time `json:"last_seen_at"`
-	// LastNudgeAt is when the user was last nudged about a behind-brew-latest
-	// release. Used to throttle the GitHub-release lookup to at most once
-	// every NudgeCooldown.
+	LastVersion string    `json:"last_version"`
+	LastSeenAt  time.Time `json:"last_seen_at"`
 	LastNudgeAt time.Time `json:"last_nudge_at,omitzero"`
 }
 
-// statePath resolves the absolute path of the state file under home.
 func statePath(home string) string {
 	return filepath.Join(home, StateDirRelative, StateFile)
 }
 
-// LoadState reads the persisted state from disk. Returns a zero State + nil
-// error when the file doesn't exist — that's the "first run" case and is
-// expected. Any other read / parse error propagates.
+// LoadState returns zero State + nil when the file is missing (first-run case).
 func LoadState(home string) (State, error) {
 	path := statePath(home)
 
@@ -62,9 +45,7 @@ func LoadState(home string) (State, error) {
 	return st, nil
 }
 
-// SaveState writes the state atomically (write-to-temp + rename) so a crash
-// between truncate and write can't leave the file half-written. State is
-// benign and last-write-wins on parallel CLI invocations; no file locking.
+// SaveState writes atomically (write-temp + rename). Last-write-wins on parallel invocations.
 func SaveState(home string, st State) error {
 	dir := filepath.Join(home, StateDirRelative)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -83,8 +64,6 @@ func SaveState(home string, st State) error {
 	}
 
 	defer func() {
-		// Best-effort: if rename below succeeded the temp is already gone, so
-		// this is a no-op error.
 		_ = os.Remove(tmp.Name())
 	}()
 

--- a/internal/versioncheck/state.go
+++ b/internal/versioncheck/state.go
@@ -1,0 +1,111 @@
+// Package versioncheck detects CLI version drift across runs and (optionally)
+// fetches the latest release tag from GitHub to nudge the user when their
+// installed CLI is behind. State is persisted under
+// ~/.local/state/bitrise-build-cache/ so it survives invocations.
+//
+// See ACI-5037 in the M1 plan. D3 (config auto-refresh on bump) consumes the
+// bump signal this package emits.
+package versioncheck
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// StateDirRelative is the path beneath the user's home where the version
+// state file lives. Aligned with the daemon log dir (ACI-5030) so a single
+// `~/.local/state/bitrise-build-cache/` tree owns all CLI-managed state.
+const StateDirRelative = ".local/state/bitrise-build-cache"
+
+// StateFile is the basename of the persisted version state.
+const StateFile = "version-state.json"
+
+// State is the on-disk shape persisted between runs.
+type State struct {
+	// LastVersion is the CLI version that wrote this file. Compared against
+	// the running binary's version to detect a bump.
+	LastVersion string `json:"last_version"`
+	// LastSeenAt is when the running binary's version was last observed.
+	// Updated on every CLI invocation regardless of bump.
+	LastSeenAt time.Time `json:"last_seen_at"`
+	// LastNudgeAt is when the user was last nudged about a behind-brew-latest
+	// release. Used to throttle the GitHub-release lookup to at most once
+	// every NudgeCooldown.
+	LastNudgeAt time.Time `json:"last_nudge_at,omitzero"`
+}
+
+// statePath resolves the absolute path of the state file under home.
+func statePath(home string) string {
+	return filepath.Join(home, StateDirRelative, StateFile)
+}
+
+// LoadState reads the persisted state from disk. Returns a zero State + nil
+// error when the file doesn't exist — that's the "first run" case and is
+// expected. Any other read / parse error propagates.
+func LoadState(home string) (State, error) {
+	path := statePath(home)
+
+	body, err := os.ReadFile(path) //nolint:gosec // path is derived from home + a constant
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return State{}, nil
+		}
+
+		return State{}, fmt.Errorf("read version state %s: %w", path, err)
+	}
+
+	var st State
+	if err := json.Unmarshal(body, &st); err != nil {
+		return State{}, fmt.Errorf("parse version state %s: %w", path, err)
+	}
+
+	return st, nil
+}
+
+// SaveState writes the state atomically (write-to-temp + rename) so a crash
+// between truncate and write can't leave the file half-written. State is
+// benign and last-write-wins on parallel CLI invocations; no file locking.
+func SaveState(home string, st State) error {
+	dir := filepath.Join(home, StateDirRelative)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+
+	body, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal version state: %w", err)
+	}
+
+	target := statePath(home)
+	tmp, err := os.CreateTemp(dir, ".version-state-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp state file: %w", err)
+	}
+
+	defer func() {
+		// Best-effort: if rename below succeeded the temp is already gone, so
+		// this is a no-op error.
+		_ = os.Remove(tmp.Name())
+	}()
+
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+
+		return fmt.Errorf("write temp state file: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp state file: %w", err)
+	}
+
+	if err := os.Rename(tmp.Name(), target); err != nil {
+		return fmt.Errorf("rename temp state to %s: %w", target, err)
+	}
+
+	return nil
+}

--- a/internal/versioncheck/state_test.go
+++ b/internal/versioncheck/state_test.go
@@ -1,0 +1,58 @@
+//go:build unit
+
+package versioncheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadState_missingFileReturnsZero(t *testing.T) {
+	home := t.TempDir()
+
+	st, err := LoadState(home)
+	require.NoError(t, err)
+	assert.Equal(t, State{}, st)
+}
+
+func TestSaveAndLoadState_roundTrip(t *testing.T) {
+	home := t.TempDir()
+	now := time.Date(2026, 6, 11, 15, 4, 5, 0, time.UTC)
+
+	want := State{
+		LastVersion: "2.8.4",
+		LastSeenAt:  now,
+		LastNudgeAt: now.Add(-2 * time.Hour),
+	}
+
+	require.NoError(t, SaveState(home, want))
+
+	got, err := LoadState(home)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestSaveState_createsStateDir(t *testing.T) {
+	home := t.TempDir()
+
+	require.NoError(t, SaveState(home, State{LastVersion: "2.8.4", LastSeenAt: time.Now()}))
+
+	info, err := os.Stat(filepath.Join(home, StateDirRelative))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestLoadState_corruptFileErrors(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, StateDirRelative)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, StateFile), []byte("not json"), 0o644))
+
+	_, err := LoadState(home)
+	require.Error(t, err)
+}

--- a/internal/versioncheck/state_test.go
+++ b/internal/versioncheck/state_test.go
@@ -5,6 +5,8 @@ package versioncheck
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
 	"testing"
 	"time"
 
@@ -42,14 +44,14 @@ func TestSaveState_createsStateDir(t *testing.T) {
 
 	require.NoError(t, SaveState(home, State{LastVersion: "2.8.4", LastSeenAt: time.Now()}))
 
-	info, err := os.Stat(filepath.Join(home, StateDirRelative))
+	info, err := os.Stat(filepath.Join(home, paths.StateDirRelative))
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())
 }
 
 func TestLoadState_corruptFileErrors(t *testing.T) {
 	home := t.TempDir()
-	dir := filepath.Join(home, StateDirRelative)
+	dir := filepath.Join(home, paths.StateDirRelative)
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, StateFile), []byte("not json"), 0o644))
 

--- a/pkg/common/childstats/childstats.go
+++ b/pkg/common/childstats/childstats.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/bitrise-io/go-utils/v2/log"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
 )
 
 const (
@@ -384,7 +386,7 @@ func Sweep(ttl time.Duration) error {
 }
 
 func ledgerRoot() string {
-	return filepath.Join(os.Getenv("HOME"), ".bitrise", "cache", "invocations")
+	return paths.FromHome(os.Getenv("HOME")).BitriseCacheDir("invocations")
 }
 
 func readEntry(path string) (Entry, error) {


### PR DESCRIPTION
**Stacked on #360 (B4). GitHub will auto-retarget down the chain as parents merge.**

## Summary

- Persists the running CLI version under \`~/.local/state/bitrise-build-cache/version-state.json\` on every invocation.
- On the next run, classifies drift as \`FirstRun\` / \`NoChange\` / \`Bump\` — D3 (config auto-refresh, ACI-5039) will consume the Bump signal.
- When not on CI and \`--no-update-check\` isn't set, queries the GitHub latest-release endpoint (2s timeout, throttled to once per 4h via persisted \`LastNudgeAt\`) and writes a one-line nudge to stderr when the installed binary is behind. Stderr (not stdout) — keeps JSON-parsing stdout consumers clean.

## Architecture

- \`internal/versioncheck/state.go\` — atomic write-temp-then-rename of the JSON state file.
- \`internal/versioncheck/detector.go\` — pure \`Detect(state, currentVersion) DriftResult\`.
- \`internal/versioncheck/nudge.go\` — \`ShouldNudge\` (typed sentinel \`ErrNudgeSuppressed\`), \`FetchLatestVersion\`, \`IsBehind\`.
- \`internal/versioncheck/run.go\` — \`Run\` / \`RunOnce\` orchestrator; \`sync.Once\` guard so multiple PreRun re-entries don't double-fire.
- Hooked into \`cmd/common/root.go\` \`PersistentPreRun\`. Skipped for \`version\`, \`help\`, \`completion\` subcommands so their output stays deterministic.

## Best-effort guarantees

- Network failures never block the CLI.
- \`LastNudgeAt\` is NOT advanced on network error — the next run retries.
- \`ErrNudgeSuppressed\` is swallowed by \`Run\` (typed sentinel, \`//nolint:nilerr\` annotated with reason).

## CI

No new e2e — the network nudge would either need to hit real api.github.com (flaky / rate-limited) or run a fake server with plumbing through Bitrise VMs. Unit tests cover the behaviour via \`httptest\`: cooldown, \`--no-update-check\`, \`IsCI\` suppression, network error path, v-prefix tolerance, devel-build no-nudge case.

## Follow-ups

- ACI-5039 (D3) consumes the \`Bump\` signal to re-run \`activate\` for previously-configured build tools.
- ACI-5038 (D2) ships the actual \`update\` subcommand the nudge text mentions.

## Test plan

- [x] \`make check\` passes (lint-fix + unit tests; 4 test files cover state, detector, nudge, and run-orchestrator).
- [ ] Manual: run the CLI locally, verify \`~/.local/state/bitrise-build-cache/version-state.json\` appears; rerun with a bumped fake version and confirm Bump classification.
- [ ] Manual: \`bitrise-build-cache --no-update-check daemon install\` does not hit GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)