### PR TITLE
docs: ACI-5043 Xcode.app integration one-pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Authentication is via two env vars (PAT + workspace ID) — see the [post-instal
 
 > The CLI configures the environment it's running in. If you're running commands in Docker containers, run the CLI inside the same container as Gradle/Bazel/Xcode/ccache.
 
+### Xcode.app (GUI builds)
+
+Pressing ▶ in Xcode.app bypasses the `xcodebuild` wrapper. Use `bitrise-build-cache xcode-app enable` to install an `XCODE_XCCONFIG_FILE` override so the GUI build pipeline also picks up the cache. See [`docs/xcode-app.md`](docs/xcode-app.md) for the full flow + a repo-controlled helper script pattern for team-wide rollout. macOS only.
+
 
 ## What does the CLI do on a high level?
 

--- a/docs/xcode-app.md
+++ b/docs/xcode-app.md
@@ -1,0 +1,211 @@
+# Use the Bitrise Build Cache from Xcode.app (GUI builds)
+
+A one-page guide for enabling the compile cache when you press ▶ in
+Xcode.app. The default `xcodebuild` wrapper only kicks in for command-line
+builds — this page covers the GUI case.
+
+For the underlying CLI install + auth, see
+[`docs/install.md`](install.md) first.
+
+---
+
+## TL;DR
+
+```sh
+# 1) one-time CLI + auth setup (see docs/install.md)
+brew install bitrise-io/bitrise-build-cache/bitrise-build-cache
+export BITRISE_BUILD_CACHE_AUTH_TOKEN="<PAT>"
+export BITRISE_BUILD_CACHE_WORKSPACE_ID="<workspace-slug>"
+
+# 2) configure the Xcode compile cache + start the proxy daemon
+bitrise-build-cache activate xcode
+bitrise-build-cache daemon install
+bitrise-build-cache daemon up
+
+# 3) enable the override for Xcode.app GUI builds
+bitrise-build-cache xcode-app enable
+
+# 4) relaunch Xcode, then build any target
+```
+
+macOS only. Linux + Windows don't ship Xcode.
+
+---
+
+## How it works
+
+Xcode.app drives its build planner through `XCBBuildService` — the
+`xcodebuild` wrapper is bypassed for GUI builds. Apple exposes a single
+override slot, `XCODE_XCCONFIG_FILE`, that sits above per-target / per-base
+xcconfig but below `xcodebuild` CLI args.
+
+`xcode-app enable` does three things:
+
+1. Writes an override `xcconfig` to
+   `~/.bitrise-xcelerate/xcode-app.xcconfig` containing
+   `COMPILATION_CACHE_REMOTE_SERVICE_PATH` plus the
+   `COMPILATION_CACHE_ENABLE_*` / `SWIFT_*` / `CLANG_*` keys.
+2. Runs `launchctl setenv XCODE_XCCONFIG_FILE <path>` so processes spawned
+   from the current GUI session inherit the override.
+3. Installs a one-shot LaunchAgent
+   (`~/Library/LaunchAgents/io.bitrise.build-cache.xcode-app-setenv.plist`)
+   that re-applies the `setenv` on every login, so the override survives
+   logout.
+
+The xcelerate-proxy daemon is also installed + started so Xcode.app has a
+socket to dial.
+
+---
+
+## Prerequisites
+
+| Step                                             | Why                                                                                                        |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `bitrise-build-cache --version` works            | Confirms the CLI is on `$PATH`. See [`docs/install.md`](install.md).                                       |
+| Auth env vars exported                           | `BITRISE_BUILD_CACHE_AUTH_TOKEN` + `BITRISE_BUILD_CACHE_WORKSPACE_ID`. See [post-install](install.md#post-install). |
+| `bitrise-build-cache activate xcode` has run     | Writes `~/.bitrise-xcelerate/config.json` containing the proxy socket path that `xcode-app enable` reads.  |
+| `bitrise-build-cache daemon install && daemon up` | Registers + starts the xcelerate-proxy service via launchd so Xcode.app finds it on first dial.            |
+
+`xcode-app enable` errors with a clear hint if any of these are missing.
+
+---
+
+## Enable
+
+```sh
+bitrise-build-cache xcode-app enable
+```
+
+Output looks like:
+
+```
+✓ Wrote override xcconfig: /Users/<you>/.bitrise-xcelerate/xcode-app.xcconfig
+✓ Set XCODE_XCCONFIG_FILE via launchctl (LaunchAgent: …/io.bitrise.build-cache.xcode-app-setenv.plist)
+✓ Proxy socket: /var/folders/.../xcelerate-proxy.sock
+! Xcode is currently running (pid [1234]). Quit and relaunch Xcode to pick up the cache override.
+```
+
+> **Relaunch Xcode after enable.** `launchctl setenv` only reaches processes
+> launched *after* it ran. Already-open Xcode windows pick up the override
+> only on the next launch. Use ⌘Q (not just close the window).
+
+---
+
+## Verify the override is in effect
+
+After relaunching Xcode, three quick checks:
+
+```sh
+# 1. The env is set in the GUI session:
+launchctl getenv XCODE_XCCONFIG_FILE
+
+# 2. The proxy is running:
+bitrise-build-cache doctor
+
+# 3. Build any target. The doctor output should show the proxy has been
+#    dialled at least once (logs under ~/.local/state/xcelerate/logs/).
+```
+
+If `launchctl getenv` prints nothing, the LaunchAgent didn't bootstrap —
+re-run `xcode-app enable` and check the output for the LaunchAgent error.
+
+If `doctor` reports the proxy is not running, run
+`bitrise-build-cache daemon up`. The override expects the proxy to be
+listening — Xcode silently skips the cache if the socket isn't there.
+
+---
+
+## Chaining an existing `XCODE_XCCONFIG_FILE`
+
+If you (or your tooling) already set `XCODE_XCCONFIG_FILE` to a custom
+xcconfig, `enable` captures the existing value and **chains it** into our
+override via `#include` at the top of the file:
+
+```text
+// Bitrise Build Cache — Xcode.app override
+// Written by `bitrise-build-cache xcode-app enable`.
+
+#include "/Users/<you>/path/to/your/Base.xcconfig"
+
+COMPILATION_CACHE_ENABLE_DETACHED_KEY_QUERIES = YES
+...
+```
+
+Your settings keep winning where they don't collide with the
+`COMPILATION_CACHE_*` keys. `disable` restores the prior value into
+`launchctl` so re-enabling later picks up the same chain.
+
+> **List settings** (`OTHER_CFLAGS`, `OTHER_LDFLAGS` etc.) — none today, but
+> if a future override ever appends to one, use `$(inherited)` in the chained
+> xcconfig so your values aren't dropped.
+
+---
+
+## Disable
+
+```sh
+bitrise-build-cache xcode-app disable
+```
+
+Reverses every step:
+
+- `launchctl bootout` + remove the LaunchAgent plist.
+- `launchctl unsetenv XCODE_XCCONFIG_FILE` — or, if a prior path was chained
+  in at enable time, `launchctl setenv` back to it.
+- Remove our override xcconfig from `~/.bitrise-xcelerate/`.
+
+Idempotent — safe to run when nothing is enabled. Does **not** stop the
+xcelerate-proxy daemon; use `bitrise-build-cache daemon down` for that.
+
+---
+
+## Team-wide rollout (repo-controlled helper script)
+
+Most iOS teams want the override applied for every developer on the team
+without each person memorising the exact command. Ship a small script in
+the repo:
+
+```sh
+# scripts/enable-bitrise-build-cache.sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v bitrise-build-cache >/dev/null; then
+  echo "Install the CLI first: see docs/install.md" >&2
+  exit 1
+fi
+
+# Auth env vars must already be set by the developer's shell rc.
+# Workspace credentials are personal — never commit them.
+
+bitrise-build-cache activate xcode
+bitrise-build-cache daemon install
+bitrise-build-cache daemon up
+bitrise-build-cache xcode-app enable
+```
+
+Document in your repo's `README.md` that running
+`./scripts/enable-bitrise-build-cache.sh` after the first `git clone` is
+all that's needed.
+
+> **Auth credentials stay personal.** Each developer's PAT is tied to their
+> Bitrise account; never commit it to the repo. The helper script assumes
+> the env vars are already exported by the developer's shell rc.
+
+---
+
+## Troubleshooting
+
+| Symptom                                                            | First thing to try                                                                                  |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `enable` errors with `xcelerate config not found`                  | Run `bitrise-build-cache activate xcode` first — that writes the proxy socket path enable depends on. |
+| `enable` succeeds but builds aren't using the cache                | Relaunched Xcode? `launchctl setenv` only reaches processes launched after `enable` ran.            |
+| `launchctl getenv XCODE_XCCONFIG_FILE` prints nothing              | The LaunchAgent failed to bootstrap. Re-run `enable` and read the error.                            |
+| `bitrise-build-cache doctor` says the proxy is down                | `bitrise-build-cache daemon up`. Override expects the proxy listening.                              |
+| Your project's existing `XCODE_XCCONFIG_FILE` was overwritten      | `disable` restores it. If state got out of sync, manually `launchctl setenv` to the prior path.     |
+| Want to skip the cache for a single build                          | Hold ⌥ when clicking Run / pass `XCODE_XCCONFIG_FILE=""` to a one-off `xcodebuild` invocation.      |
+| Multiple Xcode installs (Xcode-beta etc.)                          | The override applies to every Xcode launched after `setenv`. Only the GA `Xcode` process gets the relaunch nudge — beta users should quit-and-relaunch manually. |
+
+For deeper logging, prepend `-d`
+(`bitrise-build-cache -d xcode-app enable`). Open issues at
+[github.com/bitrise-io/bitrise-build-cache-cli](https://github.com/bitrise-io/bitrise-build-cache-cli/issues).

--- a/docs/xcode-app.md
+++ b/docs/xcode-app.md
@@ -17,12 +17,11 @@ brew install bitrise-io/bitrise-build-cache/bitrise-build-cache
 export BITRISE_BUILD_CACHE_AUTH_TOKEN="<PAT>"
 export BITRISE_BUILD_CACHE_WORKSPACE_ID="<workspace-slug>"
 
-# 2) configure the Xcode compile cache + start the proxy daemon
+# 2) configure the Xcode compile cache (writes ~/.bitrise-xcelerate/config.json)
 bitrise-build-cache activate xcode
-bitrise-build-cache daemon install
-bitrise-build-cache daemon up
 
 # 3) enable the override for Xcode.app GUI builds
+#    (also installs + starts the xcelerate-proxy daemon for you)
 bitrise-build-cache xcode-app enable
 
 # 4) relaunch Xcode, then build any target
@@ -64,9 +63,8 @@ socket to dial.
 | `bitrise-build-cache --version` works            | Confirms the CLI is on `$PATH`. See [`docs/install.md`](install.md).                                       |
 | Auth env vars exported                           | `BITRISE_BUILD_CACHE_AUTH_TOKEN` + `BITRISE_BUILD_CACHE_WORKSPACE_ID`. See [post-install](install.md#post-install). |
 | `bitrise-build-cache activate xcode` has run     | Writes `~/.bitrise-xcelerate/config.json` containing the proxy socket path that `xcode-app enable` reads.  |
-| `bitrise-build-cache daemon install && daemon up` | Registers + starts the xcelerate-proxy service via launchd so Xcode.app finds it on first dial.            |
 
-`xcode-app enable` errors with a clear hint if any of these are missing.
+`xcode-app enable` installs + starts the xcelerate-proxy service itself (filtered subset of `daemon install + up`), so you don't need to run those separately. If you've already registered the daemon for other tools (ccache etc.), the proxy install is a no-op. `xcode-app enable` errors with a clear hint if the CLI / auth / `activate xcode` prerequisite is missing.
 
 ---
 
@@ -85,6 +83,16 @@ Output looks like:
 ! Xcode is currently running (pid [1234]). Quit and relaunch Xcode to pick up the cache override.
 ```
 
+If you already had `XCODE_XCCONFIG_FILE` pointing at a project xcconfig, you'll see an extra line above the LaunchAgent confirmation:
+
+```
+Chained previous XCODE_XCCONFIG_FILE: /Users/<you>/path/to/your/Base.xcconfig
+```
+
+See [Chaining an existing `XCODE_XCCONFIG_FILE`](#chaining-an-existing-xcode_xcconfig_file) for what that means.
+
+Re-running `enable` after a successful `enable` is safe — the activator detects the self-loop (`launchctl getenv XCODE_XCCONFIG_FILE` now points at our own override) and preserves the original prior-path state on disk, so `disable` later still restores the right xcconfig.
+
 > **Relaunch Xcode after enable.** `launchctl setenv` only reaches processes
 > launched *after* it ran. Already-open Xcode windows pick up the override
 > only on the next launch. Use ⌘Q (not just close the window).
@@ -96,20 +104,29 @@ Output looks like:
 After relaunching Xcode, three quick checks:
 
 ```sh
-# 1. The env is set in the GUI session:
+# 1. The env is set in the current GUI session:
 launchctl getenv XCODE_XCCONFIG_FILE
+#  → should print ~/.bitrise-xcelerate/xcode-app.xcconfig
 
-# 2. The proxy is running:
-bitrise-build-cache doctor
+# 2. The setenv LaunchAgent is loaded (re-applies the env on every login):
+launchctl list | grep io.bitrise.build-cache
+#  → should list io.bitrise.build-cache.xcode-app-setenv (and the proxy)
 
-# 3. Build any target. The doctor output should show the proxy has been
-#    dialled at least once (logs under ~/.local/state/xcelerate/logs/).
+# 3. The proxy socket exists and is listening:
+socket_path=$(jq -r .proxySocketPath ~/.bitrise-xcelerate/config.json)
+test -S "$socket_path" && echo "proxy socket present at $socket_path"
+
+# 4. Build any target in Xcode. New entries should appear under
+#    ~/.local/state/xcelerate/logs/ — that's the proxy log directory.
+ls -lt ~/.local/state/xcelerate/logs/ | head
 ```
 
-If `launchctl getenv` prints nothing, the LaunchAgent didn't bootstrap —
-re-run `xcode-app enable` and check the output for the LaunchAgent error.
+If `launchctl getenv` prints nothing, either the initial `launchctl setenv`
+or the LaunchAgent bootstrap failed during `enable` — re-run
+`bitrise-build-cache xcode-app enable` and read the error in its output.
 
-If `doctor` reports the proxy is not running, run
+If the socket isn't there, the xcelerate-proxy service didn't start. Re-run
+`enable` (which calls daemon install + up internally) or, equivalently,
 `bitrise-build-cache daemon up`. The override expects the proxy to be
 listening — Xcode silently skips the cache if the socket isn't there.
 
@@ -200,10 +217,10 @@ all that's needed.
 | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
 | `enable` errors with `xcelerate config not found`                  | Run `bitrise-build-cache activate xcode` first — that writes the proxy socket path enable depends on. |
 | `enable` succeeds but builds aren't using the cache                | Relaunched Xcode? `launchctl setenv` only reaches processes launched after `enable` ran.            |
-| `launchctl getenv XCODE_XCCONFIG_FILE` prints nothing              | The LaunchAgent failed to bootstrap. Re-run `enable` and read the error.                            |
-| `bitrise-build-cache doctor` says the proxy is down                | `bitrise-build-cache daemon up`. Override expects the proxy listening.                              |
+| `launchctl getenv XCODE_XCCONFIG_FILE` prints nothing              | Either the initial `launchctl setenv` failed or the LaunchAgent bootstrap did. Re-run `enable` and read the error in its output. |
+| Proxy socket missing (`test -S` fails on the path in `config.json`) | Re-run `bitrise-build-cache xcode-app enable` (it ensures the daemon service is installed + up), or `bitrise-build-cache daemon up`. Override expects the proxy listening. |
 | Your project's existing `XCODE_XCCONFIG_FILE` was overwritten      | `disable` restores it. If state got out of sync, manually `launchctl setenv` to the prior path.     |
-| Want to skip the cache for a single build                          | Hold ⌥ when clicking Run / pass `XCODE_XCCONFIG_FILE=""` to a one-off `xcodebuild` invocation.      |
+| Want to skip the cache for a single CLI build                      | Pass `XCODE_XCCONFIG_FILE=""` to a one-off `xcodebuild` invocation (CLI args win over the override slot). For GUI builds, edit the scheme → Build → Pre-actions and add `unset XCODE_XCCONFIG_FILE` in a "New Run Script Action" — ⌥-clicking Run only opens the scheme editor, it does not bypass the env. |
 | Multiple Xcode installs (Xcode-beta etc.)                          | The override applies to every Xcode launched after `setenv`. Only the GA `Xcode` process gets the relaunch nudge — beta users should quit-and-relaunch manually. |
 
 For deeper logging, prepend `-d`


### PR DESCRIPTION
## Summary

- New `docs/xcode-app.md` — one-page guide for enabling the compile cache when developers press ▶ in Xcode.app. Stacks on the `xcode-app enable / disable` PR (#366).
- Cross-linked from the README's Install section so it surfaces next to the existing local-dev install pointer.

## Contents

- TL;DR (4 commands).
- How it works (override slot + LaunchAgent + proxy daemon, one paragraph each).
- Prerequisites table — what each `bitrise-build-cache activate xcode` / `daemon install + up` step is responsible for.
- Enable + relaunch step (with the GUI-session caveat that `launchctl setenv` only reaches processes spawned after it ran).
- Verification recipe — `launchctl getenv` + `doctor` + a build.
- `#include` chaining of a pre-existing `XCODE_XCCONFIG_FILE`.
- Disable behaviour.
- Repo-controlled helper script pattern (the Review-table P4 ask) — sample `scripts/enable-bitrise-build-cache.sh` + the explicit note that auth credentials stay personal and out of the repo.
- Troubleshooting table.

## Stacked PR

Based on `aci-5041-xcode-app-enable-disable`. GitHub auto-retargets to the next ancestor when #366 lands. Diff stays clean against the parent.

## Test plan

- [x] Renders correctly in GitHub's markdown preview.
- [ ] Smoke-test the TL;DR + helper-script flow on a fresh macOS box.
- [ ] Verify the troubleshooting table's suggestions actually surface the listed symptoms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)