### PR TITLE
feat: ACI-5038 update subcommand — brew + installer.sh upgrade paths

### DIFF
--- a/cmd/common/root.go
+++ b/cmd/common/root.go
@@ -47,7 +47,7 @@ In case of Bazel it's done via creating or modifying $HOME/.bazelrc.`,
 
 func ShouldSkipVersionCheck(cmd *cobra.Command) bool {
 	switch cmd.Name() {
-	case "version", "help", "completion":
+	case "version", "help", "completion", "update":
 		return true
 	case
 		"xcodebuild",

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -1,6 +1,4 @@
-// Package update exposes the `bitrise-build-cache update` subcommand. Thin
-// cobra wrapper over internal/updater; the package itself owns no business
-// logic.
+// Package update exposes the `bitrise-build-cache update` subcommand.
 package update
 
 import (

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -3,6 +3,7 @@ package update
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
@@ -41,9 +42,8 @@ After a successful manual upgrade, prints a hint to restart the daemon (` + "`bi
 		case updater.InstallBrew:
 			updater.PrintBrewUpgrade(logger)
 		case updater.InstallManual:
-			bindir := updater.BindirOf(exe)
 			if _, err := updater.ManualUpgrade(cmd.Context(), updater.ManualOptions{
-				Bindir: bindir,
+				Bindir: filepath.Dir(exe),
 				Logger: logger,
 				DryRun: dryRunFlag,
 			}); err != nil {

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -1,4 +1,3 @@
-// Package update exposes the `bitrise-build-cache update` subcommand.
 package update
 
 import (

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -1,0 +1,74 @@
+// Package update exposes the `bitrise-build-cache update` subcommand. Thin
+// cobra wrapper over internal/updater; the package itself owns no business
+// logic.
+package update
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/updater"
+)
+
+//nolint:gochecknoglobals
+var dryRunFlag bool
+
+//nolint:gochecknoglobals
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Upgrade the Bitrise Build Cache CLI binary in place",
+	Long: `update detects how this CLI was installed (Homebrew vs manual installer) and runs the corresponding upgrade flow:
+
+- Homebrew install: prints the exact ` + "`brew upgrade ...`" + ` command to run. We don't invoke brew from inside the Cellar to avoid lock clashes.
+- Manual install (` + "`installer.sh`" + ` to a custom bindir): re-downloads installer.sh and runs it against the same bindir, replacing the binary in place.
+
+After a successful manual upgrade, prints a hint to restart the daemon (` + "`bitrise-build-cache daemon restart`" + `) when one is installed.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		out := cmd.OutOrStdout()
+
+		exe, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("resolve running executable path: %w", err)
+		}
+
+		method := updater.DetectInstallMethod(exe)
+		fmt.Fprintf(out, "Detected install method: %s (binary at %s)\n", method, exe)
+
+		switch method {
+		case updater.InstallBrew:
+			updater.PrintBrewUpgrade(out)
+		case updater.InstallManual:
+			bindir := updater.BindirOf(exe)
+			if _, err := updater.ManualUpgrade(cmd.Context(), updater.ManualOptions{
+				Bindir: bindir,
+				Out:    out,
+				DryRun: dryRunFlag,
+			}); err != nil {
+				return fmt.Errorf("manual upgrade: %w", err)
+			}
+
+			if dryRunFlag {
+				break
+			}
+
+			if home, homeErr := os.UserHomeDir(); homeErr == nil && updater.DaemonInstalled(home) {
+				updater.PrintDaemonRestartHint(out)
+			}
+		case updater.InstallUnknown:
+			fmt.Fprintln(out, "Could not classify the install method. Reinstall manually:")
+			fmt.Fprintln(out, "  curl --retry 5 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' | sh -s -- -b <your-bindir>")
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	updateCmd.Flags().BoolVar(&dryRunFlag, "dry-run", false,
+		"Download installer.sh and print the exec command without running it")
+	common.RootCmd.AddCommand(updateCmd)
+}

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/exec"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/updater"
 )
 
@@ -54,7 +55,12 @@ After a successful manual upgrade, prints a hint to restart the daemon (` + "`bi
 			}
 
 			if home, homeErr := os.UserHomeDir(); homeErr == nil && updater.DaemonInstalled(home) {
-				updater.PrintDaemonRestartHint(logger)
+				logger.Infof("Restarting daemon to pick up the new binary")
+				if _, stderr, runErr := (exec.ExecRunner{}).RunCheck(cmd.Context(), exe, "daemon", "restart"); runErr != nil {
+					logger.Warnf("Daemon restart failed: %v — run `bitrise-build-cache daemon restart` manually. %s", runErr, stderr)
+				} else {
+					logger.Donef("Daemon restarted")
+				}
 			}
 		case updater.InstallUnknown:
 			logger.Warnf("Could not classify the install method. Reinstall manually:")

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
@@ -28,7 +29,7 @@ var updateCmd = &cobra.Command{
 After a successful manual upgrade, prints a hint to restart the daemon (` + "`bitrise-build-cache daemon restart`" + `) when one is installed.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		out := cmd.OutOrStdout()
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
 		exe, err := os.Executable()
 		if err != nil {
@@ -36,16 +37,16 @@ After a successful manual upgrade, prints a hint to restart the daemon (` + "`bi
 		}
 
 		method := updater.DetectInstallMethod(exe)
-		fmt.Fprintf(out, "Detected install method: %s (binary at %s)\n", method, exe)
+		logger.Infof("Detected install method: %s (binary at %s)", method, exe)
 
 		switch method {
 		case updater.InstallBrew:
-			updater.PrintBrewUpgrade(out)
+			updater.PrintBrewUpgrade(logger)
 		case updater.InstallManual:
 			bindir := updater.BindirOf(exe)
 			if _, err := updater.ManualUpgrade(cmd.Context(), updater.ManualOptions{
 				Bindir: bindir,
-				Out:    out,
+				Logger: logger,
 				DryRun: dryRunFlag,
 			}); err != nil {
 				return fmt.Errorf("manual upgrade: %w", err)
@@ -56,11 +57,11 @@ After a successful manual upgrade, prints a hint to restart the daemon (` + "`bi
 			}
 
 			if home, homeErr := os.UserHomeDir(); homeErr == nil && updater.DaemonInstalled(home) {
-				updater.PrintDaemonRestartHint(out)
+				updater.PrintDaemonRestartHint(logger)
 			}
 		case updater.InstallUnknown:
-			fmt.Fprintln(out, "Could not classify the install method. Reinstall manually:")
-			fmt.Fprintln(out, "  curl --retry 5 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' | sh -s -- -b <your-bindir>")
+			logger.Warnf("Could not classify the install method. Reinstall manually:")
+			logger.Warnf("  curl --retry 5 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' | sh -s -- -b <your-bindir>")
 		}
 
 		return nil

--- a/internal/logio/writer.go
+++ b/internal/logio/writer.go
@@ -1,0 +1,56 @@
+// Package logio bridges io.Writer consumers (subprocess stdout, library
+// writers that expect an io.Writer sink) onto a go-utils log.Logger, splitting
+// the byte stream into per-line log entries.
+package logio
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+)
+
+// Writer is an io.Writer that buffers bytes and dispatches one log.Logger.Printf
+// call per newline-delimited line. Residual bytes (no trailing newline) wait
+// until the next Write supplies one or Flush is called.
+type Writer struct {
+	logger log.Logger
+	buf    bytes.Buffer
+}
+
+// NewWriter wraps logger as an io.Writer.
+func NewWriter(logger log.Logger) *Writer {
+	return &Writer{logger: logger}
+}
+
+// Write satisfies io.Writer. Always returns len(p), nil — the underlying
+// logger is fire-and-forget so write errors are not propagated.
+func (w *Writer) Write(p []byte) (int, error) {
+	w.buf.Write(p)
+
+	for {
+		line, err := w.buf.ReadString('\n')
+		if errors.Is(err, io.EOF) {
+			w.buf.WriteString(line)
+
+			break
+		}
+
+		w.logger.Printf("%s", strings.TrimRight(line, "\n"))
+	}
+
+	return len(p), nil
+}
+
+// Flush emits any buffered residual that lacks a trailing newline. Call once
+// the source has finished writing so the last partial line isn't dropped.
+func (w *Writer) Flush() {
+	if w.buf.Len() == 0 {
+		return
+	}
+
+	w.logger.Printf("%s", strings.TrimRight(w.buf.String(), "\n"))
+	w.buf.Reset()
+}

--- a/internal/logio/writer_test.go
+++ b/internal/logio/writer_test.go
@@ -1,0 +1,93 @@
+//go:build unit
+
+package logio_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/logio"
+)
+
+// captureLogger satisfies the subset of go-utils log.Logger that Writer
+// exercises (Printf). Other methods are no-ops.
+type captureLogger struct {
+	lines []string
+}
+
+func (c *captureLogger) Printf(format string, args ...any) {
+	c.lines = append(c.lines, strings.TrimSuffix(fmt.Sprintf(format, args...), "\n"))
+}
+
+func (c *captureLogger) Println()               {}
+func (c *captureLogger) Debugf(string, ...any)  {}
+func (c *captureLogger) Infof(string, ...any)   {}
+func (c *captureLogger) Warnf(string, ...any)   {}
+func (c *captureLogger) Errorf(string, ...any)  {}
+func (c *captureLogger) TDebugf(string, ...any) {}
+func (c *captureLogger) TInfof(string, ...any)  {}
+func (c *captureLogger) TWarnf(string, ...any)  {}
+func (c *captureLogger) TPrintf(string, ...any) {}
+func (c *captureLogger) TErrorf(string, ...any) {}
+func (c *captureLogger) Donef(string, ...any)   {}
+func (c *captureLogger) TDonef(string, ...any)  {}
+func (c *captureLogger) EnableDebugLog(bool)    {}
+
+func TestWriter_splitsLinesOnNewline(t *testing.T) {
+	c := &captureLogger{}
+	w := logio.NewWriter(c)
+
+	n, err := w.Write([]byte("first\nsecond\nthird\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 19, n)
+	assert.Equal(t, []string{"first", "second", "third"}, c.lines)
+}
+
+func TestWriter_buffersAcrossWritesUntilNewline(t *testing.T) {
+	c := &captureLogger{}
+	w := logio.NewWriter(c)
+
+	_, err := w.Write([]byte("part1"))
+	require.NoError(t, err)
+	assert.Empty(t, c.lines, "no newline yet → no log line")
+
+	_, err = w.Write([]byte("-part2\n"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"part1-part2"}, c.lines)
+}
+
+func TestWriter_flushEmitsResidual(t *testing.T) {
+	c := &captureLogger{}
+	w := logio.NewWriter(c)
+
+	_, err := w.Write([]byte("no-newline-ending"))
+	require.NoError(t, err)
+	assert.Empty(t, c.lines)
+
+	w.Flush()
+	assert.Equal(t, []string{"no-newline-ending"}, c.lines)
+}
+
+func TestWriter_flushEmptyBufferIsNoOp(t *testing.T) {
+	c := &captureLogger{}
+	w := logio.NewWriter(c)
+
+	w.Flush()
+	assert.Empty(t, c.lines)
+}
+
+func TestWriter_multiLineThenResidual(t *testing.T) {
+	c := &captureLogger{}
+	w := logio.NewWriter(c)
+
+	_, err := w.Write([]byte("a\nb\nc"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, c.lines)
+
+	w.Flush()
+	assert.Equal(t, []string{"a", "b", "c"}, c.lines)
+}

--- a/internal/updater/brew.go
+++ b/internal/updater/brew.go
@@ -4,11 +4,9 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 )
 
-// BrewFormula is the Homebrew formula name shipped by the Bitrise tap.
 const BrewFormula = "bitrise-io/bitrise-build-cache/bitrise-build-cache"
 
-// PrintBrewUpgrade emits the upgrade instruction for a brew-installed CLI.
-// Running `brew upgrade` from the cellar-resident binary itself clashes with brew's file locking — let the user invoke it.
+// PrintBrewUpgrade prints rather than execs because brew upgrade run from inside the cellar binary clashes with brew's file locking.
 func PrintBrewUpgrade(logger log.Logger) {
 	if logger == nil {
 		return

--- a/internal/updater/brew.go
+++ b/internal/updater/brew.go
@@ -1,8 +1,7 @@
 package updater
 
 import (
-	"fmt"
-	"io"
+	"github.com/bitrise-io/go-utils/v2/log"
 )
 
 // BrewFormula is the Homebrew formula name shipped by the Bitrise tap.
@@ -13,14 +12,17 @@ import (
 // constant so this string and the docs / nudge text never drift.
 const BrewFormula = "bitrise-io/bitrise-build-cache/bitrise-build-cache"
 
-// PrintBrewUpgrade writes the upgrade instruction for a brew-installed CLI
-// to w. We deliberately don't *run* the upgrade ourselves — invoking
+// PrintBrewUpgrade emits the upgrade instruction for a brew-installed CLI.
+// We deliberately don't *run* the upgrade ourselves — invoking
 // `brew upgrade` from a binary that lives inside the cellar can clash with
 // brew's own file locking. Letting the user run it from their shell avoids
 // that whole class of issues.
-func PrintBrewUpgrade(w io.Writer) {
-	_, _ = fmt.Fprintf(w,
-		"This CLI was installed via Homebrew. Run:\n  brew update && brew upgrade %s\nto get the latest release.\n",
-		BrewFormula,
-	)
+func PrintBrewUpgrade(logger log.Logger) {
+	if logger == nil {
+		return
+	}
+
+	logger.Infof("This CLI was installed via Homebrew. Run:")
+	logger.Infof("  brew update && brew upgrade %s", BrewFormula)
+	logger.Infof("to get the latest release.")
 }

--- a/internal/updater/brew.go
+++ b/internal/updater/brew.go
@@ -1,0 +1,23 @@
+package updater
+
+import (
+	"fmt"
+	"io"
+)
+
+// BrewFormula is the Homebrew formula name shipped by the Bitrise tap. Kept
+// as a constant in one place so this and any future docs / nudge text stay
+// consistent.
+const BrewFormula = "bitrise-io/tools/bitrise-build-cache-cli"
+
+// PrintBrewUpgrade writes the upgrade instruction for a brew-installed CLI
+// to w. We deliberately don't *run* the upgrade ourselves — invoking
+// `brew upgrade` from a binary that lives inside the cellar can clash with
+// brew's own file locking. Letting the user run it from their shell avoids
+// that whole class of issues.
+func PrintBrewUpgrade(w io.Writer) {
+	_, _ = fmt.Fprintf(w,
+		"This CLI was installed via Homebrew. Run:\n  brew update && brew upgrade %s\nto get the latest release.\n",
+		BrewFormula,
+	)
+}

--- a/internal/updater/brew.go
+++ b/internal/updater/brew.go
@@ -5,18 +5,10 @@ import (
 )
 
 // BrewFormula is the Homebrew formula name shipped by the Bitrise tap.
-// Resolves to the formula at
-// github.com/bitrise-io/homebrew-bitrise-build-cache/Formula/bitrise-build-cache.rb
-// (see scripts/publish_homebrew_formula.sh: TAP_REMOTE_DEFAULT +
-// the rendered Formula/bitrise-build-cache.rb path). Kept as a single
-// constant so this string and the docs / nudge text never drift.
 const BrewFormula = "bitrise-io/bitrise-build-cache/bitrise-build-cache"
 
 // PrintBrewUpgrade emits the upgrade instruction for a brew-installed CLI.
-// We deliberately don't *run* the upgrade ourselves — invoking
-// `brew upgrade` from a binary that lives inside the cellar can clash with
-// brew's own file locking. Letting the user run it from their shell avoids
-// that whole class of issues.
+// Running `brew upgrade` from the cellar-resident binary itself clashes with brew's file locking — let the user invoke it.
 func PrintBrewUpgrade(logger log.Logger) {
 	if logger == nil {
 		return

--- a/internal/updater/brew.go
+++ b/internal/updater/brew.go
@@ -5,10 +5,13 @@ import (
 	"io"
 )
 
-// BrewFormula is the Homebrew formula name shipped by the Bitrise tap. Kept
-// as a constant in one place so this and any future docs / nudge text stay
-// consistent.
-const BrewFormula = "bitrise-io/tools/bitrise-build-cache-cli"
+// BrewFormula is the Homebrew formula name shipped by the Bitrise tap.
+// Resolves to the formula at
+// github.com/bitrise-io/homebrew-bitrise-build-cache/Formula/bitrise-build-cache.rb
+// (see scripts/publish_homebrew_formula.sh: TAP_REMOTE_DEFAULT +
+// the rendered Formula/bitrise-build-cache.rb path). Kept as a single
+// constant so this string and the docs / nudge text never drift.
+const BrewFormula = "bitrise-io/bitrise-build-cache/bitrise-build-cache"
 
 // PrintBrewUpgrade writes the upgrade instruction for a brew-installed CLI
 // to w. We deliberately don't *run* the upgrade ourselves — invoking

--- a/internal/updater/brew_test.go
+++ b/internal/updater/brew_test.go
@@ -6,12 +6,19 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/stretchr/testify/assert"
 )
 
+// loggerWithBuffer builds a project logger that writes into the supplied
+// buffer — the standard test seam for asserting on updater output.
+func loggerWithBuffer(buf *bytes.Buffer) log.Logger {
+	return log.NewLogger(log.WithOutput(buf))
+}
+
 func TestPrintBrewUpgrade_includesFormulaAndUpgradeVerb(t *testing.T) {
 	var buf bytes.Buffer
-	PrintBrewUpgrade(&buf)
+	PrintBrewUpgrade(loggerWithBuffer(&buf))
 
 	out := buf.String()
 	assert.Contains(t, out, "brew update")

--- a/internal/updater/brew_test.go
+++ b/internal/updater/brew_test.go
@@ -1,0 +1,20 @@
+//go:build unit
+
+package updater
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintBrewUpgrade_includesFormulaAndUpgradeVerb(t *testing.T) {
+	var buf bytes.Buffer
+	PrintBrewUpgrade(&buf)
+
+	out := buf.String()
+	assert.Contains(t, out, "brew update")
+	assert.Contains(t, out, "brew upgrade")
+	assert.Contains(t, out, BrewFormula)
+}

--- a/internal/updater/daemon.go
+++ b/internal/updater/daemon.go
@@ -1,0 +1,42 @@
+package updater
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// DaemonInstalled reports whether the user has any daemon supervisor config
+// on disk. Used after an upgrade to surface the restart hint only when it's
+// actually relevant.
+//
+// macOS: checks for either io.bitrise.build-cache.xcelerate-proxy.plist or
+// io.bitrise.build-cache.ccache-helper.plist under ~/Library/LaunchAgents.
+//
+// Linux: checks for either bitrise-build-cache-xcelerate-proxy.service or
+// bitrise-build-cache-ccache-helper.service under ~/.config/systemd/user.
+func DaemonInstalled(home string) bool {
+	candidates := []string{
+		filepath.Join(home, "Library", "LaunchAgents", "io.bitrise.build-cache.xcelerate-proxy.plist"),
+		filepath.Join(home, "Library", "LaunchAgents", "io.bitrise.build-cache.ccache-helper.plist"),
+		filepath.Join(home, ".config", "systemd", "user", "bitrise-build-cache-xcelerate-proxy.service"),
+		filepath.Join(home, ".config", "systemd", "user", "bitrise-build-cache-ccache-helper.service"),
+	}
+
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+// PrintDaemonRestartHint emits a one-line "you should restart the daemon"
+// nudge. Caller is responsible for gating on DaemonInstalled(home).
+func PrintDaemonRestartHint(w io.Writer) {
+	_, _ = fmt.Fprintln(w,
+		"You have the Bitrise Build Cache daemon installed. Run `bitrise-build-cache daemon restart` to pick up the new binary.",
+	)
+}

--- a/internal/updater/daemon.go
+++ b/internal/updater/daemon.go
@@ -1,10 +1,10 @@
 package updater
 
 import (
-	"fmt"
-	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/bitrise-io/go-utils/v2/log"
 )
 
 // DaemonInstalled reports whether the user has any daemon supervisor config
@@ -44,9 +44,12 @@ func DaemonInstalled(home string) bool {
 }
 
 // PrintDaemonRestartHint emits a one-line "you should restart the daemon"
-// nudge. Caller is responsible for gating on DaemonInstalled(home).
-func PrintDaemonRestartHint(w io.Writer) {
-	_, _ = fmt.Fprintln(w,
-		"You have the Bitrise Build Cache daemon installed. Run `bitrise-build-cache daemon restart` to pick up the new binary.",
-	)
+// nudge via logger.Infof. Caller is responsible for gating on
+// DaemonInstalled(home).
+func PrintDaemonRestartHint(logger log.Logger) {
+	if logger == nil {
+		return
+	}
+
+	logger.Infof("You have the Bitrise Build Cache daemon installed. Run `bitrise-build-cache daemon restart` to pick up the new binary.")
 }

--- a/internal/updater/daemon.go
+++ b/internal/updater/daemon.go
@@ -3,8 +3,6 @@ package updater
 import (
 	"os"
 	"path/filepath"
-
-	"github.com/bitrise-io/go-utils/v2/log"
 )
 
 // DaemonInstalled is a file-presence check — a stale plist/unit from a partial uninstall yields a benign false-positive.
@@ -23,12 +21,4 @@ func DaemonInstalled(home string) bool {
 	}
 
 	return false
-}
-
-func PrintDaemonRestartHint(logger log.Logger) {
-	if logger == nil {
-		return
-	}
-
-	logger.Infof("You have the Bitrise Build Cache daemon installed. Run `bitrise-build-cache daemon restart` to pick up the new binary.")
 }

--- a/internal/updater/daemon.go
+++ b/internal/updater/daemon.go
@@ -7,10 +7,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 )
 
-// DaemonInstalled reports whether the user has any daemon supervisor config on disk.
-//
-// File-presence check only — a stale plist/unit file from a partial uninstall yields
-// a benign false-positive (the resulting `daemon restart` is a no-op against a not-loaded service).
+// DaemonInstalled is a file-presence check — a stale plist/unit from a partial uninstall yields a benign false-positive.
 func DaemonInstalled(home string) bool {
 	candidates := []string{
 		filepath.Join(home, "Library", "LaunchAgents", "io.bitrise.build-cache.xcelerate-proxy.plist"),
@@ -28,7 +25,6 @@ func DaemonInstalled(home string) bool {
 	return false
 }
 
-// PrintDaemonRestartHint emits the restart nudge. Caller gates on DaemonInstalled(home).
 func PrintDaemonRestartHint(logger log.Logger) {
 	if logger == nil {
 		return

--- a/internal/updater/daemon.go
+++ b/internal/updater/daemon.go
@@ -7,25 +7,10 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 )
 
-// DaemonInstalled reports whether the user has any daemon supervisor config
-// on disk. Used after an upgrade to surface the restart hint only when it's
-// actually relevant.
+// DaemonInstalled reports whether the user has any daemon supervisor config on disk.
 //
-// macOS: checks for either io.bitrise.build-cache.xcelerate-proxy.plist or
-// io.bitrise.build-cache.ccache-helper.plist under ~/Library/LaunchAgents.
-//
-// Linux: checks for either bitrise-build-cache-xcelerate-proxy.service or
-// bitrise-build-cache-ccache-helper.service under ~/.config/systemd/user.
-//
-// Limitation: this is a file-presence check, NOT a "service is actually
-// loaded" check. A stale plist / unit file left behind by a partial
-// `daemon uninstall` (or by a user who manually `launchctl bootout`ed and
-// forgot to delete the file) triggers a false-positive restart hint. The
-// hint itself is benign — running `daemon restart` against a not-loaded
-// service is a no-op on launchd (bootout-then-bootstrap brings it back up
-// cleanly) and effectively `start` on systemd. Worth promoting to a real
-// `launchctl print` / `systemctl --user status` check if the false-positive
-// rate gets noisy in practice.
+// File-presence check only — a stale plist/unit file from a partial uninstall yields
+// a benign false-positive (the resulting `daemon restart` is a no-op against a not-loaded service).
 func DaemonInstalled(home string) bool {
 	candidates := []string{
 		filepath.Join(home, "Library", "LaunchAgents", "io.bitrise.build-cache.xcelerate-proxy.plist"),
@@ -43,9 +28,7 @@ func DaemonInstalled(home string) bool {
 	return false
 }
 
-// PrintDaemonRestartHint emits a one-line "you should restart the daemon"
-// nudge via logger.Infof. Caller is responsible for gating on
-// DaemonInstalled(home).
+// PrintDaemonRestartHint emits the restart nudge. Caller gates on DaemonInstalled(home).
 func PrintDaemonRestartHint(logger log.Logger) {
 	if logger == nil {
 		return

--- a/internal/updater/daemon.go
+++ b/internal/updater/daemon.go
@@ -16,6 +16,16 @@ import (
 //
 // Linux: checks for either bitrise-build-cache-xcelerate-proxy.service or
 // bitrise-build-cache-ccache-helper.service under ~/.config/systemd/user.
+//
+// Limitation: this is a file-presence check, NOT a "service is actually
+// loaded" check. A stale plist / unit file left behind by a partial
+// `daemon uninstall` (or by a user who manually `launchctl bootout`ed and
+// forgot to delete the file) triggers a false-positive restart hint. The
+// hint itself is benign — running `daemon restart` against a not-loaded
+// service is a no-op on launchd (bootout-then-bootstrap brings it back up
+// cleanly) and effectively `start` on systemd. Worth promoting to a real
+// `launchctl print` / `systemctl --user status` check if the false-positive
+// rate gets noisy in practice.
 func DaemonInstalled(home string) bool {
 	candidates := []string{
 		filepath.Join(home, "Library", "LaunchAgents", "io.bitrise.build-cache.xcelerate-proxy.plist"),

--- a/internal/updater/daemon_test.go
+++ b/internal/updater/daemon_test.go
@@ -1,0 +1,41 @@
+//go:build unit
+
+package updater
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDaemonInstalled_falseWhenAbsent(t *testing.T) {
+	assert.False(t, DaemonInstalled(t.TempDir()))
+}
+
+func TestDaemonInstalled_detectsLaunchAgent(t *testing.T) {
+	home := t.TempDir()
+	plistDir := filepath.Join(home, "Library", "LaunchAgents")
+	require.NoError(t, os.MkdirAll(plistDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(plistDir, "io.bitrise.build-cache.xcelerate-proxy.plist"), []byte("<plist/>"), 0o644))
+
+	assert.True(t, DaemonInstalled(home))
+}
+
+func TestDaemonInstalled_detectsSystemdUnit(t *testing.T) {
+	home := t.TempDir()
+	unitDir := filepath.Join(home, ".config", "systemd", "user")
+	require.NoError(t, os.MkdirAll(unitDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(unitDir, "bitrise-build-cache-ccache-helper.service"), []byte("[Unit]\n"), 0o644))
+
+	assert.True(t, DaemonInstalled(home))
+}
+
+func TestPrintDaemonRestartHint_mentionsRestartCommand(t *testing.T) {
+	var buf bytes.Buffer
+	PrintDaemonRestartHint(&buf)
+	assert.Contains(t, buf.String(), "daemon restart")
+}

--- a/internal/updater/daemon_test.go
+++ b/internal/updater/daemon_test.go
@@ -36,6 +36,6 @@ func TestDaemonInstalled_detectsSystemdUnit(t *testing.T) {
 
 func TestPrintDaemonRestartHint_mentionsRestartCommand(t *testing.T) {
 	var buf bytes.Buffer
-	PrintDaemonRestartHint(&buf)
+	PrintDaemonRestartHint(loggerWithBuffer(&buf))
 	assert.Contains(t, buf.String(), "daemon restart")
 }

--- a/internal/updater/daemon_test.go
+++ b/internal/updater/daemon_test.go
@@ -3,7 +3,6 @@
 package updater
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,10 +31,4 @@ func TestDaemonInstalled_detectsSystemdUnit(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(unitDir, "bitrise-build-cache-ccache-helper.service"), []byte("[Unit]\n"), 0o644))
 
 	assert.True(t, DaemonInstalled(home))
-}
-
-func TestPrintDaemonRestartHint_mentionsRestartCommand(t *testing.T) {
-	var buf bytes.Buffer
-	PrintDaemonRestartHint(loggerWithBuffer(&buf))
-	assert.Contains(t, buf.String(), "daemon restart")
 }

--- a/internal/updater/detect.go
+++ b/internal/updater/detect.go
@@ -8,6 +8,7 @@
 package updater
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -56,8 +57,10 @@ var brewSubstrings = []string{
 
 // DetectInstallMethod inspects the supplied executable path (typically
 // os.Executable() at the call site, optionally symlink-resolved by the
-// caller) and returns the best-guess install method. Pure function — no I/O —
-// so it's trivially testable without setting up a real install.
+// caller) and returns the best-guess install method. Reads $HOMEBREW_PREFIX
+// from the environment as a secondary signal — Homebrew exports this when
+// `brew shellenv` has been sourced, which covers unusual prefixes that
+// don't match any of the hard-coded brewSubstrings.
 func DetectInstallMethod(executable string) InstallMethod {
 	if executable == "" {
 		return InstallUnknown
@@ -67,6 +70,16 @@ func DetectInstallMethod(executable string) InstallMethod {
 
 	for _, frag := range brewSubstrings {
 		if strings.Contains(abs, frag) {
+			return InstallBrew
+		}
+	}
+
+	// HOMEBREW_PREFIX catches non-standard brew layouts (relocated prefix,
+	// custom `brew --prefix` overrides). Only consulted when the substring
+	// match misses, so the more specific Cellar/ classification still wins
+	// for stable installs.
+	if prefix := strings.TrimSpace(os.Getenv("HOMEBREW_PREFIX")); prefix != "" {
+		if strings.HasPrefix(abs, filepath.Clean(prefix)+string(filepath.Separator)) {
 			return InstallBrew
 		}
 	}

--- a/internal/updater/detect.go
+++ b/internal/updater/detect.go
@@ -1,10 +1,3 @@
-// Package updater implements the `bitrise-build-cache update` subcommand —
-// the manual install upgrade path. Detects how the running CLI was installed
-// (brew vs `installer.sh`), then either prints the brew upgrade command or
-// re-runs installer.sh against the same bindir.
-//
-// Best-effort by design — the user can always fall back to running
-// installer.sh manually if any of this misfires.
 package updater
 
 import (
@@ -13,15 +6,11 @@ import (
 	"strings"
 )
 
-// InstallMethod classifies how the running binary got onto disk.
 type InstallMethod int
 
 const (
-	// InstallUnknown is the safe default; callers print generic guidance and skip the automated upgrade.
 	InstallUnknown InstallMethod = iota
-	// InstallBrew means the running binary is under a Homebrew Cellar prefix.
 	InstallBrew
-	// InstallManual means the running binary was dropped by `installer.sh -b <bindir>`.
 	InstallManual
 )
 
@@ -38,21 +27,16 @@ func (m InstallMethod) String() string {
 	}
 }
 
-// brewSubstrings are the path fragments that mark a Homebrew install. Matched
-// against the resolved (symlink-followed) absolute path of the running
-// binary. Covers macOS (Apple Silicon + Intel) and Linuxbrew.
-//
 //nolint:gochecknoglobals
 var brewSubstrings = []string{
-	"/Cellar/",                    // generic — present in every brew install
-	"/opt/homebrew/",              // Apple Silicon prefix (symlink target dir)
-	"/usr/local/Homebrew/",        // Intel macOS Homebrew internal path
-	"/home/linuxbrew/.linuxbrew/", // Linuxbrew shared install
-	".linuxbrew/Cellar/",          // per-user Linuxbrew
+	"/Cellar/",
+	"/opt/homebrew/",
+	"/usr/local/Homebrew/",
+	"/home/linuxbrew/.linuxbrew/",
+	".linuxbrew/Cellar/",
 }
 
-// DetectInstallMethod returns the best-guess install method for the supplied executable path.
-// Falls back to $HOMEBREW_PREFIX to catch relocated/custom brew prefixes.
+// DetectInstallMethod falls back to $HOMEBREW_PREFIX for relocated/custom brew prefixes.
 func DetectInstallMethod(executable string) InstallMethod {
 	if executable == "" {
 		return InstallUnknown
@@ -66,14 +50,12 @@ func DetectInstallMethod(executable string) InstallMethod {
 		}
 	}
 
-	// HOMEBREW_PREFIX catches non-standard brew layouts (relocated prefix, custom `brew --prefix`).
 	if prefix := strings.TrimSpace(os.Getenv("HOMEBREW_PREFIX")); prefix != "" {
 		if strings.HasPrefix(abs, filepath.Clean(prefix)+string(filepath.Separator)) {
 			return InstallBrew
 		}
 	}
 
-	// Defensive against future os.Executable() return shapes.
 	if filepath.Base(abs) == "" || filepath.Base(abs) == "." {
 		return InstallUnknown
 	}

--- a/internal/updater/detect.go
+++ b/internal/updater/detect.go
@@ -1,0 +1,81 @@
+// Package updater implements the `bitrise-build-cache update` subcommand —
+// the manual install upgrade path. Detects how the running CLI was installed
+// (brew vs `installer.sh`), then either prints the brew upgrade command or
+// re-runs installer.sh against the same bindir.
+//
+// Best-effort by design — the user can always fall back to running
+// installer.sh manually if any of this misfires.
+package updater
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// InstallMethod classifies how the running binary got onto disk. Used to pick
+// the right upgrade flow.
+type InstallMethod int
+
+const (
+	// InstallUnknown is the safe default when path inspection didn't yield a
+	// confident classification. Callers print a generic guidance message and
+	// don't attempt an automated upgrade.
+	InstallUnknown InstallMethod = iota
+	// InstallBrew means the running binary is under a Homebrew Cellar prefix.
+	InstallBrew
+	// InstallManual means the running binary lives outside any brew prefix —
+	// typically dropped by `installer.sh -b <bindir>`.
+	InstallManual
+)
+
+func (m InstallMethod) String() string {
+	switch m {
+	case InstallBrew:
+		return "brew"
+	case InstallManual:
+		return "manual"
+	case InstallUnknown:
+		return "unknown"
+	default:
+		return "unknown"
+	}
+}
+
+// brewSubstrings are the path fragments that mark a Homebrew install. Matched
+// against the resolved (symlink-followed) absolute path of the running
+// binary. Covers macOS (Apple Silicon + Intel) and Linuxbrew.
+//
+//nolint:gochecknoglobals
+var brewSubstrings = []string{
+	"/Cellar/",                    // generic — present in every brew install
+	"/opt/homebrew/",              // Apple Silicon prefix (symlink target dir)
+	"/usr/local/Homebrew/",        // Intel macOS Homebrew internal path
+	"/home/linuxbrew/.linuxbrew/", // Linuxbrew shared install
+	".linuxbrew/Cellar/",          // per-user Linuxbrew
+}
+
+// DetectInstallMethod inspects the supplied executable path (typically
+// os.Executable() at the call site, optionally symlink-resolved by the
+// caller) and returns the best-guess install method. Pure function — no I/O —
+// so it's trivially testable without setting up a real install.
+func DetectInstallMethod(executable string) InstallMethod {
+	if executable == "" {
+		return InstallUnknown
+	}
+
+	abs := filepath.Clean(executable)
+
+	for _, frag := range brewSubstrings {
+		if strings.Contains(abs, frag) {
+			return InstallBrew
+		}
+	}
+
+	// Empty / unparseable basename is a hard "unknown" signal — defensive
+	// against future os.Executable() return shapes.
+	if filepath.Base(abs) == "" || filepath.Base(abs) == "." {
+		return InstallUnknown
+	}
+
+	return InstallManual
+}

--- a/internal/updater/detect.go
+++ b/internal/updater/detect.go
@@ -13,19 +13,15 @@ import (
 	"strings"
 )
 
-// InstallMethod classifies how the running binary got onto disk. Used to pick
-// the right upgrade flow.
+// InstallMethod classifies how the running binary got onto disk.
 type InstallMethod int
 
 const (
-	// InstallUnknown is the safe default when path inspection didn't yield a
-	// confident classification. Callers print a generic guidance message and
-	// don't attempt an automated upgrade.
+	// InstallUnknown is the safe default; callers print generic guidance and skip the automated upgrade.
 	InstallUnknown InstallMethod = iota
 	// InstallBrew means the running binary is under a Homebrew Cellar prefix.
 	InstallBrew
-	// InstallManual means the running binary lives outside any brew prefix —
-	// typically dropped by `installer.sh -b <bindir>`.
+	// InstallManual means the running binary was dropped by `installer.sh -b <bindir>`.
 	InstallManual
 )
 
@@ -55,12 +51,8 @@ var brewSubstrings = []string{
 	".linuxbrew/Cellar/",          // per-user Linuxbrew
 }
 
-// DetectInstallMethod inspects the supplied executable path (typically
-// os.Executable() at the call site, optionally symlink-resolved by the
-// caller) and returns the best-guess install method. Reads $HOMEBREW_PREFIX
-// from the environment as a secondary signal — Homebrew exports this when
-// `brew shellenv` has been sourced, which covers unusual prefixes that
-// don't match any of the hard-coded brewSubstrings.
+// DetectInstallMethod returns the best-guess install method for the supplied executable path.
+// Falls back to $HOMEBREW_PREFIX to catch relocated/custom brew prefixes.
 func DetectInstallMethod(executable string) InstallMethod {
 	if executable == "" {
 		return InstallUnknown
@@ -74,18 +66,14 @@ func DetectInstallMethod(executable string) InstallMethod {
 		}
 	}
 
-	// HOMEBREW_PREFIX catches non-standard brew layouts (relocated prefix,
-	// custom `brew --prefix` overrides). Only consulted when the substring
-	// match misses, so the more specific Cellar/ classification still wins
-	// for stable installs.
+	// HOMEBREW_PREFIX catches non-standard brew layouts (relocated prefix, custom `brew --prefix`).
 	if prefix := strings.TrimSpace(os.Getenv("HOMEBREW_PREFIX")); prefix != "" {
 		if strings.HasPrefix(abs, filepath.Clean(prefix)+string(filepath.Separator)) {
 			return InstallBrew
 		}
 	}
 
-	// Empty / unparseable basename is a hard "unknown" signal — defensive
-	// against future os.Executable() return shapes.
+	// Defensive against future os.Executable() return shapes.
 	if filepath.Base(abs) == "" || filepath.Base(abs) == "." {
 		return InstallUnknown
 	}

--- a/internal/updater/detect_test.go
+++ b/internal/updater/detect_test.go
@@ -1,0 +1,45 @@
+//go:build unit
+
+package updater
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectInstallMethod_truthTable(t *testing.T) {
+	cases := []struct {
+		executable string
+		want       InstallMethod
+		name       string
+	}{
+		{"/opt/homebrew/Cellar/bitrise-build-cache-cli/2.8.4/bin/bitrise-build-cache", InstallBrew, "apple-silicon-brew"},
+		{"/usr/local/Cellar/bitrise-build-cache-cli/2.8.4/bin/bitrise-build-cache", InstallBrew, "intel-brew"},
+		{"/home/linuxbrew/.linuxbrew/Cellar/bitrise-build-cache-cli/2.8.4/bin/bitrise-build-cache", InstallBrew, "linuxbrew-shared"},
+		{"/home/alice/.linuxbrew/Cellar/bitrise-build-cache-cli/2.8.4/bin/bitrise-build-cache", InstallBrew, "linuxbrew-user"},
+		{"/opt/homebrew/bin/bitrise-build-cache", InstallBrew, "brew-symlink-prefix"},
+		{"/usr/local/bin/bitrise-build-cache", InstallManual, "default-manual-prefix"},
+		{"/home/alice/.local/bin/bitrise-build-cache", InstallManual, "user-local"},
+		{"/tmp/bin/bitrise-build-cache", InstallManual, "ephemeral-bindir"},
+		{"./bitrise-build-cache", InstallManual, "relative-path"},
+		{"", InstallUnknown, "empty"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, DetectInstallMethod(tc.executable))
+		})
+	}
+}
+
+func TestInstallMethod_String(t *testing.T) {
+	assert.Equal(t, "brew", InstallBrew.String())
+	assert.Equal(t, "manual", InstallManual.String())
+	assert.Equal(t, "unknown", InstallUnknown.String())
+}
+
+func TestBindirOf_returnsDirOfExecutable(t *testing.T) {
+	assert.Equal(t, "/usr/local/bin", BindirOf("/usr/local/bin/bitrise-build-cache"))
+	assert.Equal(t, "/home/alice/.local/bin", BindirOf("/home/alice/.local/bin/bitrise-build-cache"))
+}

--- a/internal/updater/detect_test.go
+++ b/internal/updater/detect_test.go
@@ -39,19 +39,6 @@ func TestInstallMethod_String(t *testing.T) {
 	assert.Equal(t, "unknown", InstallUnknown.String())
 }
 
-func TestBindirOf_returnsDirOfExecutable(t *testing.T) {
-	assert.Equal(t, "/usr/local/bin", BindirOf("/usr/local/bin/bitrise-build-cache"))
-	assert.Equal(t, "/home/alice/.local/bin", BindirOf("/home/alice/.local/bin/bitrise-build-cache"))
-}
-
-func TestBindirOf_trailingSlashOnExecutablePath(t *testing.T) {
-	// Defensive: an executable path ending in `/` (unusual but possible on
-	// some FUSE / netfs setups where os.Executable() resolves oddly)
-	// shouldn't yield "/" as the bindir. filepath.Dir handles this — just
-	// lock the behaviour.
-	assert.Equal(t, "/usr/local/bin", BindirOf("/usr/local/bin/"))
-}
-
 func TestDetectInstallMethod_honoursHomebrewPrefix(t *testing.T) {
 	// Path that doesn't match any hard-coded brewSubstring, but
 	// $HOMEBREW_PREFIX points at its parent — classify as brew.

--- a/internal/updater/detect_test.go
+++ b/internal/updater/detect_test.go
@@ -43,3 +43,24 @@ func TestBindirOf_returnsDirOfExecutable(t *testing.T) {
 	assert.Equal(t, "/usr/local/bin", BindirOf("/usr/local/bin/bitrise-build-cache"))
 	assert.Equal(t, "/home/alice/.local/bin", BindirOf("/home/alice/.local/bin/bitrise-build-cache"))
 }
+
+func TestBindirOf_trailingSlashOnExecutablePath(t *testing.T) {
+	// Defensive: an executable path ending in `/` (unusual but possible on
+	// some FUSE / netfs setups where os.Executable() resolves oddly)
+	// shouldn't yield "/" as the bindir. filepath.Dir handles this — just
+	// lock the behaviour.
+	assert.Equal(t, "/usr/local/bin", BindirOf("/usr/local/bin/"))
+}
+
+func TestDetectInstallMethod_honoursHomebrewPrefix(t *testing.T) {
+	// Path that doesn't match any hard-coded brewSubstring, but
+	// $HOMEBREW_PREFIX points at its parent — classify as brew.
+	t.Setenv("HOMEBREW_PREFIX", "/srv/brew-relocated")
+	assert.Equal(t, InstallBrew, DetectInstallMethod("/srv/brew-relocated/bin/bitrise-build-cache"))
+}
+
+func TestDetectInstallMethod_homebrewPrefixSetButBinaryElsewhere(t *testing.T) {
+	t.Setenv("HOMEBREW_PREFIX", "/srv/brew-relocated")
+	// HOMEBREW_PREFIX is set but the binary lives outside it — still manual.
+	assert.Equal(t, InstallManual, DetectInstallMethod("/home/alice/.local/bin/bitrise-build-cache"))
+}

--- a/internal/updater/manual.go
+++ b/internal/updater/manual.go
@@ -54,10 +54,14 @@ func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 	}
 
 	if opts.DryRun {
-		opts.Logger.Infof("Dry run — installer downloaded to %s but NOT executed.", scriptPath)
-		opts.Logger.Infof("To upgrade manually: %s %s -b %s", opts.Shell, scriptPath, opts.Bindir)
+		opts.Logger.Infof("Dry run — would run: %s %s -b %s", opts.Shell, scriptPath, opts.Bindir)
+		opts.Logger.Infof("Rerun without --dry-run to apply.")
 
-		return scriptPath, nil
+		if removeErr := os.Remove(scriptPath); removeErr != nil {
+			opts.Logger.Warnf("could not clean up dry-run installer temp file %s: %s", scriptPath, removeErr)
+		}
+
+		return "", nil
 	}
 
 	opts.Logger.Infof("Running installer to upgrade CLI in %s ...", opts.Bindir)

--- a/internal/updater/manual.go
+++ b/internal/updater/manual.go
@@ -22,6 +22,12 @@ const InstallerURL = "https://raw.githubusercontent.com/bitrise-io/bitrise-build
 // (<10 KB); a short timeout makes a network blip surface as an error fast.
 const DownloadTimeout = 10 * time.Second
 
+// MaxInstallerBytes caps how much we'll read from the installer URL. The
+// real script is well under 100 KiB — 1 MiB is two orders of magnitude
+// safety margin while still bounding the worst case if a hostile / broken
+// origin streams gigabytes into os.TempDir.
+const MaxInstallerBytes = 1 << 20
+
 // ManualOptions bundles the inputs ManualUpgrade needs. Kept as a struct so
 // tests can override URL / HTTP client / shell / output writer.
 type ManualOptions struct {
@@ -114,7 +120,11 @@ func downloadInstaller(ctx context.Context, client *http.Client, url string) (st
 
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode/100 != 2 {
+	// Use the strict 2xx range. Status / 100 == 2 (used previously) would
+	// silently accept e.g. a 3xx redirect Go's client failed to follow,
+	// which produces an HTML body that goes on to be exec'd as a shell
+	// script — a bad time.
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return "", fmt.Errorf("download installer.sh: server responded %d", resp.StatusCode)
 	}
 
@@ -123,11 +133,25 @@ func downloadInstaller(ctx context.Context, client *http.Client, url string) (st
 		return "", fmt.Errorf("create installer temp file: %w", err)
 	}
 
-	if _, err := io.Copy(tmp, resp.Body); err != nil {
+	// LimitReader caps the body at MaxInstallerBytes so a hostile / broken
+	// origin can't stream gigabytes into os.TempDir. We additionally check
+	// whether the cap was actually hit (n == cap) by reading one extra byte
+	// — if anything's left, the body is over the limit.
+	limited := io.LimitReader(resp.Body, MaxInstallerBytes+1)
+
+	n, err := io.Copy(tmp, limited)
+	if err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmp.Name())
 
 		return "", fmt.Errorf("write installer to temp: %w", err)
+	}
+
+	if n > MaxInstallerBytes {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+
+		return "", fmt.Errorf("installer.sh exceeds %d bytes — refusing to execute oversized script", MaxInstallerBytes)
 	}
 
 	if err := tmp.Close(); err != nil {

--- a/internal/updater/manual.go
+++ b/internal/updater/manual.go
@@ -1,6 +1,7 @@
 package updater
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -10,6 +11,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	"github.com/bitrise-io/go-utils/v2/log"
 )
 
 // InstallerURL is the canonical location of installer.sh. The file at this
@@ -29,15 +32,16 @@ const DownloadTimeout = 10 * time.Second
 const MaxInstallerBytes = 1 << 20
 
 // ManualOptions bundles the inputs ManualUpgrade needs. Kept as a struct so
-// tests can override URL / HTTP client / shell / output writer.
+// tests can override URL / HTTP client / shell / logger.
 type ManualOptions struct {
 	// Bindir is the directory containing the running binary — passed to
 	// installer.sh via `-b`. Required.
 	Bindir string
-	// Out is where progress / completion messages go. The CLI's update
-	// subcommand passes cmd.OutOrStdout() so the user sees the upgrade
-	// log inline; tests inject a bytes.Buffer.
-	Out io.Writer
+	// Logger receives our own progress / completion messages AND the
+	// subprocess stdout/stderr (line-buffered via the loggerWriter adapter
+	// below). Tests pass log.NewLogger(log.WithOutput(&buf)); production
+	// passes a stderr-backed logger.
+	Logger log.Logger
 	// InstallerURL overrides the canonical URL for tests. Empty = use
 	// InstallerURL constant.
 	InstallerURL string
@@ -56,15 +60,14 @@ type ManualOptions struct {
 // drive it.
 //
 // Returns the local path of the downloaded installer (useful for diagnostics
-// and the DryRun case). The file is left on disk under os.TempDir() so a
-// later debug pass can re-run it; it's tiny.
+// and the DryRun case).
 func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 	if opts.Bindir == "" {
 		return "", errors.New("bindir is required for manual upgrade")
 	}
 
-	if opts.Out == nil {
-		opts.Out = os.Stderr
+	if opts.Logger == nil {
+		return "", errors.New("logger is required for manual upgrade")
 	}
 
 	if opts.InstallerURL == "" {
@@ -84,17 +87,23 @@ func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 		// Dry run intentionally leaves the script on disk — the printed
 		// "To upgrade manually" command references it, so removing it would
 		// break copy-paste. Caller / user cleans up when done.
-		fmt.Fprintf(opts.Out, "Dry run — installer downloaded to %s but NOT executed.\n", scriptPath)
-		fmt.Fprintf(opts.Out, "To upgrade manually: %s %s -b %s\n", opts.Shell, scriptPath, opts.Bindir)
+		opts.Logger.Infof("Dry run — installer downloaded to %s but NOT executed.", scriptPath)
+		opts.Logger.Infof("To upgrade manually: %s %s -b %s", opts.Shell, scriptPath, opts.Bindir)
 
 		return scriptPath, nil
 	}
 
-	fmt.Fprintf(opts.Out, "Running installer to upgrade CLI in %s ...\n", opts.Bindir)
+	opts.Logger.Infof("Running installer to upgrade CLI in %s ...", opts.Bindir)
+
+	// loggerWriter buffers subprocess output until newlines so logger.Printf
+	// emits one line per installer.sh log entry, preserving the user-visible
+	// progress stream while flowing through the same logger.
+	pipe := newLoggerWriter(opts.Logger)
+	defer pipe.Flush()
 
 	cmd := exec.CommandContext(ctx, opts.Shell, scriptPath, "-b", opts.Bindir) //nolint:gosec // scriptPath is our temp file we just wrote
-	cmd.Stdout = opts.Out
-	cmd.Stderr = opts.Out
+	cmd.Stdout = pipe
+	cmd.Stderr = pipe
 
 	if err := cmd.Run(); err != nil {
 		// Keep the script on disk on failure so the user can re-run it
@@ -105,10 +114,10 @@ func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 	// Success — drop the temp file. Best-effort; if removal fails the OS will
 	// clean it up on next reboot (os.TempDir).
 	if removeErr := os.Remove(scriptPath); removeErr != nil {
-		fmt.Fprintf(opts.Out, "warning: could not clean up installer temp file %s: %s\n", scriptPath, removeErr)
+		opts.Logger.Warnf("could not clean up installer temp file %s: %s", scriptPath, removeErr)
 	}
 
-	fmt.Fprintln(opts.Out, "Upgrade complete.")
+	opts.Logger.Donef("Upgrade complete.")
 
 	return scriptPath, nil
 }
@@ -132,10 +141,9 @@ func downloadInstaller(ctx context.Context, client *http.Client, url string) (st
 
 	defer func() { _ = resp.Body.Close() }()
 
-	// Use the strict 2xx range. Status / 100 == 2 (used previously) would
-	// silently accept e.g. a 3xx redirect Go's client failed to follow,
-	// which produces an HTML body that goes on to be exec'd as a shell
-	// script — a bad time.
+	// Strict 2xx range. Status / 100 == 2 (used previously) would silently
+	// accept a 3xx redirect Go's client failed to follow — that produces an
+	// HTML body that would go on to be exec'd as a shell script.
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return "", fmt.Errorf("download installer.sh: server responded %d", resp.StatusCode)
 	}
@@ -147,8 +155,7 @@ func downloadInstaller(ctx context.Context, client *http.Client, url string) (st
 
 	// LimitReader caps the body at MaxInstallerBytes so a hostile / broken
 	// origin can't stream gigabytes into os.TempDir. We additionally check
-	// whether the cap was actually hit (n == cap) by reading one extra byte
-	// — if anything's left, the body is over the limit.
+	// whether the cap was actually hit (n == cap+1) by reading one extra byte.
 	limited := io.LimitReader(resp.Body, MaxInstallerBytes+1)
 
 	n, err := io.Copy(tmp, limited)
@@ -172,9 +179,6 @@ func downloadInstaller(ctx context.Context, client *http.Client, url string) (st
 		return "", fmt.Errorf("close installer temp file: %w", err)
 	}
 
-	// installer.sh is sh-piped in production; making the file executable
-	// keeps the local invocation form available too if a future caller wants
-	// to skip the explicit shell.
 	if err := os.Chmod(tmp.Name(), 0o700); err != nil { //nolint:gosec // intentional: script must be readable + executable
 		return "", fmt.Errorf("chmod installer temp: %w", err)
 	}
@@ -186,4 +190,57 @@ func downloadInstaller(ctx context.Context, client *http.Client, url string) (st
 // to pass installer.sh's -b flag so the upgrade lands in the same spot.
 func BindirOf(executable string) string {
 	return filepath.Dir(executable)
+}
+
+// loggerWriter is an io.Writer that line-buffers its input and emits each
+// complete line via logger.Printf. Used to plumb subprocess stdout/stderr
+// through the project logger — exec.Cmd needs an io.Writer but the rest of
+// the package uses log.Logger.
+type loggerWriter struct {
+	logger log.Logger
+	buf    bytes.Buffer
+}
+
+func newLoggerWriter(logger log.Logger) *loggerWriter {
+	return &loggerWriter{logger: logger}
+}
+
+func (w *loggerWriter) Write(p []byte) (int, error) {
+	w.buf.Write(p)
+
+	for {
+		line, err := w.buf.ReadString('\n')
+		if errors.Is(err, io.EOF) {
+			// Incomplete trailing line — buffer it and wait for more.
+			w.buf.WriteString(line)
+
+			break
+		}
+
+		// Strip trailing newline; logger.Printf adds its own.
+		w.logger.Printf("%s", trimNewline(line))
+	}
+
+	return len(p), nil
+}
+
+// Flush emits any remaining buffered partial line. Call after the
+// subprocess exits to avoid losing a no-trailing-newline final line.
+func (w *loggerWriter) Flush() {
+	if w.buf.Len() == 0 {
+		return
+	}
+
+	w.logger.Printf("%s", trimNewline(w.buf.String()))
+	w.buf.Reset()
+}
+
+// trimNewline drops one trailing \n if present. Avoids importing strings
+// for a single-char trim on the line buffer hot path.
+func trimNewline(s string) string {
+	if len(s) > 0 && s[len(s)-1] == '\n' {
+		return s[:len(s)-1]
+	}
+
+	return s
 }

--- a/internal/updater/manual.go
+++ b/internal/updater/manual.go
@@ -15,40 +15,22 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 )
 
-// InstallerURL is the canonical location of installer.sh. The file at this
-// URL is the same one shipped at install/installer.sh in this repo —
-// reusing it instead of duplicating download / GAR-fallback / checksum logic
-// keeps the update flow in lockstep with the install flow.
 const InstallerURL = "https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh"
 
-// DownloadTimeout caps the installer.sh fetch. The script itself is small
-// (<10 KB); a short timeout makes a network blip surface as an error fast.
 const DownloadTimeout = 10 * time.Second
 
-// MaxInstallerBytes caps how much we'll read from the installer URL. The
-// real script is well under 100 KiB — 1 MiB is two orders of magnitude
-// safety margin while still bounding the worst case if a hostile / broken
-// origin streams gigabytes into os.TempDir.
+// MaxInstallerBytes — the real script is <100 KiB; 1 MiB is a wide safety margin against hostile origins.
 const MaxInstallerBytes = 1 << 20
 
-// ManualOptions bundles the inputs ManualUpgrade needs.
 type ManualOptions struct {
-	// Bindir passed to installer.sh via `-b`. Required.
-	Bindir string
-	// Logger receives progress messages and line-buffered subprocess output.
-	Logger log.Logger
-	// InstallerURL overrides the canonical URL for tests.
+	Bindir       string
+	Logger       log.Logger
 	InstallerURL string
-	// HTTPClient overrides the default 10s-timeout client.
-	HTTPClient *http.Client
-	// Shell is the program to invoke installer.sh with. Empty = "/bin/sh".
-	Shell string
-	// DryRun downloads the installer but doesn't execute it.
-	DryRun bool
+	HTTPClient   *http.Client
+	Shell        string
+	DryRun       bool
 }
 
-// ManualUpgrade downloads installer.sh and runs it against the bindir of the running binary.
-// Returns the local path of the downloaded installer.
 func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 	if opts.Bindir == "" {
 		return "", errors.New("bindir is required for manual upgrade")
@@ -72,7 +54,6 @@ func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 	}
 
 	if opts.DryRun {
-		// Leave the script on disk — the printed manual-upgrade command references it.
 		opts.Logger.Infof("Dry run — installer downloaded to %s but NOT executed.", scriptPath)
 		opts.Logger.Infof("To upgrade manually: %s %s -b %s", opts.Shell, scriptPath, opts.Bindir)
 
@@ -89,7 +70,7 @@ func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 	cmd.Stderr = pipe
 
 	if err := cmd.Run(); err != nil {
-		// Keep the script on disk on failure so the user can re-run it manually to debug.
+		// Script stays on disk on failure so the user can re-run it manually to debug.
 		return scriptPath, fmt.Errorf("run installer.sh: %w", err)
 	}
 
@@ -121,9 +102,7 @@ func downloadInstaller(ctx context.Context, client *http.Client, url string) (st
 
 	defer func() { _ = resp.Body.Close() }()
 
-	// Strict 2xx range. Status / 100 == 2 (used previously) would silently
-	// accept a 3xx redirect Go's client failed to follow — that produces an
-	// HTML body that would go on to be exec'd as a shell script.
+	// Strict 2xx — a 3xx HTML body that Go's client failed to follow would otherwise be exec'd as a shell script.
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return "", fmt.Errorf("download installer.sh: server responded %d", resp.StatusCode)
 	}
@@ -133,9 +112,7 @@ func downloadInstaller(ctx context.Context, client *http.Client, url string) (st
 		return "", fmt.Errorf("create installer temp file: %w", err)
 	}
 
-	// LimitReader caps the body at MaxInstallerBytes so a hostile / broken
-	// origin can't stream gigabytes into os.TempDir. We additionally check
-	// whether the cap was actually hit (n == cap+1) by reading one extra byte.
+	// Cap+1 byte lets us detect cap-hit via n > MaxInstallerBytes below.
 	limited := io.LimitReader(resp.Body, MaxInstallerBytes+1)
 
 	n, err := io.Copy(tmp, limited)
@@ -166,13 +143,10 @@ func downloadInstaller(ctx context.Context, client *http.Client, url string) (st
 	return tmp.Name(), nil
 }
 
-// BindirOf returns the directory of the supplied executable path — the value
-// to pass installer.sh's -b flag so the upgrade lands in the same spot.
 func BindirOf(executable string) string {
 	return filepath.Dir(executable)
 }
 
-// loggerWriter line-buffers its input and emits each complete line via logger.Printf.
 type loggerWriter struct {
 	logger log.Logger
 	buf    bytes.Buffer
@@ -188,20 +162,17 @@ func (w *loggerWriter) Write(p []byte) (int, error) {
 	for {
 		line, err := w.buf.ReadString('\n')
 		if errors.Is(err, io.EOF) {
-			// Incomplete trailing line — buffer it and wait for more.
 			w.buf.WriteString(line)
 
 			break
 		}
 
-		// Strip trailing newline; logger.Printf adds its own.
 		w.logger.Printf("%s", trimNewline(line))
 	}
 
 	return len(p), nil
 }
 
-// Flush emits any remaining buffered partial line. Call after the subprocess exits.
 func (w *loggerWriter) Flush() {
 	if w.buf.Len() == 0 {
 		return

--- a/internal/updater/manual.go
+++ b/internal/updater/manual.go
@@ -84,7 +84,7 @@ func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 
 	opts.Logger.Donef("Upgrade complete.")
 
-	return scriptPath, nil
+	return "", nil
 }
 
 func downloadInstaller(ctx context.Context, client *http.Client, url string) (string, error) {

--- a/internal/updater/manual.go
+++ b/internal/updater/manual.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"time"
 
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -143,10 +142,6 @@ func downloadInstaller(ctx context.Context, client *http.Client, url string) (st
 	}
 
 	return tmp.Name(), nil
-}
-
-func BindirOf(executable string) string {
-	return filepath.Dir(executable)
 }
 
 type loggerWriter struct {

--- a/internal/updater/manual.go
+++ b/internal/updater/manual.go
@@ -31,36 +31,24 @@ const DownloadTimeout = 10 * time.Second
 // origin streams gigabytes into os.TempDir.
 const MaxInstallerBytes = 1 << 20
 
-// ManualOptions bundles the inputs ManualUpgrade needs. Kept as a struct so
-// tests can override URL / HTTP client / shell / logger.
+// ManualOptions bundles the inputs ManualUpgrade needs.
 type ManualOptions struct {
-	// Bindir is the directory containing the running binary — passed to
-	// installer.sh via `-b`. Required.
+	// Bindir passed to installer.sh via `-b`. Required.
 	Bindir string
-	// Logger receives our own progress / completion messages AND the
-	// subprocess stdout/stderr (line-buffered via the loggerWriter adapter
-	// below). Tests pass log.NewLogger(log.WithOutput(&buf)); production
-	// passes a stderr-backed logger.
+	// Logger receives progress messages and line-buffered subprocess output.
 	Logger log.Logger
-	// InstallerURL overrides the canonical URL for tests. Empty = use
-	// InstallerURL constant.
+	// InstallerURL overrides the canonical URL for tests.
 	InstallerURL string
-	// HTTPClient is the network client. Empty = default 10s-timeout client.
+	// HTTPClient overrides the default 10s-timeout client.
 	HTTPClient *http.Client
 	// Shell is the program to invoke installer.sh with. Empty = "/bin/sh".
 	Shell string
-	// DryRun, when true, downloads the installer but doesn't execute it.
-	// Returns the path of the downloaded script so the caller can show it.
+	// DryRun downloads the installer but doesn't execute it.
 	DryRun bool
 }
 
-// ManualUpgrade downloads installer.sh and runs it against the bindir of the
-// running binary. installer.sh handles tarball download, checksum
-// verification, and atomic replacement of the binary internally — we just
-// drive it.
-//
-// Returns the local path of the downloaded installer (useful for diagnostics
-// and the DryRun case).
+// ManualUpgrade downloads installer.sh and runs it against the bindir of the running binary.
+// Returns the local path of the downloaded installer.
 func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 	if opts.Bindir == "" {
 		return "", errors.New("bindir is required for manual upgrade")
@@ -84,9 +72,7 @@ func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 	}
 
 	if opts.DryRun {
-		// Dry run intentionally leaves the script on disk — the printed
-		// "To upgrade manually" command references it, so removing it would
-		// break copy-paste. Caller / user cleans up when done.
+		// Leave the script on disk — the printed manual-upgrade command references it.
 		opts.Logger.Infof("Dry run — installer downloaded to %s but NOT executed.", scriptPath)
 		opts.Logger.Infof("To upgrade manually: %s %s -b %s", opts.Shell, scriptPath, opts.Bindir)
 
@@ -95,9 +81,6 @@ func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 
 	opts.Logger.Infof("Running installer to upgrade CLI in %s ...", opts.Bindir)
 
-	// loggerWriter buffers subprocess output until newlines so logger.Printf
-	// emits one line per installer.sh log entry, preserving the user-visible
-	// progress stream while flowing through the same logger.
 	pipe := newLoggerWriter(opts.Logger)
 	defer pipe.Flush()
 
@@ -106,13 +89,10 @@ func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 	cmd.Stderr = pipe
 
 	if err := cmd.Run(); err != nil {
-		// Keep the script on disk on failure so the user can re-run it
-		// manually with the same args to debug what went wrong.
+		// Keep the script on disk on failure so the user can re-run it manually to debug.
 		return scriptPath, fmt.Errorf("run installer.sh: %w", err)
 	}
 
-	// Success — drop the temp file. Best-effort; if removal fails the OS will
-	// clean it up on next reboot (os.TempDir).
 	if removeErr := os.Remove(scriptPath); removeErr != nil {
 		opts.Logger.Warnf("could not clean up installer temp file %s: %s", scriptPath, removeErr)
 	}
@@ -192,10 +172,7 @@ func BindirOf(executable string) string {
 	return filepath.Dir(executable)
 }
 
-// loggerWriter is an io.Writer that line-buffers its input and emits each
-// complete line via logger.Printf. Used to plumb subprocess stdout/stderr
-// through the project logger — exec.Cmd needs an io.Writer but the rest of
-// the package uses log.Logger.
+// loggerWriter line-buffers its input and emits each complete line via logger.Printf.
 type loggerWriter struct {
 	logger log.Logger
 	buf    bytes.Buffer
@@ -224,8 +201,7 @@ func (w *loggerWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// Flush emits any remaining buffered partial line. Call after the
-// subprocess exits to avoid losing a no-trailing-newline final line.
+// Flush emits any remaining buffered partial line. Call after the subprocess exits.
 func (w *loggerWriter) Flush() {
 	if w.buf.Len() == 0 {
 		return
@@ -235,8 +211,6 @@ func (w *loggerWriter) Flush() {
 	w.buf.Reset()
 }
 
-// trimNewline drops one trailing \n if present. Avoids importing strings
-// for a single-char trim on the line buffer hot path.
 func trimNewline(s string) string {
 	if len(s) > 0 && s[len(s)-1] == '\n' {
 		return s[:len(s)-1]

--- a/internal/updater/manual.go
+++ b/internal/updater/manual.go
@@ -34,8 +34,9 @@ type ManualOptions struct {
 	// Bindir is the directory containing the running binary — passed to
 	// installer.sh via `-b`. Required.
 	Bindir string
-	// Out is where progress / completion messages go. Stderr in production
-	// (keeps stdout clean for JSON consumers).
+	// Out is where progress / completion messages go. The CLI's update
+	// subcommand passes cmd.OutOrStdout() so the user sees the upgrade
+	// log inline; tests inject a bytes.Buffer.
 	Out io.Writer
 	// InstallerURL overrides the canonical URL for tests. Empty = use
 	// InstallerURL constant.
@@ -80,6 +81,9 @@ func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 	}
 
 	if opts.DryRun {
+		// Dry run intentionally leaves the script on disk — the printed
+		// "To upgrade manually" command references it, so removing it would
+		// break copy-paste. Caller / user cleans up when done.
 		fmt.Fprintf(opts.Out, "Dry run — installer downloaded to %s but NOT executed.\n", scriptPath)
 		fmt.Fprintf(opts.Out, "To upgrade manually: %s %s -b %s\n", opts.Shell, scriptPath, opts.Bindir)
 
@@ -93,7 +97,15 @@ func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 	cmd.Stderr = opts.Out
 
 	if err := cmd.Run(); err != nil {
+		// Keep the script on disk on failure so the user can re-run it
+		// manually with the same args to debug what went wrong.
 		return scriptPath, fmt.Errorf("run installer.sh: %w", err)
+	}
+
+	// Success — drop the temp file. Best-effort; if removal fails the OS will
+	// clean it up on next reboot (os.TempDir).
+	if removeErr := os.Remove(scriptPath); removeErr != nil {
+		fmt.Fprintf(opts.Out, "warning: could not clean up installer temp file %s: %s\n", scriptPath, removeErr)
 	}
 
 	fmt.Fprintln(opts.Out, "Upgrade complete.")

--- a/internal/updater/manual.go
+++ b/internal/updater/manual.go
@@ -1,7 +1,6 @@
 package updater
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,6 +11,8 @@ import (
 	"time"
 
 	"github.com/bitrise-io/go-utils/v2/log"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/logio"
 )
 
 const InstallerURL = "https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh"
@@ -61,7 +62,7 @@ func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
 
 	opts.Logger.Infof("Running installer to upgrade CLI in %s ...", opts.Bindir)
 
-	pipe := newLoggerWriter(opts.Logger)
+	pipe := logio.NewWriter(opts.Logger)
 	defer pipe.Flush()
 
 	cmd := exec.CommandContext(ctx, opts.Shell, scriptPath, "-b", opts.Bindir) //nolint:gosec // scriptPath is our temp file we just wrote
@@ -142,47 +143,4 @@ func downloadInstaller(ctx context.Context, client *http.Client, url string) (st
 	}
 
 	return tmp.Name(), nil
-}
-
-type loggerWriter struct {
-	logger log.Logger
-	buf    bytes.Buffer
-}
-
-func newLoggerWriter(logger log.Logger) *loggerWriter {
-	return &loggerWriter{logger: logger}
-}
-
-func (w *loggerWriter) Write(p []byte) (int, error) {
-	w.buf.Write(p)
-
-	for {
-		line, err := w.buf.ReadString('\n')
-		if errors.Is(err, io.EOF) {
-			w.buf.WriteString(line)
-
-			break
-		}
-
-		w.logger.Printf("%s", trimNewline(line))
-	}
-
-	return len(p), nil
-}
-
-func (w *loggerWriter) Flush() {
-	if w.buf.Len() == 0 {
-		return
-	}
-
-	w.logger.Printf("%s", trimNewline(w.buf.String()))
-	w.buf.Reset()
-}
-
-func trimNewline(s string) string {
-	if len(s) > 0 && s[len(s)-1] == '\n' {
-		return s[:len(s)-1]
-	}
-
-	return s
 }

--- a/internal/updater/manual.go
+++ b/internal/updater/manual.go
@@ -137,6 +137,8 @@ func downloadInstaller(ctx context.Context, client *http.Client, url string) (st
 	}
 
 	if err := os.Chmod(tmp.Name(), 0o700); err != nil { //nolint:gosec // intentional: script must be readable + executable
+		_ = os.Remove(tmp.Name())
+
 		return "", fmt.Errorf("chmod installer temp: %w", err)
 	}
 

--- a/internal/updater/manual.go
+++ b/internal/updater/manual.go
@@ -1,0 +1,153 @@
+package updater
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// InstallerURL is the canonical location of installer.sh. The file at this
+// URL is the same one shipped at install/installer.sh in this repo —
+// reusing it instead of duplicating download / GAR-fallback / checksum logic
+// keeps the update flow in lockstep with the install flow.
+const InstallerURL = "https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh"
+
+// DownloadTimeout caps the installer.sh fetch. The script itself is small
+// (<10 KB); a short timeout makes a network blip surface as an error fast.
+const DownloadTimeout = 10 * time.Second
+
+// ManualOptions bundles the inputs ManualUpgrade needs. Kept as a struct so
+// tests can override URL / HTTP client / shell / output writer.
+type ManualOptions struct {
+	// Bindir is the directory containing the running binary — passed to
+	// installer.sh via `-b`. Required.
+	Bindir string
+	// Out is where progress / completion messages go. Stderr in production
+	// (keeps stdout clean for JSON consumers).
+	Out io.Writer
+	// InstallerURL overrides the canonical URL for tests. Empty = use
+	// InstallerURL constant.
+	InstallerURL string
+	// HTTPClient is the network client. Empty = default 10s-timeout client.
+	HTTPClient *http.Client
+	// Shell is the program to invoke installer.sh with. Empty = "/bin/sh".
+	Shell string
+	// DryRun, when true, downloads the installer but doesn't execute it.
+	// Returns the path of the downloaded script so the caller can show it.
+	DryRun bool
+}
+
+// ManualUpgrade downloads installer.sh and runs it against the bindir of the
+// running binary. installer.sh handles tarball download, checksum
+// verification, and atomic replacement of the binary internally — we just
+// drive it.
+//
+// Returns the local path of the downloaded installer (useful for diagnostics
+// and the DryRun case). The file is left on disk under os.TempDir() so a
+// later debug pass can re-run it; it's tiny.
+func ManualUpgrade(ctx context.Context, opts ManualOptions) (string, error) {
+	if opts.Bindir == "" {
+		return "", errors.New("bindir is required for manual upgrade")
+	}
+
+	if opts.Out == nil {
+		opts.Out = os.Stderr
+	}
+
+	if opts.InstallerURL == "" {
+		opts.InstallerURL = InstallerURL
+	}
+
+	if opts.Shell == "" {
+		opts.Shell = "/bin/sh"
+	}
+
+	scriptPath, err := downloadInstaller(ctx, opts.HTTPClient, opts.InstallerURL)
+	if err != nil {
+		return "", err
+	}
+
+	if opts.DryRun {
+		fmt.Fprintf(opts.Out, "Dry run — installer downloaded to %s but NOT executed.\n", scriptPath)
+		fmt.Fprintf(opts.Out, "To upgrade manually: %s %s -b %s\n", opts.Shell, scriptPath, opts.Bindir)
+
+		return scriptPath, nil
+	}
+
+	fmt.Fprintf(opts.Out, "Running installer to upgrade CLI in %s ...\n", opts.Bindir)
+
+	cmd := exec.CommandContext(ctx, opts.Shell, scriptPath, "-b", opts.Bindir) //nolint:gosec // scriptPath is our temp file we just wrote
+	cmd.Stdout = opts.Out
+	cmd.Stderr = opts.Out
+
+	if err := cmd.Run(); err != nil {
+		return scriptPath, fmt.Errorf("run installer.sh: %w", err)
+	}
+
+	fmt.Fprintln(opts.Out, "Upgrade complete.")
+
+	return scriptPath, nil
+}
+
+func downloadInstaller(ctx context.Context, client *http.Client, url string) (string, error) {
+	if client == nil {
+		client = &http.Client{Timeout: DownloadTimeout}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build installer request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "bitrise-build-cache-cli/update")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download installer.sh: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("download installer.sh: server responded %d", resp.StatusCode)
+	}
+
+	tmp, err := os.CreateTemp("", "bitrise-build-cache-installer-*.sh")
+	if err != nil {
+		return "", fmt.Errorf("create installer temp file: %w", err)
+	}
+
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+
+		return "", fmt.Errorf("write installer to temp: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+
+		return "", fmt.Errorf("close installer temp file: %w", err)
+	}
+
+	// installer.sh is sh-piped in production; making the file executable
+	// keeps the local invocation form available too if a future caller wants
+	// to skip the explicit shell.
+	if err := os.Chmod(tmp.Name(), 0o700); err != nil { //nolint:gosec // intentional: script must be readable + executable
+		return "", fmt.Errorf("chmod installer temp: %w", err)
+	}
+
+	return tmp.Name(), nil
+}
+
+// BindirOf returns the directory of the supplied executable path — the value
+// to pass installer.sh's -b flag so the upgrade lands in the same spot.
+func BindirOf(executable string) string {
+	return filepath.Dir(executable)
+}

--- a/internal/updater/manual_test.go
+++ b/internal/updater/manual_test.go
@@ -14,9 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestManualUpgrade_dryRunDownloadsButDoesntExecute(t *testing.T) {
-	// Fake "installer" — just enough to look like a shell script. Body is a
-	// `true` so a tester executing it later would see exit 0.
+func TestManualUpgrade_dryRunCleansUpAndDoesntExecute(t *testing.T) {
+	tempDirBefore, err := os.ReadDir(os.TempDir())
+	require.NoError(t, err)
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("#!/bin/sh\ntrue\n"))
 	}))
@@ -31,13 +32,25 @@ func TestManualUpgrade_dryRunDownloadsButDoesntExecute(t *testing.T) {
 		DryRun:       true,
 	})
 	require.NoError(t, err)
-	require.FileExists(t, path)
-	defer func() { _ = os.Remove(path) }()
-
-	body, err := os.ReadFile(path) //nolint:gosec // test temp file
-	require.NoError(t, err)
-	assert.Contains(t, string(body), "true")
+	assert.Empty(t, path, "dry run returns no path — temp file is cleaned up")
 	assert.Contains(t, buf.String(), "Dry run")
+
+	tempDirAfter, err := os.ReadDir(os.TempDir())
+	require.NoError(t, err)
+	assert.Equal(t, countMatching(tempDirBefore, "bitrise-build-cache-installer-"),
+		countMatching(tempDirAfter, "bitrise-build-cache-installer-"),
+		"dry run must not leave installer temp files behind")
+}
+
+func countMatching(entries []os.DirEntry, prefix string) int {
+	n := 0
+	for _, e := range entries {
+		if len(e.Name()) >= len(prefix) && e.Name()[:len(prefix)] == prefix {
+			n++
+		}
+	}
+
+	return n
 }
 
 func TestManualUpgrade_executesInstallerAgainstBindir(t *testing.T) {

--- a/internal/updater/manual_test.go
+++ b/internal/updater/manual_test.go
@@ -1,0 +1,102 @@
+//go:build unit
+
+package updater
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManualUpgrade_dryRunDownloadsButDoesntExecute(t *testing.T) {
+	// Fake "installer" — just enough to look like a shell script. Body is a
+	// `true` so a tester executing it later would see exit 0.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("#!/bin/sh\ntrue\n"))
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	path, err := ManualUpgrade(context.Background(), ManualOptions{
+		Bindir:       t.TempDir(),
+		Out:          &buf,
+		InstallerURL: srv.URL,
+		HTTPClient:   srv.Client(),
+		DryRun:       true,
+	})
+	require.NoError(t, err)
+	require.FileExists(t, path)
+	defer func() { _ = os.Remove(path) }()
+
+	body, err := os.ReadFile(path) //nolint:gosec // test temp file
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "true")
+	assert.Contains(t, buf.String(), "Dry run")
+}
+
+func TestManualUpgrade_executesInstallerAgainstBindir(t *testing.T) {
+	bindir := t.TempDir()
+
+	// Installer body writes a marker file to bindir/marker so the test can
+	// observe that the script was executed AND received the -b flag.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("#!/bin/sh\nset -e\nbindir=\"\"\nwhile getopts \"b:\" opt; do case $opt in b) bindir=$OPTARG ;; esac; done\necho INSTALLED > \"$bindir/marker\"\n"))
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	_, err := ManualUpgrade(context.Background(), ManualOptions{
+		Bindir:       bindir,
+		Out:          &buf,
+		InstallerURL: srv.URL,
+		HTTPClient:   srv.Client(),
+	})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Upgrade complete")
+
+	body, err := os.ReadFile(bindir + "/marker") //nolint:gosec // test bindir
+	require.NoError(t, err)
+	assert.Equal(t, "INSTALLED\n", string(body))
+}
+
+func TestManualUpgrade_requiresBindir(t *testing.T) {
+	_, err := ManualUpgrade(context.Background(), ManualOptions{})
+	require.Error(t, err)
+}
+
+func TestManualUpgrade_propagatesHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	_, err := ManualUpgrade(context.Background(), ManualOptions{
+		Bindir:       t.TempDir(),
+		Out:          &bytes.Buffer{},
+		InstallerURL: srv.URL,
+		HTTPClient:   srv.Client(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "503")
+}
+
+func TestManualUpgrade_failingInstallerSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("#!/bin/sh\nexit 17\n"))
+	}))
+	defer srv.Close()
+
+	_, err := ManualUpgrade(context.Background(), ManualOptions{
+		Bindir:       t.TempDir(),
+		Out:          &bytes.Buffer{},
+		InstallerURL: srv.URL,
+		HTTPClient:   srv.Client(),
+	})
+	require.Error(t, err)
+}

--- a/internal/updater/manual_test.go
+++ b/internal/updater/manual_test.go
@@ -100,3 +100,49 @@ func TestManualUpgrade_failingInstallerSurfaces(t *testing.T) {
 	})
 	require.Error(t, err)
 }
+
+func TestManualUpgrade_rejectsOversizeInstaller(t *testing.T) {
+	// Hostile origin streams 2 MiB. Download must abort instead of writing
+	// the whole thing into os.TempDir.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(bytes.Repeat([]byte("X"), 2*MaxInstallerBytes))
+	}))
+	defer srv.Close()
+
+	_, err := ManualUpgrade(context.Background(), ManualOptions{
+		Bindir:       t.TempDir(),
+		Out:          &bytes.Buffer{},
+		InstallerURL: srv.URL,
+		HTTPClient:   srv.Client(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+func TestManualUpgrade_rejectsNon2xxStatusIncludingRedirect(t *testing.T) {
+	// Server emits a 301 with HTML body. The strict <200||>=300 check keeps
+	// us from executing an HTML page as a shell script when an upstream
+	// network appliance returns 3xx and the client isn't configured to
+	// follow it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusMovedPermanently)
+		_, _ = w.Write([]byte("<html>moved</html>"))
+	}))
+	defer srv.Close()
+
+	noRedirect := &http.Client{
+		Transport: srv.Client().Transport,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	_, err := ManualUpgrade(context.Background(), ManualOptions{
+		Bindir:       t.TempDir(),
+		Out:          &bytes.Buffer{},
+		InstallerURL: srv.URL,
+		HTTPClient:   noRedirect,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "301")
+}

--- a/internal/updater/manual_test.go
+++ b/internal/updater/manual_test.go
@@ -25,7 +25,7 @@ func TestManualUpgrade_dryRunDownloadsButDoesntExecute(t *testing.T) {
 	var buf bytes.Buffer
 	path, err := ManualUpgrade(context.Background(), ManualOptions{
 		Bindir:       t.TempDir(),
-		Out:          &buf,
+		Logger:       loggerWithBuffer(&buf),
 		InstallerURL: srv.URL,
 		HTTPClient:   srv.Client(),
 		DryRun:       true,
@@ -53,7 +53,7 @@ func TestManualUpgrade_executesInstallerAgainstBindir(t *testing.T) {
 	var buf bytes.Buffer
 	_, err := ManualUpgrade(context.Background(), ManualOptions{
 		Bindir:       bindir,
-		Out:          &buf,
+		Logger:       loggerWithBuffer(&buf),
 		InstallerURL: srv.URL,
 		HTTPClient:   srv.Client(),
 	})
@@ -78,7 +78,7 @@ func TestManualUpgrade_propagatesHTTPError(t *testing.T) {
 
 	_, err := ManualUpgrade(context.Background(), ManualOptions{
 		Bindir:       t.TempDir(),
-		Out:          &bytes.Buffer{},
+		Logger:       loggerWithBuffer(&bytes.Buffer{}),
 		InstallerURL: srv.URL,
 		HTTPClient:   srv.Client(),
 	})
@@ -94,7 +94,7 @@ func TestManualUpgrade_failingInstallerSurfaces(t *testing.T) {
 
 	_, err := ManualUpgrade(context.Background(), ManualOptions{
 		Bindir:       t.TempDir(),
-		Out:          &bytes.Buffer{},
+		Logger:       loggerWithBuffer(&bytes.Buffer{}),
 		InstallerURL: srv.URL,
 		HTTPClient:   srv.Client(),
 	})
@@ -111,7 +111,7 @@ func TestManualUpgrade_rejectsOversizeInstaller(t *testing.T) {
 
 	_, err := ManualUpgrade(context.Background(), ManualOptions{
 		Bindir:       t.TempDir(),
-		Out:          &bytes.Buffer{},
+		Logger:       loggerWithBuffer(&bytes.Buffer{}),
 		InstallerURL: srv.URL,
 		HTTPClient:   srv.Client(),
 	})
@@ -139,7 +139,7 @@ func TestManualUpgrade_rejectsNon2xxStatusIncludingRedirect(t *testing.T) {
 
 	_, err := ManualUpgrade(context.Background(), ManualOptions{
 		Bindir:       t.TempDir(),
-		Out:          &bytes.Buffer{},
+		Logger:       loggerWithBuffer(&bytes.Buffer{}),
 		InstallerURL: srv.URL,
 		HTTPClient:   noRedirect,
 	})

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/file"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/gradle"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/reactnative"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/update"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode"
 )
 


### PR DESCRIPTION
**Stacked on #362 (D3). GitHub will auto-retarget down the chain as parents merge.**

## Summary

Adds \`bitrise-build-cache update\` which detects install method (brew vs manual) and runs the matching upgrade flow.

### Brew install
Prints \`brew update && brew upgrade bitrise-io/tools/bitrise-build-cache-cli\`. We don't invoke brew from inside its own Cellar to avoid lock clashes — let the user run it from their shell.

### Manual install
Downloads the canonical \`installer.sh\` from \`raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh\` and runs it as \`/bin/sh installer.sh -b <bindir>\` where bindir is the directory of the running binary. installer.sh already handles tarball download / checksum verify / GAR fallback / atomic replace — we just drive it instead of duplicating that logic.

### Unknown install method
Prints the generic re-install command so the user has a path forward.

### Post-upgrade hint
After a successful manual upgrade, if a daemon plist (ACI-5030) or systemd unit (ACI-5031) is on disk, prints a one-line nudge to run \`bitrise-build-cache daemon restart\`.

### Flags
\`--dry-run\` downloads installer.sh to a temp file and prints the exec command without running it.

## Closes the D-series loop

D1's nudge text (#361) already says "Run \`bitrise-build-cache update\` ..." — this PR is the subcommand it points at.

## Test plan

- [x] \`make check\` passes (lint-fix + unit tests).
- [x] Install-method detection truth-table covers brew prefixes (Apple Silicon, Intel, Linuxbrew shared + per-user) and manual paths.
- [x] Manual upgrade end-to-end test runs against \`httptest\` server serving a fake installer that writes a marker file.
- [x] Dry-run test confirms script is downloaded but not executed.
- [x] Daemon detection test covers both LaunchAgent + systemd unit paths.
- [ ] Manual: local \`bitrise-build-cache update --dry-run\` — verify the install method detection lands on the right side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)