### PR TITLE
feat: ACI-5041 + ACI-5042 xcode-app enable/disable

### DIFF
--- a/cmd/xcode_app/disable.go
+++ b/cmd/xcode_app/disable.go
@@ -1,0 +1,52 @@
+package xcode_app
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	xapkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/xcode_app"
+)
+
+//nolint:gochecknoglobals
+var disableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable the Bitrise Build Cache override for Xcode.app GUI builds",
+	Long: `disable reverses ` + "`xcode-app enable`" + `: boots out the LaunchAgent, removes its plist, ` +
+		`removes the override xcconfig under ~/.bitrise-xcelerate/, and restores the prior XCODE_XCCONFIG_FILE ` +
+		`environment value (if one was captured at enable time). Idempotent — safe to run when not enabled.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+
+		activator := &xapkg.Activator{Logger: logger}
+
+		result, err := activator.Disable(cmd.Context())
+		if err != nil {
+			if errors.Is(err, xapkg.ErrUnsupportedPlatform) {
+				return err //nolint:wrapcheck // sentinel
+			}
+
+			return fmt.Errorf("xcode-app disable: %w", err)
+		}
+
+		if result.LaunchAgentRemoved {
+			logger.Donef("Removed LaunchAgent + xcconfig override")
+		}
+
+		if result.RestoredXCConfigPath != "" {
+			logger.Infof("Restored prior XCODE_XCCONFIG_FILE: %s", result.RestoredXCConfigPath)
+		} else {
+			logger.Infof("Cleared XCODE_XCCONFIG_FILE (no prior override to restore)")
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	xcodeAppCmd.AddCommand(disableCmd)
+}

--- a/cmd/xcode_app/enable.go
+++ b/cmd/xcode_app/enable.go
@@ -1,0 +1,63 @@
+package xcode_app
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	xapkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/xcode_app"
+)
+
+//nolint:gochecknoglobals
+var enableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable the Bitrise Build Cache override for Xcode.app GUI builds",
+	Long: `enable writes the override xcconfig (~/.bitrise-xcelerate/xcode-app.xcconfig), runs ` +
+		"`launchctl setenv XCODE_XCCONFIG_FILE` " +
+		`so future Xcode.app launches pick it up, registers a LaunchAgent that re-applies the override on every login, ` +
+		`and starts the xcelerate-proxy daemon service. ` +
+		`If you already have ` + "`XCODE_XCCONFIG_FILE`" + ` set, your previous file is chained in via ` + "`#include`" + `. ` +
+		`Detects running Xcode and nudges you to relaunch so the new env takes effect. ` +
+		`Run ` + "`bitrise-build-cache activate xcode`" + ` first to write the xcelerate config that supplies the proxy socket path.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+
+		activator := &xapkg.Activator{
+			Logger: logger,
+			Envs:   utils.AllEnvs(),
+		}
+
+		result, err := activator.Enable(cmd.Context())
+		if err != nil {
+			if errors.Is(err, xapkg.ErrUnsupportedPlatform) || errors.Is(err, xapkg.ErrXcelerateNotConfigured) {
+				return err //nolint:wrapcheck // sentinel
+			}
+
+			return fmt.Errorf("xcode-app enable: %w", err)
+		}
+
+		logger.Donef("Wrote override xcconfig: %s", result.XCConfigPath)
+		if result.PreviousXCConfigPath != "" {
+			logger.Infof("Chained previous XCODE_XCCONFIG_FILE: %s", result.PreviousXCConfigPath)
+		}
+		logger.Donef("Set XCODE_XCCONFIG_FILE via launchctl (LaunchAgent: %s)", result.LaunchAgentPlistPath)
+		logger.Donef("Proxy socket: %s", result.XcelerateProxySocket)
+
+		if len(result.RunningXcodePIDs) > 0 {
+			logger.Warnf("Xcode is currently running (pid %v). Quit and relaunch Xcode to pick up the cache override.", result.RunningXcodePIDs)
+		} else {
+			logger.Infof("Next launch of Xcode will pick up the override.")
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	xcodeAppCmd.AddCommand(enableCmd)
+}

--- a/cmd/xcode_app/xcode_app.go
+++ b/cmd/xcode_app/xcode_app.go
@@ -1,0 +1,26 @@
+// Package xcode_app exposes CLI subcommands that enable / disable the
+// Bitrise Build Cache override for Xcode.app (GUI) builds.
+//
+// The implementation lives in pkg/xcode_app and internal/xcode_app. This
+// package is a thin cobra wrapper.
+package xcode_app
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+)
+
+//nolint:gochecknoglobals
+var xcodeAppCmd = &cobra.Command{
+	Use:   "xcode-app",
+	Short: "Enable / disable the Bitrise Build Cache override for Xcode.app GUI builds",
+	Long: `xcode-app configures Xcode.app (the GUI application) to use the Bitrise Build Cache by writing ` +
+		`an override xcconfig under ~/.bitrise-xcelerate/ and pointing XCODE_XCCONFIG_FILE at it via launchctl. ` +
+		`This complements ` + "`xcodebuild`" + ` activation, which only affects command-line builds. ` +
+		`macOS only.`,
+}
+
+func init() {
+	common.RootCmd.AddCommand(xcodeAppCmd)
+}

--- a/cmd/xcode_app/xcode_app.go
+++ b/cmd/xcode_app/xcode_app.go
@@ -1,8 +1,3 @@
-// Package xcode_app exposes CLI subcommands that enable / disable the
-// Bitrise Build Cache override for Xcode.app (GUI) builds.
-//
-// The implementation lives in pkg/xcode_app and internal/xcode_app. This
-// package is a thin cobra wrapper.
 package xcode_app
 
 import (

--- a/internal/xcode_app/launch_agent.go
+++ b/internal/xcode_app/launch_agent.go
@@ -1,0 +1,122 @@
+package xcode_app
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SetenvAgentLabel is the LaunchAgent label we install to make the
+// XCODE_XCCONFIG_FILE setenv survive logout. Distinct from the daemon's
+// xcelerate-proxy label so wholesale uninstall of one doesn't disturb the
+// other.
+const SetenvAgentLabel = "io.bitrise.build-cache.xcode-app-setenv"
+
+// SetenvAgentPlistRelative is the LaunchAgent plist filename — same as
+// SetenvAgentLabel with `.plist` appended.
+const SetenvAgentPlistRelative = "Library/LaunchAgents/" + SetenvAgentLabel + ".plist"
+
+// SetenvAgentPlistPath returns the absolute path of our setenv LaunchAgent
+// plist under ~/Library/LaunchAgents/.
+func SetenvAgentPlistPath(home string) string {
+	return filepath.Join(home, SetenvAgentPlistRelative)
+}
+
+// setenvPlistTemplate is the LaunchAgent body. RunAtLoad=true fires once at
+// login; KeepAlive=false (the default — we omit the key) lets the one-shot
+// `launchctl setenv` call exit cleanly without a restart loop. The agent
+// re-applies our XCODE_XCCONFIG_FILE override on every login, which is the
+// whole point of the file.
+//
+// We write the launchctl call verbatim rather than chain through `sh -c …`
+// to avoid quoting hazards on paths with spaces.
+const setenvPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>%s</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>%s</string>
+		<string>setenv</string>
+		<string>%s</string>
+		<string>%s</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+</dict>
+</plist>
+`
+
+// RenderSetenvAgent returns the LaunchAgent plist body that re-runs
+// `launchctl setenv XCODE_XCCONFIG_FILE <xcconfigPath>` at every login.
+func RenderSetenvAgent(xcconfigPath string) (string, error) {
+	if strings.TrimSpace(xcconfigPath) == "" {
+		return "", errors.New("xcconfig path is empty")
+	}
+
+	return fmt.Sprintf(
+		setenvPlistTemplate,
+		xmlEscape(SetenvAgentLabel),
+		xmlEscape(LaunchctlBin),
+		xmlEscape(XCConfigEnvVar),
+		xmlEscape(xcconfigPath),
+	), nil
+}
+
+// WriteSetenvAgent renders and writes our LaunchAgent plist. mkdir the
+// ~/Library/LaunchAgents directory if missing — fresh user accounts don't
+// always have it.
+func WriteSetenvAgent(home, xcconfigPath string) (string, error) {
+	body, err := RenderSetenvAgent(xcconfigPath)
+	if err != nil {
+		return "", err
+	}
+
+	path := SetenvAgentPlistPath(home)
+	dir := filepath.Dir(path)
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil { //nolint:gosec // plist must be world-readable for launchctl
+		return "", fmt.Errorf("write %s: %w", path, err)
+	}
+
+	return path, nil
+}
+
+// RemoveSetenvAgent removes the LaunchAgent plist. Missing file is treated
+// as success so `disable` is idempotent.
+func RemoveSetenvAgent(home string) (string, error) {
+	path := SetenvAgentPlistPath(home)
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return path, fmt.Errorf("remove %s: %w", path, err)
+	}
+
+	return path, nil
+}
+
+// xmlEscape escapes a string for use as XML text. We avoid the stdlib's
+// io.Writer-based EscapeText surface so callers can drop the return value
+// straight into a format string.
+func xmlEscape(s string) string {
+	var buf bytes.Buffer
+	if err := xml.EscapeText(&buf, []byte(s)); err != nil {
+		// xml.EscapeText only errors on writer failure, which a
+		// bytes.Buffer can't produce — but if it ever did, falling back
+		// to the un-escaped value keeps us from crashing on a setenv
+		// install. The plist may then be malformed; launchctl would
+		// reject it loudly.
+		return s
+	}
+
+	return strings.ReplaceAll(buf.String(), "\t", "&#9;")
+}

--- a/internal/xcode_app/launch_agent.go
+++ b/internal/xcode_app/launch_agent.go
@@ -11,30 +11,19 @@ import (
 	"strings"
 )
 
-// SetenvAgentLabel is the LaunchAgent label we install to make the
-// XCODE_XCCONFIG_FILE setenv survive logout. Distinct from the daemon's
-// xcelerate-proxy label so wholesale uninstall of one doesn't disturb the
-// other.
+// SetenvAgentLabel is the LaunchAgent label we install to make XCODE_XCCONFIG_FILE survive logout.
 const SetenvAgentLabel = "io.bitrise.build-cache.xcode-app-setenv"
 
-// SetenvAgentPlistRelative is the LaunchAgent plist filename — same as
-// SetenvAgentLabel with `.plist` appended.
+// SetenvAgentPlistRelative is the LaunchAgent plist filename relative to $HOME.
 const SetenvAgentPlistRelative = "Library/LaunchAgents/" + SetenvAgentLabel + ".plist"
 
-// SetenvAgentPlistPath returns the absolute path of our setenv LaunchAgent
-// plist under ~/Library/LaunchAgents/.
+// SetenvAgentPlistPath returns the absolute path of our setenv LaunchAgent plist.
 func SetenvAgentPlistPath(home string) string {
 	return filepath.Join(home, SetenvAgentPlistRelative)
 }
 
-// setenvPlistTemplate is the LaunchAgent body. RunAtLoad=true fires once at
-// login; KeepAlive=false (the default — we omit the key) lets the one-shot
-// `launchctl setenv` call exit cleanly without a restart loop. The agent
-// re-applies our XCODE_XCCONFIG_FILE override on every login, which is the
-// whole point of the file.
-//
-// We write the launchctl call verbatim rather than chain through `sh -c …`
-// to avoid quoting hazards on paths with spaces.
+// setenvPlistTemplate fires the one-shot `launchctl setenv` at login.
+// Verbatim ProgramArguments (no `sh -c …`) avoid quoting hazards on paths with spaces.
 const setenvPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -54,8 +43,7 @@ const setenvPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 </plist>
 `
 
-// RenderSetenvAgent returns the LaunchAgent plist body that re-runs
-// `launchctl setenv XCODE_XCCONFIG_FILE <xcconfigPath>` at every login.
+// RenderSetenvAgent returns the LaunchAgent plist body that re-runs the setenv at every login.
 func RenderSetenvAgent(xcconfigPath string) (string, error) {
 	if strings.TrimSpace(xcconfigPath) == "" {
 		return "", errors.New("xcconfig path is empty")
@@ -70,9 +58,7 @@ func RenderSetenvAgent(xcconfigPath string) (string, error) {
 	), nil
 }
 
-// WriteSetenvAgent renders and writes our LaunchAgent plist. mkdir the
-// ~/Library/LaunchAgents directory if missing — fresh user accounts don't
-// always have it.
+// WriteSetenvAgent renders and writes our LaunchAgent plist, creating ~/Library/LaunchAgents if missing.
 func WriteSetenvAgent(home, xcconfigPath string) (string, error) {
 	body, err := RenderSetenvAgent(xcconfigPath)
 	if err != nil {
@@ -93,8 +79,7 @@ func WriteSetenvAgent(home, xcconfigPath string) (string, error) {
 	return path, nil
 }
 
-// RemoveSetenvAgent removes the LaunchAgent plist. Missing file is treated
-// as success so `disable` is idempotent.
+// RemoveSetenvAgent removes the LaunchAgent plist idempotently (missing file = success).
 func RemoveSetenvAgent(home string) (string, error) {
 	path := SetenvAgentPlistPath(home)
 	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
@@ -104,17 +89,11 @@ func RemoveSetenvAgent(home string) (string, error) {
 	return path, nil
 }
 
-// xmlEscape escapes a string for use as XML text. We avoid the stdlib's
-// io.Writer-based EscapeText surface so callers can drop the return value
-// straight into a format string.
+// xmlEscape escapes a string for XML text, returning a string for direct format-string use.
 func xmlEscape(s string) string {
 	var buf bytes.Buffer
 	if err := xml.EscapeText(&buf, []byte(s)); err != nil {
-		// xml.EscapeText only errors on writer failure, which a
-		// bytes.Buffer can't produce — but if it ever did, falling back
-		// to the un-escaped value keeps us from crashing on a setenv
-		// install. The plist may then be malformed; launchctl would
-		// reject it loudly.
+		// xml.EscapeText only errors on writer failure; bytes.Buffer can't produce one.
 		return s
 	}
 

--- a/internal/xcode_app/launch_agent.go
+++ b/internal/xcode_app/launch_agent.go
@@ -11,18 +11,14 @@ import (
 	"strings"
 )
 
-// SetenvAgentLabel is the LaunchAgent label we install to make XCODE_XCCONFIG_FILE survive logout.
 const SetenvAgentLabel = "io.bitrise.build-cache.xcode-app-setenv"
 
-// SetenvAgentPlistRelative is the LaunchAgent plist filename relative to $HOME.
 const SetenvAgentPlistRelative = "Library/LaunchAgents/" + SetenvAgentLabel + ".plist"
 
-// SetenvAgentPlistPath returns the absolute path of our setenv LaunchAgent plist.
 func SetenvAgentPlistPath(home string) string {
 	return filepath.Join(home, SetenvAgentPlistRelative)
 }
 
-// setenvPlistTemplate fires the one-shot `launchctl setenv` at login.
 // Verbatim ProgramArguments (no `sh -c …`) avoid quoting hazards on paths with spaces.
 const setenvPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -43,7 +39,6 @@ const setenvPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 </plist>
 `
 
-// RenderSetenvAgent returns the LaunchAgent plist body that re-runs the setenv at every login.
 func RenderSetenvAgent(xcconfigPath string) (string, error) {
 	if strings.TrimSpace(xcconfigPath) == "" {
 		return "", errors.New("xcconfig path is empty")
@@ -58,7 +53,6 @@ func RenderSetenvAgent(xcconfigPath string) (string, error) {
 	), nil
 }
 
-// WriteSetenvAgent renders and writes our LaunchAgent plist, creating ~/Library/LaunchAgents if missing.
 func WriteSetenvAgent(home, xcconfigPath string) (string, error) {
 	body, err := RenderSetenvAgent(xcconfigPath)
 	if err != nil {
@@ -79,7 +73,6 @@ func WriteSetenvAgent(home, xcconfigPath string) (string, error) {
 	return path, nil
 }
 
-// RemoveSetenvAgent removes the LaunchAgent plist idempotently (missing file = success).
 func RemoveSetenvAgent(home string) (string, error) {
 	path := SetenvAgentPlistPath(home)
 	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
@@ -89,11 +82,9 @@ func RemoveSetenvAgent(home string) (string, error) {
 	return path, nil
 }
 
-// xmlEscape escapes a string for XML text, returning a string for direct format-string use.
 func xmlEscape(s string) string {
 	var buf bytes.Buffer
 	if err := xml.EscapeText(&buf, []byte(s)); err != nil {
-		// xml.EscapeText only errors on writer failure; bytes.Buffer can't produce one.
 		return s
 	}
 

--- a/internal/xcode_app/launch_agent_test.go
+++ b/internal/xcode_app/launch_agent_test.go
@@ -1,0 +1,66 @@
+//go:build unit
+
+package xcode_app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderSetenvAgent_includesLabelAndProgramArgs(t *testing.T) {
+	got, err := RenderSetenvAgent("/Users/me/.bitrise-xcelerate/xcode-app.xcconfig")
+	require.NoError(t, err)
+
+	assert.Contains(t, got, "<string>"+SetenvAgentLabel+"</string>")
+	assert.Contains(t, got, "<string>"+LaunchctlBin+"</string>")
+	assert.Contains(t, got, "<string>setenv</string>")
+	assert.Contains(t, got, "<string>"+XCConfigEnvVar+"</string>")
+	assert.Contains(t, got, "<string>/Users/me/.bitrise-xcelerate/xcode-app.xcconfig</string>")
+	assert.Contains(t, got, "<key>RunAtLoad</key>")
+	assert.Contains(t, got, "<true/>")
+}
+
+func TestRenderSetenvAgent_emptyPathIsError(t *testing.T) {
+	_, err := RenderSetenvAgent("")
+	require.Error(t, err)
+}
+
+func TestRenderSetenvAgent_escapesXMLSpecialChars(t *testing.T) {
+	got, err := RenderSetenvAgent("/Users/me/With <> & quote.xcconfig")
+	require.NoError(t, err)
+
+	// Raw special characters should not appear in the rendered body.
+	assert.NotContains(t, got, "/Users/me/With <> & quote.xcconfig")
+	// XML-escaped form should appear instead.
+	assert.Contains(t, got, "&lt;")
+	assert.Contains(t, got, "&gt;")
+	assert.Contains(t, got, "&amp;")
+}
+
+func TestWriteAndRemoveSetenvAgent(t *testing.T) {
+	home := t.TempDir()
+
+	path, err := WriteSetenvAgent(home, "/Users/me/x.xcconfig")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, SetenvAgentPlistRelative), path)
+
+	content, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "<string>/Users/me/x.xcconfig</string>")
+
+	removed, err := RemoveSetenvAgent(home)
+	require.NoError(t, err)
+	assert.Equal(t, path, removed)
+
+	_, err = os.Stat(path)
+	require.Error(t, err, "plist file should be gone after RemoveSetenvAgent")
+}
+
+func TestRemoveSetenvAgent_missingFileIsNotAnError(t *testing.T) {
+	_, err := RemoveSetenvAgent(t.TempDir())
+	require.NoError(t, err)
+}

--- a/internal/xcode_app/launch_agent_test.go
+++ b/internal/xcode_app/launch_agent_test.go
@@ -33,9 +33,7 @@ func TestRenderSetenvAgent_escapesXMLSpecialChars(t *testing.T) {
 	got, err := RenderSetenvAgent("/Users/me/With <> & quote.xcconfig")
 	require.NoError(t, err)
 
-	// Raw special characters should not appear in the rendered body.
 	assert.NotContains(t, got, "/Users/me/With <> & quote.xcconfig")
-	// XML-escaped form should appear instead.
 	assert.Contains(t, got, "&lt;")
 	assert.Contains(t, got, "&gt;")
 	assert.Contains(t, got, "&amp;")

--- a/internal/xcode_app/launchctl.go
+++ b/internal/xcode_app/launchctl.go
@@ -11,24 +11,16 @@ import (
 )
 
 // LaunchctlBin is the absolute path of the launchctl binary on macOS.
-// Exported so tests can inject a stub via the LaunchctlClient.Bin field.
 const LaunchctlBin = "/bin/launchctl"
 
-// XCConfigEnvVar is the environment variable Xcode reads to discover an
-// override xcconfig. We set it via `launchctl setenv` so processes launched
-// from the current GUI session (including Xcode.app) inherit it.
+// XCConfigEnvVar is the env var Xcode reads for an override xcconfig path.
 const XCConfigEnvVar = "XCODE_XCCONFIG_FILE"
 
-// LaunchctlClient wraps the few `launchctl` verbs we need to drive an
-// XCODE_XCCONFIG_FILE override. The underlying Runner contract is shared
-// with the daemon package — reusing daemon.ExecRunner gives us identical
-// LC_ALL=C / LANG=C locale pinning + exit-code propagation.
+// LaunchctlClient wraps the `launchctl` verbs needed to drive an XCODE_XCCONFIG_FILE override.
 type LaunchctlClient struct {
-	// Runner executes the launchctl process. nil falls back to
-	// daemon.ExecRunner.
+	// Runner executes launchctl. nil = daemon.ExecRunner (shared locale pinning + exit propagation).
 	Runner daemon.CommandRunner
-	// Bin overrides the launchctl binary path. nil falls back to
-	// LaunchctlBin.
+	// Bin overrides the launchctl binary path; empty = LaunchctlBin.
 	Bin string
 }
 
@@ -48,10 +40,8 @@ func (c LaunchctlClient) bin() string {
 	return LaunchctlBin
 }
 
-// Setenv runs `launchctl setenv <key> <value>` so future GUI-launched
-// processes inherit the variable. Affects the user's current bootstrap
-// session only; survives only until the user logs out. Pair with the
-// LaunchAgent in launch_agent.go to make it survive logout.
+// Setenv runs `launchctl setenv <key> <value>` so GUI-launched processes inherit it.
+// Lasts only until the user logs out — pair with the LaunchAgent to survive logout.
 func (c LaunchctlClient) Setenv(ctx context.Context, key, value string) error {
 	_, stderr, code, err := c.runner().Run(ctx, c.bin(), "setenv", key, value)
 	if err != nil {
@@ -65,9 +55,7 @@ func (c LaunchctlClient) Setenv(ctx context.Context, key, value string) error {
 	return nil
 }
 
-// Unsetenv runs `launchctl unsetenv <key>`. A non-zero exit is treated as
-// success because launchctl returns 113 when the variable is already
-// unset — we want disable to be idempotent.
+// Unsetenv runs `launchctl unsetenv <key>` idempotently — launchctl returns 113 when already unset.
 func (c LaunchctlClient) Unsetenv(ctx context.Context, key string) error {
 	if _, _, _, err := c.runner().Run(ctx, c.bin(), "unsetenv", key); err != nil { //nolint:dogsled // matches the runner contract; we intentionally ignore stdout/stderr/exit
 		return fmt.Errorf("launchctl unsetenv: %w", err)
@@ -76,15 +64,12 @@ func (c LaunchctlClient) Unsetenv(ctx context.Context, key string) error {
 	return nil
 }
 
-// Bootstrap loads a LaunchAgent plist into the user's GUI session via
-// `launchctl bootstrap gui/$UID <plist>`. The bootout-then-bootstrap pre-step
-// (mirroring daemon.LaunchdBackend) is what makes Bootstrap idempotent — if
-// the plist is already loaded, the prior version is unloaded first.
+// Bootstrap loads a LaunchAgent plist into the user's GUI session.
+// Idempotent: pre-boots out any prior load so a stale plist is replaced.
 func (c LaunchctlClient) Bootstrap(ctx context.Context, plistPath string) error {
 	target := guiTarget()
 
-	// Best-effort pre-bootout: a "not loaded" exit is fine, but a runner-side
-	// error means launchctl itself couldn't run, which we surface.
+	// Best-effort pre-bootout: "not loaded" is fine, but a runner-side failure means launchctl itself couldn't run.
 	if _, _, _, runErr := c.runner().Run(ctx, c.bin(), "bootout", target, plistPath); runErr != nil { //nolint:dogsled // runner returns stdout/stderr/exit/err — we only care about err here
 		return fmt.Errorf("launchctl bootout (pre-bootstrap): %w", runErr)
 	}
@@ -101,17 +86,14 @@ func (c LaunchctlClient) Bootstrap(ctx context.Context, plistPath string) error 
 	return nil
 }
 
-// Bootout removes a LaunchAgent plist from the user's GUI session via
-// `launchctl bootout gui/$UID <plist>`. A "not loaded" exit is treated as
-// success so disable is idempotent.
+// Bootout removes a LaunchAgent plist from the user's GUI session.
+// Idempotent: "not loaded" is treated as success.
 func (c LaunchctlClient) Bootout(ctx context.Context, plistPath string) error {
 	_, stderr, code, err := c.runner().Run(ctx, c.bin(), "bootout", guiTarget(), plistPath)
 	if err != nil {
 		return fmt.Errorf("launchctl bootout: %w", err)
 	}
 
-	// 113 / "service not loaded" is fine — that's the disable-after-disable
-	// case. Anything else is a real error.
 	if code != 0 && !isNotLoaded(stderr) {
 		return fmt.Errorf("launchctl bootout %s exited %d: %s", plistPath, code, strings.TrimSpace(stderr))
 	}

--- a/internal/xcode_app/launchctl.go
+++ b/internal/xcode_app/launchctl.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/exec"
 )
 
 const LaunchctlBin = "/bin/launchctl"
@@ -24,7 +25,7 @@ func (c LaunchctlClient) runner() daemon.CommandRunner {
 		return c.Runner
 	}
 
-	return daemon.ExecRunner{}
+	return exec.ExecRunner{PinLocale: true}
 }
 
 func (c LaunchctlClient) bin() string {

--- a/internal/xcode_app/launchctl.go
+++ b/internal/xcode_app/launchctl.go
@@ -1,0 +1,132 @@
+package xcode_app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+)
+
+// LaunchctlBin is the absolute path of the launchctl binary on macOS.
+// Exported so tests can inject a stub via the LaunchctlClient.Bin field.
+const LaunchctlBin = "/bin/launchctl"
+
+// XCConfigEnvVar is the environment variable Xcode reads to discover an
+// override xcconfig. We set it via `launchctl setenv` so processes launched
+// from the current GUI session (including Xcode.app) inherit it.
+const XCConfigEnvVar = "XCODE_XCCONFIG_FILE"
+
+// LaunchctlClient wraps the few `launchctl` verbs we need to drive an
+// XCODE_XCCONFIG_FILE override. The underlying Runner contract is shared
+// with the daemon package — reusing daemon.ExecRunner gives us identical
+// LC_ALL=C / LANG=C locale pinning + exit-code propagation.
+type LaunchctlClient struct {
+	// Runner executes the launchctl process. nil falls back to
+	// daemon.ExecRunner.
+	Runner daemon.CommandRunner
+	// Bin overrides the launchctl binary path. nil falls back to
+	// LaunchctlBin.
+	Bin string
+}
+
+func (c LaunchctlClient) runner() daemon.CommandRunner {
+	if c.Runner != nil {
+		return c.Runner
+	}
+
+	return daemon.ExecRunner{}
+}
+
+func (c LaunchctlClient) bin() string {
+	if c.Bin != "" {
+		return c.Bin
+	}
+
+	return LaunchctlBin
+}
+
+// Setenv runs `launchctl setenv <key> <value>` so future GUI-launched
+// processes inherit the variable. Affects the user's current bootstrap
+// session only; survives only until the user logs out. Pair with the
+// LaunchAgent in launch_agent.go to make it survive logout.
+func (c LaunchctlClient) Setenv(ctx context.Context, key, value string) error {
+	_, stderr, code, err := c.runner().Run(ctx, c.bin(), "setenv", key, value)
+	if err != nil {
+		return fmt.Errorf("launchctl setenv: %w", err)
+	}
+
+	if code != 0 {
+		return fmt.Errorf("launchctl setenv %s exited %d: %s", key, code, strings.TrimSpace(stderr))
+	}
+
+	return nil
+}
+
+// Unsetenv runs `launchctl unsetenv <key>`. A non-zero exit is treated as
+// success because launchctl returns 113 when the variable is already
+// unset — we want disable to be idempotent.
+func (c LaunchctlClient) Unsetenv(ctx context.Context, key string) error {
+	if _, _, _, err := c.runner().Run(ctx, c.bin(), "unsetenv", key); err != nil { //nolint:dogsled // matches the runner contract; we intentionally ignore stdout/stderr/exit
+		return fmt.Errorf("launchctl unsetenv: %w", err)
+	}
+
+	return nil
+}
+
+// Bootstrap loads a LaunchAgent plist into the user's GUI session via
+// `launchctl bootstrap gui/$UID <plist>`. The bootout-then-bootstrap pre-step
+// (mirroring daemon.LaunchdBackend) is what makes Bootstrap idempotent — if
+// the plist is already loaded, the prior version is unloaded first.
+func (c LaunchctlClient) Bootstrap(ctx context.Context, plistPath string) error {
+	target := guiTarget()
+
+	// Best-effort pre-bootout: a "not loaded" exit is fine, but a runner-side
+	// error means launchctl itself couldn't run, which we surface.
+	if _, _, _, runErr := c.runner().Run(ctx, c.bin(), "bootout", target, plistPath); runErr != nil { //nolint:dogsled // runner returns stdout/stderr/exit/err — we only care about err here
+		return fmt.Errorf("launchctl bootout (pre-bootstrap): %w", runErr)
+	}
+
+	_, stderr, code, err := c.runner().Run(ctx, c.bin(), "bootstrap", target, plistPath)
+	if err != nil {
+		return fmt.Errorf("launchctl bootstrap: %w", err)
+	}
+
+	if code != 0 {
+		return fmt.Errorf("launchctl bootstrap %s exited %d: %s", plistPath, code, strings.TrimSpace(stderr))
+	}
+
+	return nil
+}
+
+// Bootout removes a LaunchAgent plist from the user's GUI session via
+// `launchctl bootout gui/$UID <plist>`. A "not loaded" exit is treated as
+// success so disable is idempotent.
+func (c LaunchctlClient) Bootout(ctx context.Context, plistPath string) error {
+	_, stderr, code, err := c.runner().Run(ctx, c.bin(), "bootout", guiTarget(), plistPath)
+	if err != nil {
+		return fmt.Errorf("launchctl bootout: %w", err)
+	}
+
+	// 113 / "service not loaded" is fine — that's the disable-after-disable
+	// case. Anything else is a real error.
+	if code != 0 && !isNotLoaded(stderr) {
+		return fmt.Errorf("launchctl bootout %s exited %d: %s", plistPath, code, strings.TrimSpace(stderr))
+	}
+
+	return nil
+}
+
+func guiTarget() string {
+	return "gui/" + strconv.Itoa(os.Getuid())
+}
+
+func isNotLoaded(stderr string) bool {
+	s := strings.ToLower(stderr)
+
+	return strings.Contains(s, "could not find service") ||
+		strings.Contains(s, "service not loaded") ||
+		strings.Contains(s, "no such process")
+}

--- a/internal/xcode_app/launchctl.go
+++ b/internal/xcode_app/launchctl.go
@@ -10,18 +10,13 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
 )
 
-// LaunchctlBin is the absolute path of the launchctl binary on macOS.
 const LaunchctlBin = "/bin/launchctl"
 
-// XCConfigEnvVar is the env var Xcode reads for an override xcconfig path.
 const XCConfigEnvVar = "XCODE_XCCONFIG_FILE"
 
-// LaunchctlClient wraps the `launchctl` verbs needed to drive an XCODE_XCCONFIG_FILE override.
 type LaunchctlClient struct {
-	// Runner executes launchctl. nil = daemon.ExecRunner (shared locale pinning + exit propagation).
 	Runner daemon.CommandRunner
-	// Bin overrides the launchctl binary path; empty = LaunchctlBin.
-	Bin string
+	Bin    string
 }
 
 func (c LaunchctlClient) runner() daemon.CommandRunner {
@@ -40,8 +35,7 @@ func (c LaunchctlClient) bin() string {
 	return LaunchctlBin
 }
 
-// Setenv runs `launchctl setenv <key> <value>` so GUI-launched processes inherit it.
-// Lasts only until the user logs out — pair with the LaunchAgent to survive logout.
+// Setenv lasts only until logout — pair with the LaunchAgent to survive logout.
 func (c LaunchctlClient) Setenv(ctx context.Context, key, value string) error {
 	_, stderr, code, err := c.runner().Run(ctx, c.bin(), "setenv", key, value)
 	if err != nil {
@@ -55,7 +49,7 @@ func (c LaunchctlClient) Setenv(ctx context.Context, key, value string) error {
 	return nil
 }
 
-// Unsetenv runs `launchctl unsetenv <key>` idempotently — launchctl returns 113 when already unset.
+// Unsetenv treats launchctl exit 113 ("already unset") as success.
 func (c LaunchctlClient) Unsetenv(ctx context.Context, key string) error {
 	if _, _, _, err := c.runner().Run(ctx, c.bin(), "unsetenv", key); err != nil { //nolint:dogsled // matches the runner contract; we intentionally ignore stdout/stderr/exit
 		return fmt.Errorf("launchctl unsetenv: %w", err)
@@ -64,12 +58,10 @@ func (c LaunchctlClient) Unsetenv(ctx context.Context, key string) error {
 	return nil
 }
 
-// Bootstrap loads a LaunchAgent plist into the user's GUI session.
-// Idempotent: pre-boots out any prior load so a stale plist is replaced.
+// Bootstrap pre-boots out any prior load so a stale plist is replaced.
 func (c LaunchctlClient) Bootstrap(ctx context.Context, plistPath string) error {
 	target := guiTarget()
 
-	// Best-effort pre-bootout: "not loaded" is fine, but a runner-side failure means launchctl itself couldn't run.
 	if _, _, _, runErr := c.runner().Run(ctx, c.bin(), "bootout", target, plistPath); runErr != nil { //nolint:dogsled // runner returns stdout/stderr/exit/err — we only care about err here
 		return fmt.Errorf("launchctl bootout (pre-bootstrap): %w", runErr)
 	}
@@ -86,8 +78,7 @@ func (c LaunchctlClient) Bootstrap(ctx context.Context, plistPath string) error 
 	return nil
 }
 
-// Bootout removes a LaunchAgent plist from the user's GUI session.
-// Idempotent: "not loaded" is treated as success.
+// Bootout treats "not loaded" stderr as success.
 func (c LaunchctlClient) Bootout(ctx context.Context, plistPath string) error {
 	_, stderr, code, err := c.runner().Run(ctx, c.bin(), "bootout", guiTarget(), plistPath)
 	if err != nil {

--- a/internal/xcode_app/launchctl_test.go
+++ b/internal/xcode_app/launchctl_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeRunner records the exact launchctl invocations and returns canned
-// stdout/stderr/exit codes per call.
 type fakeRunner struct {
 	calls  []runnerCall
 	stdout string
@@ -56,7 +54,6 @@ func TestLaunchctl_Unsetenv_swallowsNonZero(t *testing.T) {
 	r := &fakeRunner{exit: 113}
 	c := LaunchctlClient{Runner: r}
 
-	// Idempotent — non-zero exit is fine (variable already unset).
 	require.NoError(t, c.Unsetenv(context.Background(), "K"))
 }
 

--- a/internal/xcode_app/launchctl_test.go
+++ b/internal/xcode_app/launchctl_test.go
@@ -1,0 +1,97 @@
+//go:build unit
+
+package xcode_app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRunner records the exact launchctl invocations and returns canned
+// stdout/stderr/exit codes per call.
+type fakeRunner struct {
+	calls  []runnerCall
+	stdout string
+	stderr string
+	exit   int
+	err    error
+}
+
+type runnerCall struct {
+	bin  string
+	args []string
+}
+
+func (f *fakeRunner) Run(_ context.Context, bin string, args ...string) (string, string, int, error) {
+	f.calls = append(f.calls, runnerCall{bin: bin, args: append([]string(nil), args...)})
+
+	return f.stdout, f.stderr, f.exit, f.err
+}
+
+func TestLaunchctl_Setenv_invokesLaunchctlWithKeyValue(t *testing.T) {
+	r := &fakeRunner{}
+	c := LaunchctlClient{Runner: r, Bin: "/fake/launchctl"}
+
+	require.NoError(t, c.Setenv(context.Background(), XCConfigEnvVar, "/path/x.xcconfig"))
+
+	require.Len(t, r.calls, 1)
+	assert.Equal(t, "/fake/launchctl", r.calls[0].bin)
+	assert.Equal(t, []string{"setenv", XCConfigEnvVar, "/path/x.xcconfig"}, r.calls[0].args)
+}
+
+func TestLaunchctl_Setenv_nonZeroExitIsError(t *testing.T) {
+	r := &fakeRunner{exit: 1, stderr: "boom"}
+	c := LaunchctlClient{Runner: r}
+
+	err := c.Setenv(context.Background(), "K", "v")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestLaunchctl_Unsetenv_swallowsNonZero(t *testing.T) {
+	r := &fakeRunner{exit: 113}
+	c := LaunchctlClient{Runner: r}
+
+	// Idempotent — non-zero exit is fine (variable already unset).
+	require.NoError(t, c.Unsetenv(context.Background(), "K"))
+}
+
+func TestLaunchctl_Bootstrap_runsBootoutThenBootstrap(t *testing.T) {
+	r := &fakeRunner{}
+	c := LaunchctlClient{Runner: r}
+
+	require.NoError(t, c.Bootstrap(context.Background(), "/plist"))
+
+	require.Len(t, r.calls, 2)
+	assert.Equal(t, "bootout", r.calls[0].args[0])
+	assert.Equal(t, "bootstrap", r.calls[1].args[0])
+}
+
+func TestLaunchctl_Bootout_notLoadedTreatedAsSuccess(t *testing.T) {
+	r := &fakeRunner{exit: 113, stderr: "Could not find service \"foo\" in domain for gui/501"}
+	c := LaunchctlClient{Runner: r}
+
+	require.NoError(t, c.Bootout(context.Background(), "/plist"))
+}
+
+func TestLaunchctl_Bootout_realErrorPropagates(t *testing.T) {
+	r := &fakeRunner{exit: 1, stderr: "permission denied"}
+	c := LaunchctlClient{Runner: r}
+
+	err := c.Bootout(context.Background(), "/plist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission denied")
+}
+
+func TestLaunchctl_runnerErrorPropagates(t *testing.T) {
+	r := &fakeRunner{err: errors.New("exec failed")}
+	c := LaunchctlClient{Runner: r}
+
+	err := c.Setenv(context.Background(), "K", "v")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exec failed")
+}

--- a/internal/xcode_app/paths.go
+++ b/internal/xcode_app/paths.go
@@ -1,13 +1,4 @@
-// Package xcode_app implements the Xcode.app (GUI) build-cache enablement
-// flow backing the `bitrise-build-cache xcode-app enable/disable` subcommands.
-//
-// Mechanism: write an override xcconfig under ~/.bitrise-xcelerate/ with the
-// COMPILATION_CACHE_* keys + the proxy socket path, then `launchctl setenv
-// XCODE_XCCONFIG_FILE` so the Xcode.app build planner picks it up. A
-// LaunchAgent re-runs the setenv on login so the override survives logout.
-//
-// macOS-only — `launchctl` and Xcode.app don't exist on Linux. The cmd-layer
-// gate-keeps that.
+// Package xcode_app drives Xcode.app (GUI) build-cache enable/disable via launchctl + an override xcconfig. macOS-only.
 package xcode_app
 
 import (
@@ -17,18 +8,14 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
-// OverrideXCConfigFileName is the basename of the override xcconfig under ~/.bitrise-xcelerate/.
 const OverrideXCConfigFileName = "xcode-app.xcconfig"
 
-// StateFileName holds the previous XCODE_XCCONFIG_FILE so disable can restore it.
 const StateFileName = "xcode-app-state.json"
 
-// OverrideXCConfigPath returns the absolute path of the override xcconfig.
 func OverrideXCConfigPath(osProxy utils.OsProxy) string {
 	return filepath.Join(xcelerate.DirPath(osProxy), OverrideXCConfigFileName)
 }
 
-// StateFilePath returns the absolute path of the disable-restore state file.
 func StateFilePath(osProxy utils.OsProxy) string {
 	return filepath.Join(xcelerate.DirPath(osProxy), StateFileName)
 }

--- a/internal/xcode_app/paths.go
+++ b/internal/xcode_app/paths.go
@@ -1,0 +1,39 @@
+// Package xcode_app implements the Xcode.app (GUI) build-cache enablement
+// flow backing the `bitrise-build-cache xcode-app enable/disable` subcommands.
+//
+// Mechanism: write an override xcconfig under ~/.bitrise-xcelerate/ with the
+// COMPILATION_CACHE_* keys + the proxy socket path, then `launchctl setenv
+// XCODE_XCCONFIG_FILE` so the Xcode.app build planner picks it up. A
+// LaunchAgent re-runs the setenv on login so the override survives logout.
+//
+// macOS-only — `launchctl` and Xcode.app don't exist on Linux. The cmd-layer
+// gate-keeps that.
+package xcode_app
+
+import (
+	"path/filepath"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+)
+
+// OverrideXCConfigFileName is the basename of the xcconfig we drop into
+// ~/.bitrise-xcelerate/. Kept distinct from `config.json` (the xcelerate CLI
+// config) so the two files never collide.
+const OverrideXCConfigFileName = "xcode-app.xcconfig"
+
+// StateFileName captures the previous XCODE_XCCONFIG_FILE value at enable
+// time so disable can restore it. Lives next to the xcconfig.
+const StateFileName = "xcode-app-state.json"
+
+// OverrideXCConfigPath returns the absolute path of the override xcconfig
+// we manage under ~/.bitrise-xcelerate/.
+func OverrideXCConfigPath(osProxy utils.OsProxy) string {
+	return filepath.Join(xcelerate.DirPath(osProxy), OverrideXCConfigFileName)
+}
+
+// StateFilePath returns the absolute path of the disable-restore state file
+// under ~/.bitrise-xcelerate/.
+func StateFilePath(osProxy utils.OsProxy) string {
+	return filepath.Join(xcelerate.DirPath(osProxy), StateFileName)
+}

--- a/internal/xcode_app/paths.go
+++ b/internal/xcode_app/paths.go
@@ -17,23 +17,18 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
-// OverrideXCConfigFileName is the basename of the xcconfig we drop into
-// ~/.bitrise-xcelerate/. Kept distinct from `config.json` (the xcelerate CLI
-// config) so the two files never collide.
+// OverrideXCConfigFileName is the basename of the override xcconfig under ~/.bitrise-xcelerate/.
 const OverrideXCConfigFileName = "xcode-app.xcconfig"
 
-// StateFileName captures the previous XCODE_XCCONFIG_FILE value at enable
-// time so disable can restore it. Lives next to the xcconfig.
+// StateFileName holds the previous XCODE_XCCONFIG_FILE so disable can restore it.
 const StateFileName = "xcode-app-state.json"
 
-// OverrideXCConfigPath returns the absolute path of the override xcconfig
-// we manage under ~/.bitrise-xcelerate/.
+// OverrideXCConfigPath returns the absolute path of the override xcconfig.
 func OverrideXCConfigPath(osProxy utils.OsProxy) string {
 	return filepath.Join(xcelerate.DirPath(osProxy), OverrideXCConfigFileName)
 }
 
-// StateFilePath returns the absolute path of the disable-restore state file
-// under ~/.bitrise-xcelerate/.
+// StateFilePath returns the absolute path of the disable-restore state file.
 func StateFilePath(osProxy utils.OsProxy) string {
 	return filepath.Join(xcelerate.DirPath(osProxy), StateFileName)
 }

--- a/internal/xcode_app/state.go
+++ b/internal/xcode_app/state.go
@@ -8,13 +8,11 @@ import (
 	"os"
 )
 
-// State captures what `xcode-app enable` did so `xcode-app disable` can undo it cleanly.
 type State struct {
-	// PreviousXCConfigPath is the value of XCODE_XCCONFIG_FILE captured before enable overwrote it.
 	PreviousXCConfigPath string `json:"previousXCConfigPath,omitempty"`
 }
 
-// LoadState reads the state file; missing file returns zero + false + nil (treat as never enabled).
+// LoadState returns zero + false + nil for a missing file (caller treats as never enabled).
 func LoadState(path string) (State, bool, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // we control the path
 	if err != nil {
@@ -33,7 +31,7 @@ func LoadState(path string) (State, bool, error) {
 	return s, true, nil
 }
 
-// SaveState writes the state file atomically (write-temp + rename).
+// SaveState writes atomically (write-temp + rename).
 func SaveState(path string, s State) error {
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
@@ -41,7 +39,6 @@ func SaveState(path string, s State) error {
 	}
 
 	tmp := path + ".tmp"
-	// 0o600: internal enable/disable handoff, Xcode never reads it.
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", tmp, err)
 	}
@@ -55,7 +52,6 @@ func SaveState(path string, s State) error {
 	return nil
 }
 
-// RemoveState deletes the state file idempotently.
 func RemoveState(path string) error {
 	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("remove state file %s: %w", path, err)

--- a/internal/xcode_app/state.go
+++ b/internal/xcode_app/state.go
@@ -8,20 +8,13 @@ import (
 	"os"
 )
 
-// State captures what `xcode-app enable` did to the user's environment so
-// `xcode-app disable` can undo it cleanly. Persisted as JSON next to the
-// override xcconfig.
+// State captures what `xcode-app enable` did so `xcode-app disable` can undo it cleanly.
 type State struct {
-	// PreviousXCConfigPath is the value of XCODE_XCCONFIG_FILE at enable
-	// time, captured BEFORE we overwrote it via `launchctl setenv`. On
-	// disable we re-`setenv` to this value if non-empty, or `unsetenv` if
-	// empty.
+	// PreviousXCConfigPath is the value of XCODE_XCCONFIG_FILE captured before enable overwrote it.
 	PreviousXCConfigPath string `json:"previousXCConfigPath,omitempty"`
 }
 
-// LoadState reads the state file. Missing file returns the zero value + false
-// + nil error so the caller can treat "never enabled" as a normal disable
-// no-op rather than a hard failure.
+// LoadState reads the state file; missing file returns zero + false + nil (treat as never enabled).
 func LoadState(path string) (State, bool, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // we control the path
 	if err != nil {
@@ -40,8 +33,7 @@ func LoadState(path string) (State, bool, error) {
 	return s, true, nil
 }
 
-// SaveState writes the state file atomically (write-temp + rename) so a
-// crash mid-write never leaves a half-written JSON behind.
+// SaveState writes the state file atomically (write-temp + rename).
 func SaveState(path string, s State) error {
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
@@ -49,11 +41,7 @@ func SaveState(path string, s State) error {
 	}
 
 	tmp := path + ".tmp"
-	// 0o600 (not 0o644 like the xcconfig itself) because the state file is
-	// purely an internal handoff between enable and disable — Xcode never
-	// reads it, so there's no reason to expose it to other users on the
-	// host. Tighter mode reduces the surface in case a future field is more
-	// sensitive than today's prior-path string.
+	// 0o600: internal enable/disable handoff, Xcode never reads it.
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", tmp, err)
 	}
@@ -67,8 +55,7 @@ func SaveState(path string, s State) error {
 	return nil
 }
 
-// RemoveState deletes the state file. Missing file is not an error — disable
-// is idempotent.
+// RemoveState deletes the state file idempotently.
 func RemoveState(path string) error {
 	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("remove state file %s: %w", path, err)

--- a/internal/xcode_app/state.go
+++ b/internal/xcode_app/state.go
@@ -1,0 +1,73 @@
+package xcode_app
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+// State captures what `xcode-app enable` did to the user's environment so
+// `xcode-app disable` can undo it cleanly. Persisted as JSON next to the
+// override xcconfig.
+type State struct {
+	// PreviousXCConfigPath is the value of XCODE_XCCONFIG_FILE at enable
+	// time, captured BEFORE we overwrote it via `launchctl setenv`. On
+	// disable we re-`setenv` to this value if non-empty, or `unsetenv` if
+	// empty.
+	PreviousXCConfigPath string `json:"previousXCConfigPath,omitempty"`
+}
+
+// LoadState reads the state file. Missing file returns the zero value + false
+// + nil error so the caller can treat "never enabled" as a normal disable
+// no-op rather than a hard failure.
+func LoadState(path string) (State, bool, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // we control the path
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return State{}, false, nil
+		}
+
+		return State{}, false, fmt.Errorf("read state file %s: %w", path, err)
+	}
+
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		return State{}, false, fmt.Errorf("decode state file %s: %w", path, err)
+	}
+
+	return s, true, nil
+}
+
+// SaveState writes the state file atomically (write-temp + rename) so a
+// crash mid-write never leaves a half-written JSON behind.
+func SaveState(path string, s State) error {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode state: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", tmp, err)
+	}
+
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+
+		return fmt.Errorf("rename %s -> %s: %w", tmp, path, err)
+	}
+
+	return nil
+}
+
+// RemoveState deletes the state file. Missing file is not an error — disable
+// is idempotent.
+func RemoveState(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove state file %s: %w", path, err)
+	}
+
+	return nil
+}

--- a/internal/xcode_app/state.go
+++ b/internal/xcode_app/state.go
@@ -49,6 +49,11 @@ func SaveState(path string, s State) error {
 	}
 
 	tmp := path + ".tmp"
+	// 0o600 (not 0o644 like the xcconfig itself) because the state file is
+	// purely an internal handoff between enable and disable — Xcode never
+	// reads it, so there's no reason to expose it to other users on the
+	// host. Tighter mode reduces the surface in case a future field is more
+	// sensitive than today's prior-path string.
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", tmp, err)
 	}

--- a/internal/xcode_app/state_test.go
+++ b/internal/xcode_app/state_test.go
@@ -1,0 +1,47 @@
+//go:build unit
+
+package xcode_app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadState_missingFileReturnsZeroValueAndFalse(t *testing.T) {
+	got, found, err := LoadState(filepath.Join(t.TempDir(), "nope.json"))
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Empty(t, got.PreviousXCConfigPath)
+}
+
+func TestSaveLoadRoundtrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+
+	want := State{PreviousXCConfigPath: "/Users/me/Base.xcconfig"}
+	require.NoError(t, SaveState(path, want))
+
+	got, found, err := LoadState(path)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, want, got)
+}
+
+func TestSaveState_atomicRename_noTmpLeftBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	require.NoError(t, SaveState(path, State{PreviousXCConfigPath: "/x"}))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".tmp", "no .tmp leftover expected")
+	}
+}
+
+func TestRemoveState_missingFileIsNotAnError(t *testing.T) {
+	require.NoError(t, RemoveState(filepath.Join(t.TempDir(), "nope.json")))
+}

--- a/internal/xcode_app/xcconfig.go
+++ b/internal/xcode_app/xcconfig.go
@@ -33,6 +33,16 @@ func RenderOverride(proxySocketPath, previousIncludePath string) (string, error)
 		return "", fmt.Errorf("proxy socket path is empty")
 	}
 
+	// xcconfig's `#include "<path>"` form has no documented escape for
+	// embedded quotes, so reject paths that contain one rather than emit a
+	// malformed override that Xcode would silently ignore. Practically
+	// unreachable on macOS (HFS+ / APFS allow quote chars in filenames but
+	// they're vanishingly rare), but the cheap upfront check beats the
+	// silent-broken-build failure mode.
+	if strings.ContainsRune(previousIncludePath, '"') {
+		return "", fmt.Errorf("previous XCODE_XCCONFIG_FILE path contains a quote character — cannot safely #include")
+	}
+
 	var b strings.Builder
 
 	b.WriteString("// Bitrise Build Cache — Xcode.app override\n")

--- a/internal/xcode_app/xcconfig.go
+++ b/internal/xcode_app/xcconfig.go
@@ -8,17 +8,14 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/xcodeargs"
 )
 
-// RemoteServicePathKey is the xcconfig key Xcode reads to discover the xcelerate-proxy unix socket.
 const RemoteServicePathKey = "COMPILATION_CACHE_REMOTE_SERVICE_PATH"
 
-// RenderOverride returns the xcconfig content for ~/.bitrise-xcelerate/xcode-app.xcconfig.
-// When non-empty, previousIncludePath is chained via `#include` so the user's prior xcconfig still applies.
 func RenderOverride(proxySocketPath, previousIncludePath string) (string, error) {
 	if strings.TrimSpace(proxySocketPath) == "" {
 		return "", fmt.Errorf("proxy socket path is empty")
 	}
 
-	// xcconfig's `#include "<path>"` has no documented quote-escape — reject embedded quotes rather than emit a silently malformed file.
+	// xcconfig `#include "<path>"` has no documented quote-escape — reject quotes rather than emit a silently malformed file.
 	if strings.ContainsRune(previousIncludePath, '"') {
 		return "", fmt.Errorf("previous XCODE_XCCONFIG_FILE path contains a quote character — cannot safely #include")
 	}

--- a/internal/xcode_app/xcconfig.go
+++ b/internal/xcode_app/xcconfig.go
@@ -8,37 +8,17 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/xcodeargs"
 )
 
-// RemoteServicePathKey is the xcconfig key Xcode reads to discover the
-// xcelerate-proxy unix socket. Mirrors the additional[] entry that
-// cmd/xcode/xcodebuild.go injects via `xcodebuild` CLI args.
+// RemoteServicePathKey is the xcconfig key Xcode reads to discover the xcelerate-proxy unix socket.
 const RemoteServicePathKey = "COMPILATION_CACHE_REMOTE_SERVICE_PATH"
 
-// RenderOverride returns the xcconfig content we write to
-// ~/.bitrise-xcelerate/xcode-app.xcconfig.
-//
-// previousIncludePath is the prior `XCODE_XCCONFIG_FILE` value captured at
-// enable time. When non-empty, the rendered file leads with
-//
-//	#include "<previousIncludePath>"
-//
-// so the user's existing xcconfig keys take effect except where our cache
-// keys override (the override slot has higher precedence than per-target/base
-// xcconfigs but lower than `xcodebuild` CLI args — see the E1 spike doc).
-//
-// proxySocketPath is the absolute path of the xcelerate-proxy unix socket.
-// Must be non-empty; an empty path is a programmer error (caller should have
-// validated the xcelerate config exists).
+// RenderOverride returns the xcconfig content for ~/.bitrise-xcelerate/xcode-app.xcconfig.
+// When non-empty, previousIncludePath is chained via `#include` so the user's prior xcconfig still applies.
 func RenderOverride(proxySocketPath, previousIncludePath string) (string, error) {
 	if strings.TrimSpace(proxySocketPath) == "" {
 		return "", fmt.Errorf("proxy socket path is empty")
 	}
 
-	// xcconfig's `#include "<path>"` form has no documented escape for
-	// embedded quotes, so reject paths that contain one rather than emit a
-	// malformed override that Xcode would silently ignore. Practically
-	// unreachable on macOS (HFS+ / APFS allow quote chars in filenames but
-	// they're vanishingly rare), but the cheap upfront check beats the
-	// silent-broken-build failure mode.
+	// xcconfig's `#include "<path>"` has no documented quote-escape — reject embedded quotes rather than emit a silently malformed file.
 	if strings.ContainsRune(previousIncludePath, '"') {
 		return "", fmt.Errorf("previous XCODE_XCCONFIG_FILE path contains a quote character — cannot safely #include")
 	}
@@ -51,8 +31,7 @@ func RenderOverride(proxySocketPath, previousIncludePath string) (string, error)
 	b.WriteString("// Do not edit by hand.\n\n")
 
 	if previousIncludePath != "" {
-		// Chain the prior override so we don't clobber the user's setup
-		// (E3 — ACI-5042). Quoted form supports paths with spaces.
+		// Chain the prior override so we don't clobber the user's setup. Quoted form supports paths with spaces.
 		fmt.Fprintf(&b, "#include \"%s\"\n\n", previousIncludePath)
 	}
 

--- a/internal/xcode_app/xcconfig.go
+++ b/internal/xcode_app/xcconfig.go
@@ -1,0 +1,66 @@
+package xcode_app
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/xcodeargs"
+)
+
+// RemoteServicePathKey is the xcconfig key Xcode reads to discover the
+// xcelerate-proxy unix socket. Mirrors the additional[] entry that
+// cmd/xcode/xcodebuild.go injects via `xcodebuild` CLI args.
+const RemoteServicePathKey = "COMPILATION_CACHE_REMOTE_SERVICE_PATH"
+
+// RenderOverride returns the xcconfig content we write to
+// ~/.bitrise-xcelerate/xcode-app.xcconfig.
+//
+// previousIncludePath is the prior `XCODE_XCCONFIG_FILE` value captured at
+// enable time. When non-empty, the rendered file leads with
+//
+//	#include "<previousIncludePath>"
+//
+// so the user's existing xcconfig keys take effect except where our cache
+// keys override (the override slot has higher precedence than per-target/base
+// xcconfigs but lower than `xcodebuild` CLI args — see the E1 spike doc).
+//
+// proxySocketPath is the absolute path of the xcelerate-proxy unix socket.
+// Must be non-empty; an empty path is a programmer error (caller should have
+// validated the xcelerate config exists).
+func RenderOverride(proxySocketPath, previousIncludePath string) (string, error) {
+	if strings.TrimSpace(proxySocketPath) == "" {
+		return "", fmt.Errorf("proxy socket path is empty")
+	}
+
+	var b strings.Builder
+
+	b.WriteString("// Bitrise Build Cache — Xcode.app override\n")
+	b.WriteString("// Written by `bitrise-build-cache xcode-app enable`.\n")
+	b.WriteString("// Removed by `bitrise-build-cache xcode-app disable`.\n")
+	b.WriteString("// Do not edit by hand.\n\n")
+
+	if previousIncludePath != "" {
+		// Chain the prior override so we don't clobber the user's setup
+		// (E3 — ACI-5042). Quoted form supports paths with spaces.
+		fmt.Fprintf(&b, "#include \"%s\"\n\n", previousIncludePath)
+	}
+
+	keys := make([]string, 0, len(xcodeargs.CacheArgs)+1)
+	keys = append(keys, RemoteServicePathKey)
+	for k := range xcodeargs.CacheArgs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		switch k {
+		case RemoteServicePathKey:
+			fmt.Fprintf(&b, "%s = %s\n", k, proxySocketPath)
+		default:
+			fmt.Fprintf(&b, "%s = %s\n", k, xcodeargs.CacheArgs[k])
+		}
+	}
+
+	return b.String(), nil
+}

--- a/internal/xcode_app/xcconfig_test.go
+++ b/internal/xcode_app/xcconfig_test.go
@@ -51,3 +51,9 @@ func TestRenderOverride_includePathWithSpacesIsQuoted(t *testing.T) {
 
 	assert.Contains(t, got, `#include "/Users/me/With Space/Base.xcconfig"`)
 }
+
+func TestRenderOverride_rejectsIncludePathWithQuote(t *testing.T) {
+	_, err := RenderOverride("/tmp/p.sock", `/Users/me/"weird".xcconfig`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "quote")
+}

--- a/internal/xcode_app/xcconfig_test.go
+++ b/internal/xcode_app/xcconfig_test.go
@@ -1,0 +1,53 @@
+//go:build unit
+
+package xcode_app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderOverride_writesRemoteServicePathAndKnownCacheKeys(t *testing.T) {
+	got, err := RenderOverride("/tmp/xcelerate-proxy.sock", "")
+	require.NoError(t, err)
+
+	assert.Contains(t, got, "COMPILATION_CACHE_REMOTE_SERVICE_PATH = /tmp/xcelerate-proxy.sock")
+	assert.Contains(t, got, "COMPILATION_CACHE_ENABLE_PLUGIN = YES")
+	assert.Contains(t, got, "COMPILATION_CACHE_ENABLE_INTEGRATED_QUERIES = YES")
+	assert.Contains(t, got, "COMPILATION_CACHE_ENABLE_DETACHED_KEY_QUERIES = YES")
+	assert.Contains(t, got, "SWIFT_ENABLE_COMPILE_CACHE = YES")
+	assert.Contains(t, got, "CLANG_ENABLE_COMPILE_CACHE = YES")
+}
+
+func TestRenderOverride_includesPreviousFileBeforeKeys(t *testing.T) {
+	got, err := RenderOverride("/tmp/p.sock", "/Users/me/MyProject.xcconfig")
+	require.NoError(t, err)
+
+	idxInclude := strings.Index(got, `#include "/Users/me/MyProject.xcconfig"`)
+	idxRemote := strings.Index(got, "COMPILATION_CACHE_REMOTE_SERVICE_PATH")
+
+	require.GreaterOrEqual(t, idxInclude, 0, "expected an #include line for the previous xcconfig")
+	require.Greater(t, idxRemote, idxInclude, "expected our keys to follow the #include")
+}
+
+func TestRenderOverride_noIncludeWhenNoPrevious(t *testing.T) {
+	got, err := RenderOverride("/tmp/p.sock", "")
+	require.NoError(t, err)
+
+	assert.NotContains(t, got, "#include")
+}
+
+func TestRenderOverride_emptyProxySocketIsError(t *testing.T) {
+	_, err := RenderOverride("", "")
+	require.Error(t, err)
+}
+
+func TestRenderOverride_includePathWithSpacesIsQuoted(t *testing.T) {
+	got, err := RenderOverride("/tmp/p.sock", "/Users/me/With Space/Base.xcconfig")
+	require.NoError(t, err)
+
+	assert.Contains(t, got, `#include "/Users/me/With Space/Base.xcconfig"`)
+}

--- a/internal/xcode_app/xcode_running.go
+++ b/internal/xcode_app/xcode_running.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/exec"
 )
 
 const pgrepBin = "/usr/bin/pgrep"
@@ -27,7 +28,7 @@ func (d DefaultXcodeChecker) runner() daemon.CommandRunner {
 		return d.Runner
 	}
 
-	return daemon.ExecRunner{}
+	return exec.ExecRunner{}
 }
 
 // RunningPIDs returns empty slice when pgrep exit 1 (no match).

--- a/internal/xcode_app/xcode_running.go
+++ b/internal/xcode_app/xcode_running.go
@@ -9,12 +9,9 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
 )
 
-// pgrepBin is the macOS pgrep binary. Exported as a var (not const) so the
-// rare test that needs to inject a stub can swap it; production code does
-// not mutate it.
-//
-//nolint:gochecknoglobals
-var pgrepBin = "/usr/bin/pgrep"
+// pgrepBin is the macOS pgrep binary. Tests inject a stub via the Runner
+// field on DefaultXcodeChecker rather than mutating this constant.
+const pgrepBin = "/usr/bin/pgrep"
 
 // XcodeProcessName is the executable name `pgrep -x` matches against. The
 // GUI app's main process is literally `Xcode`; `Xcode-beta` would have a

--- a/internal/xcode_app/xcode_running.go
+++ b/internal/xcode_app/xcode_running.go
@@ -9,27 +9,18 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
 )
 
-// pgrepBin is the macOS pgrep binary. Tests inject a stub via the Runner
-// field on DefaultXcodeChecker rather than mutating this constant.
+// pgrepBin is the macOS pgrep binary.
 const pgrepBin = "/usr/bin/pgrep"
 
-// XcodeProcessName is the executable name `pgrep -x` matches against. The
-// GUI app's main process is literally `Xcode`; `Xcode-beta` would have a
-// different process name and isn't covered here intentionally — beta users
-// can re-run enable themselves.
+// XcodeProcessName is the GUI app's main executable name. Xcode-beta is intentionally not covered.
 const XcodeProcessName = "Xcode"
 
-// XcodeProcessChecker reports whether Xcode is currently running. It is a
-// no-arg function on purpose so the activator only needs to inject a
-// concrete checker (real or fake) without threading context through extra
-// indirection.
+// XcodeProcessChecker reports whether Xcode is currently running.
 type XcodeProcessChecker interface {
 	RunningPIDs(ctx context.Context) ([]int, error)
 }
 
-// DefaultXcodeChecker shells out to /usr/bin/pgrep -x Xcode. Reuses the
-// daemon package's CommandRunner contract so tests can drive deterministic
-// pgrep replies without forking real processes.
+// DefaultXcodeChecker shells out to /usr/bin/pgrep -x Xcode.
 type DefaultXcodeChecker struct {
 	Runner daemon.CommandRunner
 }
@@ -42,21 +33,13 @@ func (d DefaultXcodeChecker) runner() daemon.CommandRunner {
 	return daemon.ExecRunner{}
 }
 
-// RunningPIDs returns the PIDs of running Xcode processes. pgrep exits 1
-// with no output when no process matches — we treat that as "not running"
-// (empty slice, no error), matching the spec'd pgrep contract.
+// RunningPIDs returns the PIDs of running Xcode processes; empty slice = not running (pgrep exit 1).
 func (d DefaultXcodeChecker) RunningPIDs(ctx context.Context) ([]int, error) {
 	stdout, _, code, err := d.runner().Run(ctx, pgrepBin, "-x", XcodeProcessName)
 	if err != nil {
-		// "pgrep not found" or another exec-side error. Surface as "we
-		// couldn't tell"; the caller's policy decides whether to abort
-		// enable or just skip the relaunch nudge.
 		return nil, fmt.Errorf("pgrep -x %s: %w", XcodeProcessName, err)
 	}
 
-	// pgrep exit code 1 == no match. Anything else above 1 == operational
-	// error (bad arg, etc.); we don't try to differentiate further because
-	// the only thing we'd do is log it.
 	if code == 1 {
 		return nil, nil
 	}
@@ -64,8 +47,6 @@ func (d DefaultXcodeChecker) RunningPIDs(ctx context.Context) ([]int, error) {
 	return parsePIDs(stdout), nil
 }
 
-// parsePIDs splits pgrep's stdout into a slice of PIDs, dropping anything
-// that isn't a positive integer. Defensive against trailing newlines.
 func parsePIDs(stdout string) []int {
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
 	pids := make([]int, 0, len(lines))

--- a/internal/xcode_app/xcode_running.go
+++ b/internal/xcode_app/xcode_running.go
@@ -9,18 +9,15 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
 )
 
-// pgrepBin is the macOS pgrep binary.
 const pgrepBin = "/usr/bin/pgrep"
 
-// XcodeProcessName is the GUI app's main executable name. Xcode-beta is intentionally not covered.
+// XcodeProcessName intentionally omits Xcode-beta.
 const XcodeProcessName = "Xcode"
 
-// XcodeProcessChecker reports whether Xcode is currently running.
 type XcodeProcessChecker interface {
 	RunningPIDs(ctx context.Context) ([]int, error)
 }
 
-// DefaultXcodeChecker shells out to /usr/bin/pgrep -x Xcode.
 type DefaultXcodeChecker struct {
 	Runner daemon.CommandRunner
 }
@@ -33,7 +30,7 @@ func (d DefaultXcodeChecker) runner() daemon.CommandRunner {
 	return daemon.ExecRunner{}
 }
 
-// RunningPIDs returns the PIDs of running Xcode processes; empty slice = not running (pgrep exit 1).
+// RunningPIDs returns empty slice when pgrep exit 1 (no match).
 func (d DefaultXcodeChecker) RunningPIDs(ctx context.Context) ([]int, error) {
 	stdout, _, code, err := d.runner().Run(ctx, pgrepBin, "-x", XcodeProcessName)
 	if err != nil {

--- a/internal/xcode_app/xcode_running.go
+++ b/internal/xcode_app/xcode_running.go
@@ -1,0 +1,90 @@
+package xcode_app
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+)
+
+// pgrepBin is the macOS pgrep binary. Exported as a var (not const) so the
+// rare test that needs to inject a stub can swap it; production code does
+// not mutate it.
+//
+//nolint:gochecknoglobals
+var pgrepBin = "/usr/bin/pgrep"
+
+// XcodeProcessName is the executable name `pgrep -x` matches against. The
+// GUI app's main process is literally `Xcode`; `Xcode-beta` would have a
+// different process name and isn't covered here intentionally — beta users
+// can re-run enable themselves.
+const XcodeProcessName = "Xcode"
+
+// XcodeProcessChecker reports whether Xcode is currently running. It is a
+// no-arg function on purpose so the activator only needs to inject a
+// concrete checker (real or fake) without threading context through extra
+// indirection.
+type XcodeProcessChecker interface {
+	RunningPIDs(ctx context.Context) ([]int, error)
+}
+
+// DefaultXcodeChecker shells out to /usr/bin/pgrep -x Xcode. Reuses the
+// daemon package's CommandRunner contract so tests can drive deterministic
+// pgrep replies without forking real processes.
+type DefaultXcodeChecker struct {
+	Runner daemon.CommandRunner
+}
+
+func (d DefaultXcodeChecker) runner() daemon.CommandRunner {
+	if d.Runner != nil {
+		return d.Runner
+	}
+
+	return daemon.ExecRunner{}
+}
+
+// RunningPIDs returns the PIDs of running Xcode processes. pgrep exits 1
+// with no output when no process matches — we treat that as "not running"
+// (empty slice, no error), matching the spec'd pgrep contract.
+func (d DefaultXcodeChecker) RunningPIDs(ctx context.Context) ([]int, error) {
+	stdout, _, code, err := d.runner().Run(ctx, pgrepBin, "-x", XcodeProcessName)
+	if err != nil {
+		// "pgrep not found" or another exec-side error. Surface as "we
+		// couldn't tell"; the caller's policy decides whether to abort
+		// enable or just skip the relaunch nudge.
+		return nil, fmt.Errorf("pgrep -x %s: %w", XcodeProcessName, err)
+	}
+
+	// pgrep exit code 1 == no match. Anything else above 1 == operational
+	// error (bad arg, etc.); we don't try to differentiate further because
+	// the only thing we'd do is log it.
+	if code == 1 {
+		return nil, nil
+	}
+
+	return parsePIDs(stdout), nil
+}
+
+// parsePIDs splits pgrep's stdout into a slice of PIDs, dropping anything
+// that isn't a positive integer. Defensive against trailing newlines.
+func parsePIDs(stdout string) []int {
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	pids := make([]int, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		n, err := strconv.Atoi(trimmed)
+		if err != nil || n <= 0 {
+			continue
+		}
+
+		pids = append(pids, n)
+	}
+
+	return pids
+}

--- a/internal/xcode_app/xcode_running_test.go
+++ b/internal/xcode_app/xcode_running_test.go
@@ -1,0 +1,46 @@
+//go:build unit
+
+package xcode_app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultXcodeChecker_returnsPIDsOnMatch(t *testing.T) {
+	r := &fakeRunner{stdout: "1234\n5678\n", exit: 0}
+	c := DefaultXcodeChecker{Runner: r}
+
+	pids, err := c.RunningPIDs(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []int{1234, 5678}, pids)
+}
+
+func TestDefaultXcodeChecker_exit1MeansNotRunning(t *testing.T) {
+	r := &fakeRunner{exit: 1}
+	c := DefaultXcodeChecker{Runner: r}
+
+	pids, err := c.RunningPIDs(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, pids)
+}
+
+func TestDefaultXcodeChecker_execErrorPropagates(t *testing.T) {
+	r := &fakeRunner{err: errors.New("pgrep missing")}
+	c := DefaultXcodeChecker{Runner: r}
+
+	_, err := c.RunningPIDs(context.Background())
+	require.Error(t, err)
+}
+
+func TestParsePIDs_filtersInvalidLines(t *testing.T) {
+	assert.Equal(t, []int{1, 2}, parsePIDs("1\nnot-a-pid\n\n2\n"))
+}
+
+func TestParsePIDs_emptyStringReturnsEmpty(t *testing.T) {
+	assert.Empty(t, parsePIDs(""))
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/reactnative"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/update"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode_app"
 )
 
 func main() {

--- a/pkg/xcode_app/activator.go
+++ b/pkg/xcode_app/activator.go
@@ -1,0 +1,339 @@
+// Package xcode_app exposes the public API for the `bitrise-build-cache
+// xcode-app enable / disable` flows.
+//
+// The Activator wires together the building blocks under
+// internal/xcode_app and the daemon package so external Go consumers
+// (Bitrise steps, custom tooling) can drive Xcode.app cache enablement
+// without depending on cobra.
+//
+// Design follows the project's exported-struct-no-interface convention:
+// consumers define their own interfaces for mocking via Go's implicit
+// satisfaction.
+package xcode_app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"runtime"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	xa "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcode_app"
+)
+
+// ErrUnsupportedPlatform is returned by Enable / Disable on non-macOS hosts.
+// Xcode.app + launchctl only exist on Darwin.
+var ErrUnsupportedPlatform = errors.New("xcode-app is only supported on macOS")
+
+// ErrXcelerateNotConfigured is returned when the xcelerate config file is
+// not on disk. enable depends on it for the proxy socket path; the user is
+// expected to run `bitrise-build-cache activate xcode` first.
+var ErrXcelerateNotConfigured = errors.New("xcelerate config not found — run `bitrise-build-cache activate xcode` first")
+
+// Activator drives `xcode-app enable` / `disable`. All collaborator fields
+// are injectable; nil means "use the production default".
+type Activator struct {
+	// Logger is the user-facing log surface. Required.
+	Logger log.Logger
+
+	// Envs is the environment snapshot used to detect a pre-existing
+	// XCODE_XCCONFIG_FILE override at enable time. Production callers
+	// pass utils.AllEnvs().
+	Envs map[string]string
+
+	// OsProxy gates filesystem reads (xcelerate config). nil falls back to
+	// utils.DefaultOsProxy.
+	OsProxy utils.OsProxy
+
+	// DecoderFactory builds the JSON decoder for the xcelerate config.
+	// nil falls back to utils.DefaultDecoderFactory.
+	DecoderFactory utils.DecoderFactory
+
+	// Launchctl handles setenv / unsetenv / bootstrap / bootout. Nil falls
+	// back to xa.LaunchctlClient{} (real `/bin/launchctl`).
+	Launchctl xa.LaunchctlClient
+
+	// XcodeChecker reports whether Xcode is currently running so we can
+	// nudge the user to relaunch. Nil falls back to
+	// xa.DefaultXcodeChecker{}.
+	XcodeChecker xa.XcodeProcessChecker
+
+	// DaemonBackend supervises the xcelerate-proxy service. Nil falls
+	// back to daemon.DefaultBackend(). Enable runs Install + Up filtered
+	// to the xcelerate-proxy service so the proxy is alive when Xcode.app
+	// next dials it.
+	DaemonBackend daemon.Backend
+
+	// DaemonPaths is the supervisor paths struct. Nil falls back to
+	// daemon.NewPaths() at call time.
+	DaemonPaths *daemon.Paths
+
+	// Executable is the path of this CLI binary, used as the supervisor's
+	// ProgramArguments[0]. Empty falls back to os.Executable() at call
+	// time.
+	Executable string
+}
+
+// EnableResult describes what Enable did. Used by the CLI command to surface
+// concrete next-step prompts (e.g. relaunch Xcode).
+type EnableResult struct {
+	XCConfigPath         string
+	LaunchAgentPlistPath string
+	PreviousXCConfigPath string
+	XcelerateProxySocket string
+	RunningXcodePIDs     []int
+}
+
+// DisableResult describes what Disable did.
+type DisableResult struct {
+	XCConfigRemoved      bool
+	LaunchAgentRemoved   bool
+	PreviousXCConfigPath string
+	RestoredXCConfigPath string
+}
+
+// Enable applies the Xcode.app build-cache override. See package doc for the
+// mechanism overview.
+func (a *Activator) Enable(ctx context.Context) (EnableResult, error) {
+	if runtime.GOOS != "darwin" {
+		return EnableResult{}, ErrUnsupportedPlatform
+	}
+
+	osProxy := a.osProxy()
+	logger := a.Logger
+
+	cfg, err := xcelerate.ReadConfig(osProxy, a.decoderFactory())
+	if err != nil {
+		return EnableResult{}, fmt.Errorf("%w: %w", ErrXcelerateNotConfigured, err)
+	}
+
+	if cfg.ProxySocketPath == "" {
+		return EnableResult{}, fmt.Errorf("xcelerate config has empty proxy socket path — re-run `activate xcode`")
+	}
+
+	previous := a.Envs["XCODE_XCCONFIG_FILE"]
+
+	body, err := xa.RenderOverride(cfg.ProxySocketPath, previous)
+	if err != nil {
+		return EnableResult{}, fmt.Errorf("render override xcconfig: %w", err)
+	}
+
+	xcconfigPath := xa.OverrideXCConfigPath(osProxy)
+
+	if err := osProxy.MkdirAll(xcelerate.DirPath(osProxy), 0o755); err != nil {
+		return EnableResult{}, fmt.Errorf("mkdir xcelerate dir: %w", err)
+	}
+
+	if err := osProxy.WriteFile(xcconfigPath, []byte(body), 0o644); err != nil { //nolint:gosec // xcconfig must be readable by Xcode
+		return EnableResult{}, fmt.Errorf("write %s: %w", xcconfigPath, err)
+	}
+
+	if err := xa.SaveState(xa.StateFilePath(osProxy), xa.State{PreviousXCConfigPath: previous}); err != nil {
+		return EnableResult{}, fmt.Errorf("save state: %w", err)
+	}
+
+	if err := a.Launchctl.Setenv(ctx, xa.XCConfigEnvVar, xcconfigPath); err != nil {
+		return EnableResult{}, fmt.Errorf("set XCODE_XCCONFIG_FILE: %w", err)
+	}
+
+	home, err := osProxy.UserHomeDir()
+	if err != nil {
+		return EnableResult{}, fmt.Errorf("resolve home dir: %w", err)
+	}
+
+	plistPath, err := xa.WriteSetenvAgent(home, xcconfigPath)
+	if err != nil {
+		return EnableResult{}, fmt.Errorf("write LaunchAgent: %w", err)
+	}
+
+	if err := a.Launchctl.Bootstrap(ctx, plistPath); err != nil {
+		return EnableResult{}, fmt.Errorf("bootstrap LaunchAgent: %w", err)
+	}
+
+	if err := a.installAndStartProxy(ctx); err != nil {
+		logger.Warnf("Could not start xcelerate-proxy daemon: %s. Run `bitrise-build-cache daemon install + up` manually.", err)
+	}
+
+	pids, checkErr := a.xcodeChecker().RunningPIDs(ctx)
+	if checkErr != nil {
+		logger.Debugf("Could not detect running Xcode: %s", checkErr)
+	}
+
+	return EnableResult{
+		XCConfigPath:         xcconfigPath,
+		LaunchAgentPlistPath: plistPath,
+		PreviousXCConfigPath: previous,
+		XcelerateProxySocket: cfg.ProxySocketPath,
+		RunningXcodePIDs:     pids,
+	}, nil
+}
+
+// Disable reverses what Enable did. Safe to run repeatedly — every step is
+// idempotent against "never enabled" / "already disabled".
+func (a *Activator) Disable(ctx context.Context) (DisableResult, error) {
+	if runtime.GOOS != "darwin" {
+		return DisableResult{}, ErrUnsupportedPlatform
+	}
+
+	osProxy := a.osProxy()
+
+	home, err := osProxy.UserHomeDir()
+	if err != nil {
+		return DisableResult{}, fmt.Errorf("resolve home dir: %w", err)
+	}
+
+	plistPath := xa.SetenvAgentPlistPath(home)
+
+	if err := a.Launchctl.Bootout(ctx, plistPath); err != nil {
+		return DisableResult{}, fmt.Errorf("bootout LaunchAgent: %w", err)
+	}
+
+	if _, err := xa.RemoveSetenvAgent(home); err != nil {
+		return DisableResult{}, fmt.Errorf("remove LaunchAgent plist: %w", err)
+	}
+
+	state, _, err := xa.LoadState(xa.StateFilePath(osProxy))
+	if err != nil {
+		return DisableResult{}, fmt.Errorf("load state: %w", err)
+	}
+
+	result := DisableResult{
+		LaunchAgentRemoved:   true,
+		PreviousXCConfigPath: state.PreviousXCConfigPath,
+	}
+
+	if state.PreviousXCConfigPath != "" {
+		// Restore the user's prior override so their tooling keeps working.
+		if err := a.Launchctl.Setenv(ctx, xa.XCConfigEnvVar, state.PreviousXCConfigPath); err != nil {
+			return result, fmt.Errorf("restore previous XCODE_XCCONFIG_FILE: %w", err)
+		}
+
+		result.RestoredXCConfigPath = state.PreviousXCConfigPath
+	} else {
+		if err := a.Launchctl.Unsetenv(ctx, xa.XCConfigEnvVar); err != nil {
+			return result, fmt.Errorf("unset XCODE_XCCONFIG_FILE: %w", err)
+		}
+	}
+
+	xcconfigPath := xa.OverrideXCConfigPath(osProxy)
+	if err := osProxy.Remove(xcconfigPath); err != nil {
+		// Not-exist is fine — already disabled.
+		if !errors.Is(err, fs.ErrNotExist) {
+			return result, fmt.Errorf("remove %s: %w", xcconfigPath, err)
+		}
+	} else {
+		result.XCConfigRemoved = true
+	}
+
+	if err := xa.RemoveState(xa.StateFilePath(osProxy)); err != nil {
+		return result, fmt.Errorf("remove state file: %w", err)
+	}
+
+	return result, nil
+}
+
+func (a *Activator) installAndStartProxy(ctx context.Context) error {
+	backend, err := a.daemonBackend()
+	if err != nil {
+		return err
+	}
+
+	paths, err := a.daemonPaths()
+	if err != nil {
+		return err
+	}
+
+	executable, err := a.executable()
+	if err != nil {
+		return err
+	}
+
+	svc := xcelerateProxyService()
+
+	if _, err := daemon.Install(ctx, backend, paths, []daemon.Service{svc}, executable); err != nil {
+		return fmt.Errorf("daemon install: %w", err)
+	}
+
+	if _, err := daemon.Up(ctx, backend, paths, []daemon.Service{svc}); err != nil {
+		return fmt.Errorf("daemon up: %w", err)
+	}
+
+	return nil
+}
+
+// xcelerateProxyService picks the xcelerate-proxy service out of the
+// daemon's DefaultServices set. We deliberately don't drive ccache-helper
+// from here — Xcode.app builds don't use ccache, and bundling the two would
+// surprise C/C++-only users.
+func xcelerateProxyService() daemon.Service {
+	for _, s := range daemon.DefaultServices() {
+		if s.Name == "xcelerate-proxy" {
+			return s
+		}
+	}
+
+	// Defensive — the only way to reach this is if someone removes
+	// xcelerate-proxy from daemon.DefaultServices, which would break a
+	// lot more than this code path.
+	return daemon.Service{Name: "xcelerate-proxy", Args: []string{"xcelerate", "start-proxy"}}
+}
+
+// ───── Private ─ DI fallbacks ─────
+
+func (a *Activator) osProxy() utils.OsProxy {
+	if a.OsProxy != nil {
+		return a.OsProxy
+	}
+
+	return utils.DefaultOsProxy{}
+}
+
+func (a *Activator) decoderFactory() utils.DecoderFactory {
+	if a.DecoderFactory != nil {
+		return a.DecoderFactory
+	}
+
+	return utils.DefaultDecoderFactory{}
+}
+
+func (a *Activator) xcodeChecker() xa.XcodeProcessChecker {
+	if a.XcodeChecker != nil {
+		return a.XcodeChecker
+	}
+
+	return xa.DefaultXcodeChecker{}
+}
+
+func (a *Activator) daemonBackend() (daemon.Backend, error) {
+	if a.DaemonBackend != nil {
+		return a.DaemonBackend, nil
+	}
+
+	return daemon.DefaultBackend() //nolint:wrapcheck // sentinel ErrUnsupportedPlatform from daemon is the right error shape
+}
+
+func (a *Activator) daemonPaths() (daemon.Paths, error) {
+	if a.DaemonPaths != nil {
+		return *a.DaemonPaths, nil
+	}
+
+	return daemon.NewPaths() //nolint:wrapcheck
+}
+
+func (a *Activator) executable() (string, error) {
+	if a.Executable != "" {
+		return a.Executable, nil
+	}
+
+	exe, err := a.osProxy().Executable()
+	if err != nil {
+		return "", fmt.Errorf("os.Executable: %w", err)
+	}
+
+	return exe, nil
+}

--- a/pkg/xcode_app/activator.go
+++ b/pkg/xcode_app/activator.go
@@ -1,14 +1,4 @@
-// Package xcode_app exposes the public API for the `bitrise-build-cache
-// xcode-app enable / disable` flows.
-//
-// The Activator wires together the building blocks under
-// internal/xcode_app and the daemon package so external Go consumers
-// (Bitrise steps, custom tooling) can drive Xcode.app cache enablement
-// without depending on cobra.
-//
-// Design follows the project's exported-struct-no-interface convention:
-// consumers define their own interfaces for mocking via Go's implicit
-// satisfaction.
+// Package xcode_app exposes the public API for the `bitrise-build-cache xcode-app enable / disable` flows.
 package xcode_app
 
 import (
@@ -26,61 +16,35 @@ import (
 	xa "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcode_app"
 )
 
-// ErrUnsupportedPlatform is returned by Enable / Disable on non-macOS hosts.
-// Xcode.app + launchctl only exist on Darwin.
+// ErrUnsupportedPlatform is returned by Enable/Disable on non-macOS hosts.
 var ErrUnsupportedPlatform = errors.New("xcode-app is only supported on macOS")
 
-// ErrXcelerateNotConfigured is returned when the xcelerate config file is
-// not on disk. enable depends on it for the proxy socket path; the user is
-// expected to run `bitrise-build-cache activate xcode` first.
+// ErrXcelerateNotConfigured is returned when the xcelerate config file is not on disk.
 var ErrXcelerateNotConfigured = errors.New("xcelerate config not found — run `bitrise-build-cache activate xcode` first")
 
-// Activator drives `xcode-app enable` / `disable`. All collaborator fields
-// are injectable; nil means "use the production default".
+// Activator drives `xcode-app enable` / `disable`. Nil fields fall back to production defaults.
 type Activator struct {
-	// Logger is the user-facing log surface. Required.
+	// Logger is required.
 	Logger log.Logger
-
-	// Envs is the environment snapshot used to detect a pre-existing
-	// XCODE_XCCONFIG_FILE override at enable time. Production callers
-	// pass utils.AllEnvs().
+	// Envs snapshots XCODE_XCCONFIG_FILE at enable time; production passes utils.AllEnvs().
 	Envs map[string]string
-
-	// OsProxy gates filesystem reads (xcelerate config). nil falls back to
-	// utils.DefaultOsProxy.
+	// OsProxy gates filesystem reads; nil = utils.DefaultOsProxy.
 	OsProxy utils.OsProxy
-
-	// DecoderFactory builds the JSON decoder for the xcelerate config.
-	// nil falls back to utils.DefaultDecoderFactory.
+	// DecoderFactory builds the JSON decoder; nil = utils.DefaultDecoderFactory.
 	DecoderFactory utils.DecoderFactory
-
-	// Launchctl handles setenv / unsetenv / bootstrap / bootout. Nil falls
-	// back to xa.LaunchctlClient{} (real `/bin/launchctl`).
+	// Launchctl handles setenv/unsetenv/bootstrap/bootout; nil = xa.LaunchctlClient{}.
 	Launchctl xa.LaunchctlClient
-
-	// XcodeChecker reports whether Xcode is currently running so we can
-	// nudge the user to relaunch. Nil falls back to
-	// xa.DefaultXcodeChecker{}.
+	// XcodeChecker reports whether Xcode is running; nil = xa.DefaultXcodeChecker{}.
 	XcodeChecker xa.XcodeProcessChecker
-
-	// DaemonBackend supervises the xcelerate-proxy service. Nil falls
-	// back to daemon.DefaultBackend(). Enable runs Install + Up filtered
-	// to the xcelerate-proxy service so the proxy is alive when Xcode.app
-	// next dials it.
+	// DaemonBackend supervises the xcelerate-proxy service; nil = daemon.DefaultBackend().
 	DaemonBackend daemon.Backend
-
-	// DaemonPaths is the supervisor paths struct. Nil falls back to
-	// daemon.NewPaths() at call time.
+	// DaemonPaths is the supervisor paths struct; nil = daemon.NewPaths().
 	DaemonPaths *daemon.Paths
-
-	// Executable is the path of this CLI binary, used as the supervisor's
-	// ProgramArguments[0]. Empty falls back to os.Executable() at call
-	// time.
+	// Executable is the supervisor's ProgramArguments[0]; empty = os.Executable().
 	Executable string
 }
 
-// EnableResult describes what Enable did. Used by the CLI command to surface
-// concrete next-step prompts (e.g. relaunch Xcode).
+// EnableResult describes what Enable did.
 type EnableResult struct {
 	XCConfigPath         string
 	LaunchAgentPlistPath string
@@ -97,13 +61,8 @@ type DisableResult struct {
 	RestoredXCConfigPath string
 }
 
-// Enable applies the Xcode.app build-cache override. See package doc for the
-// mechanism overview.
-//
-// Recovery: if Enable fails partway through (Launchctl.Setenv succeeded but
-// a later step failed), running Disable cleans up the partial state — every
-// teardown step swallows the "already gone / not loaded / not set" case, so
-// repeated runs converge on a clean state.
+// Enable applies the Xcode.app build-cache override.
+// Partial failure recovery: a follow-up Disable cleans up — each teardown step swallows the already-gone case.
 func (a *Activator) Enable(ctx context.Context) (EnableResult, error) {
 	if runtime.GOOS != "darwin" {
 		return EnableResult{}, ErrUnsupportedPlatform

--- a/pkg/xcode_app/activator.go
+++ b/pkg/xcode_app/activator.go
@@ -99,6 +99,11 @@ type DisableResult struct {
 
 // Enable applies the Xcode.app build-cache override. See package doc for the
 // mechanism overview.
+//
+// Recovery: if Enable fails partway through (Launchctl.Setenv succeeded but
+// a later step failed), running Disable cleans up the partial state — every
+// teardown step swallows the "already gone / not loaded / not set" case, so
+// repeated runs converge on a clean state.
 func (a *Activator) Enable(ctx context.Context) (EnableResult, error) {
 	if runtime.GOOS != "darwin" {
 		return EnableResult{}, ErrUnsupportedPlatform
@@ -116,14 +121,33 @@ func (a *Activator) Enable(ctx context.Context) (EnableResult, error) {
 		return EnableResult{}, fmt.Errorf("xcelerate config has empty proxy socket path — re-run `activate xcode`")
 	}
 
-	previous := a.Envs["XCODE_XCCONFIG_FILE"]
+	xcconfigPath := xa.OverrideXCConfigPath(osProxy)
+	statePath := xa.StateFilePath(osProxy)
+
+	// Self-loop guard. After a successful enable, launchctl exports our
+	// override path into the GUI session; any shell spawned from that
+	// session inherits XCODE_XCCONFIG_FILE pointing at our own xcconfig.
+	// A second enable would then read its own xcconfig path as the
+	// "previous" override and clobber the state file, losing the original
+	// user-supplied prior path forever (and disable would later "restore"
+	// to our own subsequently-deleted xcconfig). When we see the self-loop,
+	// fall back to the PreviousXCConfigPath already on disk so re-enabling
+	// is idempotent.
+	previous := a.Envs[xa.XCConfigEnvVar]
+	if previous == xcconfigPath {
+		if existing, found, loadErr := xa.LoadState(statePath); loadErr == nil && found {
+			previous = existing.PreviousXCConfigPath
+		} else {
+			// Existing state unreadable or absent — treat the env value as
+			// noise rather than a real prior override.
+			previous = ""
+		}
+	}
 
 	body, err := xa.RenderOverride(cfg.ProxySocketPath, previous)
 	if err != nil {
 		return EnableResult{}, fmt.Errorf("render override xcconfig: %w", err)
 	}
-
-	xcconfigPath := xa.OverrideXCConfigPath(osProxy)
 
 	if err := osProxy.MkdirAll(xcelerate.DirPath(osProxy), 0o755); err != nil {
 		return EnableResult{}, fmt.Errorf("mkdir xcelerate dir: %w", err)
@@ -133,7 +157,7 @@ func (a *Activator) Enable(ctx context.Context) (EnableResult, error) {
 		return EnableResult{}, fmt.Errorf("write %s: %w", xcconfigPath, err)
 	}
 
-	if err := xa.SaveState(xa.StateFilePath(osProxy), xa.State{PreviousXCConfigPath: previous}); err != nil {
+	if err := xa.SaveState(statePath, xa.State{PreviousXCConfigPath: previous}); err != nil {
 		return EnableResult{}, fmt.Errorf("save state: %w", err)
 	}
 
@@ -253,7 +277,10 @@ func (a *Activator) installAndStartProxy(ctx context.Context) error {
 		return err
 	}
 
-	svc := xcelerateProxyService()
+	svc, err := xcelerateProxyService()
+	if err != nil {
+		return err
+	}
 
 	if _, err := daemon.Install(ctx, backend, paths, []daemon.Service{svc}, executable); err != nil {
 		return fmt.Errorf("daemon install: %w", err)
@@ -270,17 +297,19 @@ func (a *Activator) installAndStartProxy(ctx context.Context) error {
 // daemon's DefaultServices set. We deliberately don't drive ccache-helper
 // from here — Xcode.app builds don't use ccache, and bundling the two would
 // surprise C/C++-only users.
-func xcelerateProxyService() daemon.Service {
+//
+// Returns an error rather than a hardcoded fallback if the daemon package
+// ever drops xcelerate-proxy — silent divergence between this caller and
+// daemon's canonical definition would mean shipping a different supervisor
+// config than the rest of the CLI thinks is current.
+func xcelerateProxyService() (daemon.Service, error) {
 	for _, s := range daemon.DefaultServices() {
 		if s.Name == "xcelerate-proxy" {
-			return s
+			return s, nil
 		}
 	}
 
-	// Defensive — the only way to reach this is if someone removes
-	// xcelerate-proxy from daemon.DefaultServices, which would break a
-	// lot more than this code path.
-	return daemon.Service{Name: "xcelerate-proxy", Args: []string{"xcelerate", "start-proxy"}}
+	return daemon.Service{}, fmt.Errorf("daemon.DefaultServices() no longer includes 'xcelerate-proxy' — refusing to fall back to a stale hardcoded service definition")
 }
 
 // ───── Private ─ DI fallbacks ─────

--- a/pkg/xcode_app/activator.go
+++ b/pkg/xcode_app/activator.go
@@ -16,35 +16,23 @@ import (
 	xa "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcode_app"
 )
 
-// ErrUnsupportedPlatform is returned by Enable/Disable on non-macOS hosts.
 var ErrUnsupportedPlatform = errors.New("xcode-app is only supported on macOS")
 
-// ErrXcelerateNotConfigured is returned when the xcelerate config file is not on disk.
 var ErrXcelerateNotConfigured = errors.New("xcelerate config not found — run `bitrise-build-cache activate xcode` first")
 
-// Activator drives `xcode-app enable` / `disable`. Nil fields fall back to production defaults.
+// Activator nil fields fall back to production defaults.
 type Activator struct {
-	// Logger is required.
-	Logger log.Logger
-	// Envs snapshots XCODE_XCCONFIG_FILE at enable time; production passes utils.AllEnvs().
-	Envs map[string]string
-	// OsProxy gates filesystem reads; nil = utils.DefaultOsProxy.
-	OsProxy utils.OsProxy
-	// DecoderFactory builds the JSON decoder; nil = utils.DefaultDecoderFactory.
+	Logger         log.Logger
+	Envs           map[string]string
+	OsProxy        utils.OsProxy
 	DecoderFactory utils.DecoderFactory
-	// Launchctl handles setenv/unsetenv/bootstrap/bootout; nil = xa.LaunchctlClient{}.
-	Launchctl xa.LaunchctlClient
-	// XcodeChecker reports whether Xcode is running; nil = xa.DefaultXcodeChecker{}.
-	XcodeChecker xa.XcodeProcessChecker
-	// DaemonBackend supervises the xcelerate-proxy service; nil = daemon.DefaultBackend().
-	DaemonBackend daemon.Backend
-	// DaemonPaths is the supervisor paths struct; nil = daemon.NewPaths().
-	DaemonPaths *daemon.Paths
-	// Executable is the supervisor's ProgramArguments[0]; empty = os.Executable().
-	Executable string
+	Launchctl      xa.LaunchctlClient
+	XcodeChecker   xa.XcodeProcessChecker
+	DaemonBackend  daemon.Backend
+	DaemonPaths    *daemon.Paths
+	Executable     string
 }
 
-// EnableResult describes what Enable did.
 type EnableResult struct {
 	XCConfigPath         string
 	LaunchAgentPlistPath string
@@ -53,7 +41,6 @@ type EnableResult struct {
 	RunningXcodePIDs     []int
 }
 
-// DisableResult describes what Disable did.
 type DisableResult struct {
 	XCConfigRemoved      bool
 	LaunchAgentRemoved   bool
@@ -61,8 +48,7 @@ type DisableResult struct {
 	RestoredXCConfigPath string
 }
 
-// Enable applies the Xcode.app build-cache override.
-// Partial failure recovery: a follow-up Disable cleans up — each teardown step swallows the already-gone case.
+// Enable: on partial failure, follow-up Disable cleans up — each teardown step swallows already-gone.
 func (a *Activator) Enable(ctx context.Context) (EnableResult, error) {
 	if runtime.GOOS != "darwin" {
 		return EnableResult{}, ErrUnsupportedPlatform
@@ -83,15 +69,7 @@ func (a *Activator) Enable(ctx context.Context) (EnableResult, error) {
 	xcconfigPath := xa.OverrideXCConfigPath(osProxy)
 	statePath := xa.StateFilePath(osProxy)
 
-	// Self-loop guard. After a successful enable, launchctl exports our
-	// override path into the GUI session; any shell spawned from that
-	// session inherits XCODE_XCCONFIG_FILE pointing at our own xcconfig.
-	// A second enable would then read its own xcconfig path as the
-	// "previous" override and clobber the state file, losing the original
-	// user-supplied prior path forever (and disable would later "restore"
-	// to our own subsequently-deleted xcconfig). When we see the self-loop,
-	// fall back to the PreviousXCConfigPath already on disk so re-enabling
-	// is idempotent.
+	// Self-loop guard: a second enable inheriting our own override path would clobber the state file and lose the original prior path.
 	previous := a.Envs[xa.XCConfigEnvVar]
 	if previous == xcconfigPath {
 		if existing, found, loadErr := xa.LoadState(statePath); loadErr == nil && found {
@@ -156,8 +134,7 @@ func (a *Activator) Enable(ctx context.Context) (EnableResult, error) {
 	}, nil
 }
 
-// Disable reverses what Enable did. Safe to run repeatedly — every step is
-// idempotent against "never enabled" / "already disabled".
+// Disable is idempotent against "never enabled" / "already disabled".
 func (a *Activator) Disable(ctx context.Context) (DisableResult, error) {
 	if runtime.GOOS != "darwin" {
 		return DisableResult{}, ErrUnsupportedPlatform
@@ -252,15 +229,8 @@ func (a *Activator) installAndStartProxy(ctx context.Context) error {
 	return nil
 }
 
-// xcelerateProxyService picks the xcelerate-proxy service out of the
-// daemon's DefaultServices set. We deliberately don't drive ccache-helper
-// from here — Xcode.app builds don't use ccache, and bundling the two would
-// surprise C/C++-only users.
-//
-// Returns an error rather than a hardcoded fallback if the daemon package
-// ever drops xcelerate-proxy — silent divergence between this caller and
-// daemon's canonical definition would mean shipping a different supervisor
-// config than the rest of the CLI thinks is current.
+// xcelerateProxyService excludes ccache-helper intentionally — Xcode.app builds don't use ccache.
+// Errors rather than falling back so this caller and daemon's canonical service set can't silently diverge.
 func xcelerateProxyService() (daemon.Service, error) {
 	for _, s := range daemon.DefaultServices() {
 		if s.Name == "xcelerate-proxy" {

--- a/pkg/xcode_app/activator_darwin_test.go
+++ b/pkg/xcode_app/activator_darwin_test.go
@@ -1,0 +1,280 @@
+//go:build unit && darwin
+
+package xcode_app
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+	xa "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcode_app"
+)
+
+// stubBackend implements daemon.Backend without touching the OS supervisor.
+// Records Install/Start calls so tests can assert the activator wired the
+// xcelerate-proxy service through correctly.
+type stubBackend struct {
+	installed []daemon.Service
+	started   []daemon.Service
+}
+
+// Name returns "launchd" so daemon.Up's configPath dispatcher uses
+// PlistPath — the test setup writes the supervisor config under that exact
+// path so the Stat-then-Start check inside daemon.Up succeeds.
+func (*stubBackend) Name() string { return "launchd" }
+
+func (b *stubBackend) Install(_ context.Context, paths daemon.Paths, svc daemon.Service, _ string) (string, error) {
+	b.installed = append(b.installed, svc)
+
+	// daemon.Up does Stat-then-Start on the plist path; write a placeholder
+	// so the upstream Stat succeeds. The contents don't matter — the stub
+	// Start ignores them.
+	path := paths.PlistPath(svc.Label())
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil { //nolint:gosec // test plist must be readable
+		return "", err
+	}
+
+	return path, nil
+}
+
+func (b *stubBackend) Uninstall(_ context.Context, paths daemon.Paths, svc daemon.Service) (string, bool, error) {
+	return paths.PlistPath(svc.Label()), true, nil
+}
+
+func (b *stubBackend) Start(_ context.Context, _ daemon.Paths, svc daemon.Service) error {
+	b.started = append(b.started, svc)
+
+	return nil
+}
+
+func (*stubBackend) Stop(_ context.Context, _ daemon.Paths, _ daemon.Service) error { return nil }
+
+// recordingRunner is a daemon.CommandRunner that captures the args of every
+// invocation so tests can assert on the launchctl calls the activator made.
+type recordingRunner struct {
+	calls [][]string
+}
+
+func (r *recordingRunner) Run(_ context.Context, bin string, args ...string) (string, string, int, error) {
+	r.calls = append(r.calls, append([]string{bin}, args...))
+
+	return "", "", 0, nil
+}
+
+// stubXcodeChecker reports no running Xcode processes; tests that care about
+// the relaunch nudge construct a different one inline.
+type stubXcodeChecker struct{ pids []int }
+
+func (s stubXcodeChecker) RunningPIDs(_ context.Context) ([]int, error) {
+	return s.pids, nil
+}
+
+// setupDarwinFixture wires t.TempDir() as $HOME and seeds a valid xcelerate
+// config so ReadConfig succeeds.
+func setupDarwinFixture(t *testing.T, proxySocket string) (home string) {
+	t.Helper()
+
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+
+	xceleratehome := filepath.Join(home, ".bitrise-xcelerate")
+	require.NoError(t, os.MkdirAll(xceleratehome, 0o755))
+
+	cfg := map[string]any{
+		"proxyVersion":           "test",
+		"proxySocketPath":        proxySocket,
+		"cliVersion":             "test",
+		"wrapperVersion":         "test",
+		"originalXcodebuildPath": "/usr/bin/xcodebuild",
+		"originalXcrunPath":      "/usr/bin/xcrun",
+		"buildCacheEnabled":      true,
+		"buildCacheSkipFlags":    false,
+		"buildCacheEndpoint":     "",
+		"pushEnabled":            true,
+	}
+	raw, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(xceleratehome, "config.json"), raw, 0o644))
+
+	return home
+}
+
+func newActivatorForTest(t *testing.T, home string, envs map[string]string) (*Activator, *recordingRunner, *stubBackend) {
+	t.Helper()
+
+	runner := &recordingRunner{}
+	backend := &stubBackend{}
+	paths := daemon.NewPathsFromHome(home)
+
+	a := &Activator{
+		Logger:        newLogger(),
+		Envs:          envs,
+		Launchctl:     xa.LaunchctlClient{Runner: runner, Bin: "/fake/launchctl"},
+		XcodeChecker:  stubXcodeChecker{},
+		DaemonBackend: backend,
+		DaemonPaths:   &paths,
+		Executable:    "/fake/cli",
+	}
+
+	return a, runner, backend
+}
+
+func TestEnable_writesXCConfigAndStateFile_noPrevious(t *testing.T) {
+	home := setupDarwinFixture(t, "/tmp/xcelerate-proxy.sock")
+	a, runner, backend := newActivatorForTest(t, home, map[string]string{})
+
+	got, err := a.Enable(context.Background())
+	require.NoError(t, err)
+
+	xcconfigPath := filepath.Join(home, ".bitrise-xcelerate", xa.OverrideXCConfigFileName)
+	assert.Equal(t, xcconfigPath, got.XCConfigPath)
+
+	content, err := os.ReadFile(xcconfigPath) //nolint:gosec
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "COMPILATION_CACHE_REMOTE_SERVICE_PATH = /tmp/xcelerate-proxy.sock")
+	assert.NotContains(t, string(content), "#include")
+
+	statePath := filepath.Join(home, ".bitrise-xcelerate", xa.StateFileName)
+	state, found, err := xa.LoadState(statePath)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Empty(t, state.PreviousXCConfigPath, "no previous override at enable time")
+
+	assertLaunchctlCall(t, runner, "setenv", xa.XCConfigEnvVar, xcconfigPath)
+
+	require.Len(t, backend.installed, 1)
+	assert.Equal(t, "xcelerate-proxy", backend.installed[0].Name)
+	require.Len(t, backend.started, 1)
+	assert.Equal(t, "xcelerate-proxy", backend.started[0].Name)
+}
+
+func TestEnable_chainsPreviousXCConfigViaInclude(t *testing.T) {
+	home := setupDarwinFixture(t, "/tmp/xcelerate-proxy.sock")
+	previousPath := "/Users/me/Base.xcconfig"
+	a, _, _ := newActivatorForTest(t, home, map[string]string{xa.XCConfigEnvVar: previousPath})
+
+	_, err := a.Enable(context.Background())
+	require.NoError(t, err)
+
+	xcconfigPath := filepath.Join(home, ".bitrise-xcelerate", xa.OverrideXCConfigFileName)
+	content, err := os.ReadFile(xcconfigPath) //nolint:gosec
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `#include "/Users/me/Base.xcconfig"`)
+
+	state, found, err := xa.LoadState(filepath.Join(home, ".bitrise-xcelerate", xa.StateFileName))
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, previousPath, state.PreviousXCConfigPath)
+}
+
+func TestEnable_selfLoopPreservesOriginalState(t *testing.T) {
+	// Regression for the review's blocker (issue 1).
+	//
+	// First enable: previous == "/Users/me/Base.xcconfig" — user's real
+	// prior override. Stored on disk.
+	// Second enable: previous == our own override path (would happen if
+	// the user re-runs enable from a shell launched in the GUI session
+	// that already inherited our XCODE_XCCONFIG_FILE). Activator must
+	// preserve "/Users/me/Base.xcconfig" in state — not clobber it with
+	// our own path.
+	home := setupDarwinFixture(t, "/tmp/xcelerate-proxy.sock")
+	originalPath := "/Users/me/Base.xcconfig"
+
+	// First enable with the real user-supplied prior override.
+	a, _, _ := newActivatorForTest(t, home, map[string]string{xa.XCConfigEnvVar: originalPath})
+	_, err := a.Enable(context.Background())
+	require.NoError(t, err)
+
+	xcconfigPath := filepath.Join(home, ".bitrise-xcelerate", xa.OverrideXCConfigFileName)
+
+	// Second enable — env now points at our own xcconfig (the self-loop).
+	a2, _, _ := newActivatorForTest(t, home, map[string]string{xa.XCConfigEnvVar: xcconfigPath})
+	_, err = a2.Enable(context.Background())
+	require.NoError(t, err)
+
+	state, found, err := xa.LoadState(filepath.Join(home, ".bitrise-xcelerate", xa.StateFileName))
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, originalPath, state.PreviousXCConfigPath, "state must still point at the user's real prior override after the self-loop")
+
+	// Override xcconfig must also keep the `#include` of the original.
+	content, err := os.ReadFile(xcconfigPath) //nolint:gosec
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `#include "`+originalPath+`"`)
+}
+
+func TestDisable_restoresPreviousXCConfig(t *testing.T) {
+	home := setupDarwinFixture(t, "/tmp/xcelerate-proxy.sock")
+	previousPath := "/Users/me/Base.xcconfig"
+	a, runner, _ := newActivatorForTest(t, home, map[string]string{xa.XCConfigEnvVar: previousPath})
+
+	_, err := a.Enable(context.Background())
+	require.NoError(t, err)
+
+	got, err := a.Disable(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, got.LaunchAgentRemoved)
+	assert.True(t, got.XCConfigRemoved)
+	assert.Equal(t, previousPath, got.RestoredXCConfigPath)
+
+	// State file gone.
+	_, found, err := xa.LoadState(filepath.Join(home, ".bitrise-xcelerate", xa.StateFileName))
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	// XCConfig override gone.
+	_, statErr := os.Stat(filepath.Join(home, ".bitrise-xcelerate", xa.OverrideXCConfigFileName))
+	require.Error(t, statErr)
+
+	// Last launchctl call is setenv to the restored previous path.
+	assertLaunchctlCall(t, runner, "setenv", xa.XCConfigEnvVar, previousPath)
+}
+
+func TestDisable_noPriorStateClearsEnv(t *testing.T) {
+	home := setupDarwinFixture(t, "/tmp/xcelerate-proxy.sock")
+	a, runner, _ := newActivatorForTest(t, home, map[string]string{})
+
+	_, err := a.Enable(context.Background())
+	require.NoError(t, err)
+
+	got, err := a.Disable(context.Background())
+	require.NoError(t, err)
+
+	assert.Empty(t, got.RestoredXCConfigPath)
+	assertLaunchctlCall(t, runner, "unsetenv", xa.XCConfigEnvVar)
+}
+
+// assertLaunchctlCall asserts the recorded runner saw at least one call
+// whose args exactly match the supplied verb + value tuple (in order). Used
+// to verify Activator sent the right launchctl invocations without caring
+// about ordering between setenv and bootstrap.
+func assertLaunchctlCall(t *testing.T, runner *recordingRunner, verbAndArgs ...string) {
+	t.Helper()
+
+	for _, call := range runner.calls {
+		// Skip the launchctl bin position; compare from args[1:].
+		if len(call) < 1+len(verbAndArgs) {
+			continue
+		}
+
+		joined := strings.Join(call[1:1+len(verbAndArgs)], "\x00")
+		want := strings.Join(verbAndArgs, "\x00")
+		if joined == want {
+			return
+		}
+	}
+
+	t.Fatalf("expected a launchctl call with args %v; got %v", verbAndArgs, runner.calls)
+}

--- a/pkg/xcode_app/activator_test.go
+++ b/pkg/xcode_app/activator_test.go
@@ -1,0 +1,47 @@
+//go:build unit
+
+package xcode_app
+
+import (
+	"bytes"
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// On non-darwin hosts Enable / Disable short-circuit to the sentinel without
+// touching the filesystem or launchctl. We can only validate this branch on
+// a non-darwin runner; the happy path is exercised through the internal
+// package tests + manual macOS verification + the daemon-install-macos e2e.
+
+func newLogger() log.Logger {
+	return log.NewLogger(log.WithOutput(&bytes.Buffer{}))
+}
+
+func TestEnable_returnsErrUnsupportedPlatformOnNonDarwin(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("non-darwin-only assertion")
+	}
+
+	a := &Activator{Logger: newLogger()}
+
+	_, err := a.Enable(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedPlatform)
+}
+
+func TestDisable_returnsErrUnsupportedPlatformOnNonDarwin(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("non-darwin-only assertion")
+	}
+
+	a := &Activator{Logger: newLogger()}
+
+	_, err := a.Disable(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedPlatform)
+}


### PR DESCRIPTION
## Summary

- Adds `bitrise-build-cache xcode-app enable` / `disable` so Xcode.app (GUI) builds use the compile cache without going through the `xcodebuild` wrapper. Targets the #1 iOS-customer ask (Foreflight / Redfin / Depop / Expedia).
- `enable` writes an override `xcconfig` under `~/.bitrise-xcelerate/`, runs `launchctl setenv XCODE_XCCONFIG_FILE`, registers a one-shot LaunchAgent that re-applies the `setenv` on login, and installs + starts the `xcelerate-proxy` daemon service. Detects running Xcode and nudges the user to relaunch.
- ACI-5042 is folded in: if `XCODE_XCCONFIG_FILE` is already set at enable time, the previous path is `#include`-chained at the top of our override and captured in a state file. `disable` restores it.

## Mechanism

Per the [E1 spike doc](docs/xcode-companion-app-spike-2026-05-22.md): the override slot wins over all per-project / per-target xcconfigs but stays below `xcodebuild` CLI args, so the `xcodebuild` wrapper flow is unaffected. The xcconfig writes:

- `COMPILATION_CACHE_REMOTE_SERVICE_PATH` → the xcelerate-proxy unix socket (read from `~/.bitrise-xcelerate/config.json`)
- All key/value pairs from `internal/xcelerate/xcodeargs.CacheArgs` (`COMPILATION_CACHE_ENABLE_PLUGIN/INTEGRATED_QUERIES/DETACHED_KEY_QUERIES`, `SWIFT_*`, `CLANG_*`)

## Layout

- `cmd/xcode_app/{xcode_app,enable,disable}.go` — cobra wrapper, registered in `main.go` via blank import
- `pkg/xcode_app/activator.go` — public `Activator` struct; all collaborators injectable, nil = production default
- `internal/xcode_app/`:
  - `paths.go` — override xcconfig + state file paths under `~/.bitrise-xcelerate/`
  - `xcconfig.go` — render override, with optional `#include` chain (E3)
  - `state.go` — atomic write-temp-rename JSON capturing the previous `XCODE_XCCONFIG_FILE` for restore on disable
  - `launchctl.go` — `setenv` / `unsetenv` / `bootstrap` / `bootout` wrappers; reuses `daemon.CommandRunner` + `daemon.ExecRunner` for identical `LC_ALL=C` locale pinning + exit-code propagation
  - `launch_agent.go` — renders the one-shot LaunchAgent plist that re-runs `launchctl setenv` on login (so the env survives logout)
  - `xcode_running.go` — `pgrep -x Xcode` for the relaunch nudge

## Sentinels

- `xcode_app.ErrUnsupportedPlatform` — `xcode-app` is darwin-only (Xcode + `launchctl`).
- `xcode_app.ErrXcelerateNotConfigured` — `enable` requires `~/.bitrise-xcelerate/config.json` to exist for the proxy socket path. Hint message points the user at `activate xcode`.

## Stacked PR

Based on `aci-5029-install-doc` (top of the M1 stack). GitHub will auto-retarget to `main` once M1 lands.

## Test plan

- [ ] `make check` (lint + unit) passes locally — done.
- [ ] Manual on macOS:
  - [ ] `bitrise-build-cache activate xcode` → ensure `~/.bitrise-xcelerate/config.json` exists.
  - [ ] `bitrise-build-cache xcode-app enable` → check that `~/.bitrise-xcelerate/xcode-app.xcconfig` is written, `launchctl getenv XCODE_XCCONFIG_FILE` points to it, `~/Library/LaunchAgents/io.bitrise.build-cache.xcode-app-setenv.plist` is bootstrapped, xcelerate-proxy is running.
  - [ ] Relaunch Xcode, build a small project, verify the proxy log shows incoming requests + hit rate moves.
  - [ ] `bitrise-build-cache xcode-app disable` → confirm reversal: env unset, plist gone, xcconfig removed.
  - [ ] Re-run `enable` with a pre-existing `XCODE_XCCONFIG_FILE`, confirm `#include` chain works and `disable` restores the prior value.

## Out of scope

- E4 (`docs/`-side public doc) — separate ticket (ACI-5043).
- F1 / F2 (analytics emit + xcactivitylog watcher) — blocked on M1 daemon merging; separate tickets (ACI-5044 / ACI-5045).
- Xcode-beta / multi-Xcode coverage — `pgrep -x Xcode` only matches the GA app; beta users can re-run `enable` themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)