### PR TITLE
feat: ACI-5049 browse subcommand

### DIFF
--- a/cmd/browse/browse.go
+++ b/cmd/browse/browse.go
@@ -1,5 +1,3 @@
-// Package browse exposes the `bitrise-build-cache browse` cobra subcommand.
-// Thin wrapper that maps flags into pkg/browse and prints the dashboard URL.
 package browse
 
 import (

--- a/cmd/browse/browse.go
+++ b/cmd/browse/browse.go
@@ -1,0 +1,69 @@
+// Package browse exposes the `bitrise-build-cache browse` cobra subcommand.
+// Thin wrapper that maps flags into pkg/browse and prints the dashboard URL.
+package browse
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	browsepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/browse"
+)
+
+// browseParams collects flag-mapped inputs for the subcommand. Kept in a
+// struct so additional flags can land without expanding the RunE
+// signature. Exported field-by-field for inspection in tests.
+//
+//nolint:gochecknoglobals // mirrors the pattern in cmd/xcode, cmd/gradle, …
+var browseParams struct {
+	printOnly bool
+}
+
+//nolint:gochecknoglobals
+var browseCmd = &cobra.Command{
+	Use:   "browse [invocation-id]",
+	Short: "Open the Bitrise Build Cache dashboard for the configured workspace",
+	Long: `browse opens the user's default browser at the Bitrise Build Cache dashboard, ` +
+		`pre-filtered to the configured workspace (BITRISE_BUILD_CACHE_WORKSPACE_ID) and ` + "`source=local`" + ` invocations. ` +
+		`Pass an optional invocation ID positional argument to deep-link to a specific invocation page. ` +
+		`Use ` + "`--print`" + ` to skip the launcher and only emit the URL — useful in headless / CI sessions.`,
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+
+		params := browsepkg.Params{
+			Envs:      utils.AllEnvs(),
+			PrintOnly: browseParams.printOnly,
+		}
+		if len(args) == 1 {
+			params.InvocationID = args[0]
+		}
+
+		b := &browsepkg.Browser{Logger: logger}
+		if _, err := b.Open(cmd.Context(), params); err != nil {
+			if errors.Is(err, browsepkg.ErrWorkspaceNotConfigured) {
+				return err //nolint:wrapcheck // sentinel
+			}
+
+			return fmt.Errorf("browse: %w", err)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	browseCmd.Flags().BoolVar(
+		&browseParams.printOnly,
+		"print",
+		false,
+		"Print the dashboard URL instead of launching a browser. Useful in headless or CI sessions where no GUI is available.",
+	)
+
+	common.RootCmd.AddCommand(browseCmd)
+}

--- a/cmd/browse/browse.go
+++ b/cmd/browse/browse.go
@@ -14,13 +14,10 @@ import (
 	browsepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/browse"
 )
 
-// browseParams collects flag-mapped inputs for the subcommand. Kept in a
-// struct so additional flags can land without expanding the RunE
-// signature. Exported field-by-field for inspection in tests.
-//
-//nolint:gochecknoglobals // mirrors the pattern in cmd/xcode, cmd/gradle, …
+//nolint:gochecknoglobals
 var browseParams struct {
-	printOnly bool
+	workspaceID string
+	printOnly   bool
 }
 
 //nolint:gochecknoglobals
@@ -37,8 +34,9 @@ var browseCmd = &cobra.Command{
 		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
 		params := browsepkg.Params{
-			Envs:      utils.AllEnvs(),
-			PrintOnly: browseParams.printOnly,
+			WorkspaceID: browseParams.workspaceID,
+			Envs:        utils.AllEnvs(),
+			PrintOnly:   browseParams.printOnly,
 		}
 		if len(args) == 1 {
 			params.InvocationID = args[0]
@@ -58,11 +56,17 @@ var browseCmd = &cobra.Command{
 }
 
 func init() {
+	browseCmd.Flags().StringVar(
+		&browseParams.workspaceID,
+		"workspace",
+		"",
+		"Workspace slug. Falls back to BITRISE_BUILD_CACHE_WORKSPACE_ID env var when empty.",
+	)
 	browseCmd.Flags().BoolVar(
 		&browseParams.printOnly,
 		"print",
 		false,
-		"Print the dashboard URL instead of launching a browser. Useful in headless or CI sessions where no GUI is available.",
+		"Skip launching the default browser. The dashboard URL is always logged at Info level; this flag only suppresses the auto-open step. Useful in headless or CI sessions.",
 	)
 
 	common.RootCmd.AddCommand(browseCmd)

--- a/cmd/browse/browse.go
+++ b/cmd/browse/browse.go
@@ -1,6 +1,7 @@
 package browse
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -16,6 +17,7 @@ import (
 var browseParams struct {
 	workspaceID string
 	printOnly   bool
+	jsonOutput  bool
 }
 
 //nolint:gochecknoglobals
@@ -23,7 +25,9 @@ var browseCmd = &cobra.Command{
 	Use:   "browse [invocation-id]",
 	Short: "Open the Bitrise Build Cache dashboard for the configured workspace",
 	Long: `browse opens the user's default browser at the Bitrise Build Cache dashboard, ` +
-		`pre-filtered to the configured workspace (BITRISE_BUILD_CACHE_WORKSPACE_ID) and ` + "`source=local`" + ` invocations. ` +
+		`pre-filtered to the configured workspace (BITRISE_BUILD_CACHE_WORKSPACE_ID or --workspace; ` +
+		`falls back to the workspace stored by ` + "`auth set`" + ` / ` + "`activate`" + `) and ` +
+		`to ` + "`ci_provider=unknown`" + ` (closest "my local invocations" filter until the BE adds a username field). ` +
 		`Pass an optional invocation ID positional argument to deep-link to a specific invocation page. ` +
 		`Use ` + "`--print`" + ` to skip the launcher and only emit the URL — useful in headless / CI sessions.`,
 	Args:         cobra.MaximumNArgs(1),
@@ -34,19 +38,32 @@ var browseCmd = &cobra.Command{
 		params := browsepkg.Params{
 			WorkspaceID: browseParams.workspaceID,
 			Envs:        utils.AllEnvs(),
-			PrintOnly:   browseParams.printOnly,
+			PrintOnly:   browseParams.printOnly || browseParams.jsonOutput,
 		}
 		if len(args) == 1 {
 			params.InvocationID = args[0]
 		}
 
-		b := &browsepkg.Browser{Logger: logger}
-		if _, err := b.Open(cmd.Context(), params); err != nil {
+		browserLogger := logger
+		if browseParams.jsonOutput {
+			browserLogger = nil
+		}
+
+		b := &browsepkg.Browser{Logger: browserLogger}
+		res, err := b.Open(cmd.Context(), params)
+		if err != nil {
 			if errors.Is(err, browsepkg.ErrWorkspaceNotConfigured) {
 				return err //nolint:wrapcheck // sentinel
 			}
 
 			return fmt.Errorf("browse: %w", err)
+		}
+
+		if browseParams.jsonOutput {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			if err := enc.Encode(res); err != nil {
+				return fmt.Errorf("encode browse result: %w", err)
+			}
 		}
 
 		return nil
@@ -58,13 +75,19 @@ func init() {
 		&browseParams.workspaceID,
 		"workspace",
 		"",
-		"Workspace slug. Falls back to BITRISE_BUILD_CACHE_WORKSPACE_ID env var when empty.",
+		"Workspace slug. Falls back to BITRISE_BUILD_CACHE_WORKSPACE_ID, then to the workspace stored in the OS keychain / multiplatform-analytics config (whichever `auth set` or `activate` wrote).",
 	)
 	browseCmd.Flags().BoolVar(
 		&browseParams.printOnly,
 		"print",
 		false,
 		"Skip launching the default browser. The dashboard URL is always logged at Info level; this flag only suppresses the auto-open step. Useful in headless or CI sessions.",
+	)
+	browseCmd.Flags().BoolVar(
+		&browseParams.jsonOutput,
+		"json",
+		false,
+		"Emit `{url, workspace_id, invocation_id}` as a single JSON object on stdout and skip both the human log line and the auto-open. Useful for downstream automation.",
 	)
 
 	common.RootCmd.AddCommand(browseCmd)

--- a/internal/browse/open.go
+++ b/internal/browse/open.go
@@ -1,0 +1,77 @@
+package browse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// ErrNoOpener is returned by DefaultOpener.Open when the host OS doesn't
+// have a recognised default-browser launcher (Windows / unknown). Callers
+// fall back to printing the URL.
+var ErrNoOpener = errors.New("no supported browser opener for this OS")
+
+// Opener launches the user's default browser at the given URL. Production
+// uses DefaultOpener (exec macOS `open` / Linux `xdg-open`); tests inject
+// a stub that records the URL without actually spawning anything.
+type Opener interface {
+	Open(ctx context.Context, url string) error
+}
+
+// DefaultOpener runs the platform's default browser-launcher binary.
+// CommandRunner is injectable for tests; nil falls back to a stdlib
+// exec.CommandContext implementation.
+type DefaultOpener struct {
+	// CommandRunner runs the launcher binary. Returning a wrapped error
+	// surfaces "binary not found" / "exec failed" without the caller
+	// having to know which launcher we tried.
+	CommandRunner func(ctx context.Context, bin string, args ...string) error
+}
+
+// Open executes the platform-specific browser-launcher binary against url.
+// Returns ErrNoOpener on unsupported platforms so the caller can fall back
+// to printing the URL — the browse subcommand should not be a hard failure
+// just because we couldn't auto-launch a browser.
+func (o DefaultOpener) Open(ctx context.Context, url string) error {
+	bin, args, ok := launcherForOS(runtime.GOOS, url)
+	if !ok {
+		return ErrNoOpener
+	}
+
+	runner := o.CommandRunner
+	if runner == nil {
+		runner = defaultRunner
+	}
+
+	if err := runner(ctx, bin, args...); err != nil {
+		return fmt.Errorf("%s %s: %w", bin, url, err)
+	}
+
+	return nil
+}
+
+// launcherForOS picks the binary + args for the host. Linux + BSDs ship
+// `xdg-open` as the freedesktop-standard launcher; macOS uses `open`. Other
+// platforms (Windows, unknown) return ok=false so the caller picks the
+// print-URL fallback rather than us guessing.
+func launcherForOS(goos, url string) (string, []string, bool) {
+	switch goos {
+	case "darwin":
+		return "/usr/bin/open", []string{url}, true
+	case "linux", "freebsd", "openbsd", "netbsd":
+		return "xdg-open", []string{url}, true
+	default:
+		return "", nil, false
+	}
+}
+
+func defaultRunner(ctx context.Context, bin string, args ...string) error {
+	cmd := exec.CommandContext(ctx, bin, args...)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("exec: %w", err)
+	}
+
+	return nil
+}

--- a/internal/browse/open.go
+++ b/internal/browse/open.go
@@ -43,10 +43,7 @@ func (o DefaultOpener) Open(ctx context.Context, url string) error {
 	return nil
 }
 
-// launcherForOS picks the binary for the host. Linux + BSDs ship
-// `xdg-open` (freedesktop standard); macOS uses `open`. Other platforms
-// return ok=false so the caller picks the print-URL fallback rather than
-// us guessing.
+// launcherForOS returns ok=false on unknown platforms so the caller falls back to printing rather than guessing a binary.
 func launcherForOS(goos, url string) (string, []string, bool) {
 	switch goos {
 	case "darwin":

--- a/internal/browse/open.go
+++ b/internal/browse/open.go
@@ -8,9 +8,6 @@ import (
 	"runtime"
 )
 
-// ErrNoOpener is returned by DefaultOpener.Open when the host OS doesn't
-// have a recognised default-browser launcher (Windows / unknown). Callers
-// fall back to printing the URL.
 var ErrNoOpener = errors.New("no supported browser opener for this OS")
 
 type Opener interface {
@@ -18,13 +15,10 @@ type Opener interface {
 }
 
 type DefaultOpener struct {
-	// CommandRunner is the injection point for tests. Nil = real exec.
 	CommandRunner func(ctx context.Context, bin string, args ...string) error
 }
 
-// Open returns ErrNoOpener on unsupported platforms so callers can fall
-// back to printing the URL — browse should not hard-fail just because we
-// couldn't auto-launch a browser.
+// Open returns ErrNoOpener rather than failing hard — the caller can fall back to printing.
 func (o DefaultOpener) Open(ctx context.Context, url string) error {
 	bin, args, ok := launcherForOS(runtime.GOOS, url)
 	if !ok {
@@ -43,7 +37,6 @@ func (o DefaultOpener) Open(ctx context.Context, url string) error {
 	return nil
 }
 
-// launcherForOS returns ok=false on unknown platforms so the caller falls back to printing rather than guessing a binary.
 func launcherForOS(goos, url string) (string, []string, bool) {
 	switch goos {
 	case "darwin":

--- a/internal/browse/open.go
+++ b/internal/browse/open.go
@@ -13,27 +13,18 @@ import (
 // fall back to printing the URL.
 var ErrNoOpener = errors.New("no supported browser opener for this OS")
 
-// Opener launches the user's default browser at the given URL. Production
-// uses DefaultOpener (exec macOS `open` / Linux `xdg-open`); tests inject
-// a stub that records the URL without actually spawning anything.
 type Opener interface {
 	Open(ctx context.Context, url string) error
 }
 
-// DefaultOpener runs the platform's default browser-launcher binary.
-// CommandRunner is injectable for tests; nil falls back to a stdlib
-// exec.CommandContext implementation.
 type DefaultOpener struct {
-	// CommandRunner runs the launcher binary. Returning a wrapped error
-	// surfaces "binary not found" / "exec failed" without the caller
-	// having to know which launcher we tried.
+	// CommandRunner is the injection point for tests. Nil = real exec.
 	CommandRunner func(ctx context.Context, bin string, args ...string) error
 }
 
-// Open executes the platform-specific browser-launcher binary against url.
-// Returns ErrNoOpener on unsupported platforms so the caller can fall back
-// to printing the URL — the browse subcommand should not be a hard failure
-// just because we couldn't auto-launch a browser.
+// Open returns ErrNoOpener on unsupported platforms so callers can fall
+// back to printing the URL — browse should not hard-fail just because we
+// couldn't auto-launch a browser.
 func (o DefaultOpener) Open(ctx context.Context, url string) error {
 	bin, args, ok := launcherForOS(runtime.GOOS, url)
 	if !ok {
@@ -52,10 +43,10 @@ func (o DefaultOpener) Open(ctx context.Context, url string) error {
 	return nil
 }
 
-// launcherForOS picks the binary + args for the host. Linux + BSDs ship
-// `xdg-open` as the freedesktop-standard launcher; macOS uses `open`. Other
-// platforms (Windows, unknown) return ok=false so the caller picks the
-// print-URL fallback rather than us guessing.
+// launcherForOS picks the binary for the host. Linux + BSDs ship
+// `xdg-open` (freedesktop standard); macOS uses `open`. Other platforms
+// return ok=false so the caller picks the print-URL fallback rather than
+// us guessing.
 func launcherForOS(goos, url string) (string, []string, bool) {
 	switch goos {
 	case "darwin":

--- a/internal/browse/open_test.go
+++ b/internal/browse/open_test.go
@@ -46,8 +46,6 @@ func TestDefaultOpener_invokesRunnerWithLauncher(t *testing.T) {
 	err := opener.Open(context.Background(), "https://example.com")
 	require.NoError(t, err)
 
-	// We can't assert the exact binary cross-platform, but we can assert
-	// the URL made it through to the runner intact.
 	assert.NotEmpty(t, seenBin)
 	require.Len(t, seenArgs, 1)
 	assert.Equal(t, "https://example.com", seenArgs[0])

--- a/internal/browse/open_test.go
+++ b/internal/browse/open_test.go
@@ -1,0 +1,66 @@
+//go:build unit
+
+package browse
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLauncherForOS_darwinUsesOpen(t *testing.T) {
+	bin, args, ok := launcherForOS("darwin", "https://example.com")
+	require.True(t, ok)
+	assert.Equal(t, "/usr/bin/open", bin)
+	assert.Equal(t, []string{"https://example.com"}, args)
+}
+
+func TestLauncherForOS_linuxUsesXdgOpen(t *testing.T) {
+	bin, args, ok := launcherForOS("linux", "https://example.com")
+	require.True(t, ok)
+	assert.Equal(t, "xdg-open", bin)
+	assert.Equal(t, []string{"https://example.com"}, args)
+}
+
+func TestLauncherForOS_unknownPlatformReturnsNotOk(t *testing.T) {
+	_, _, ok := launcherForOS("windows", "https://example.com")
+	assert.False(t, ok, "windows + unknown platforms should fall back to print-URL")
+}
+
+func TestDefaultOpener_invokesRunnerWithLauncher(t *testing.T) {
+	var seenBin string
+	var seenArgs []string
+
+	opener := DefaultOpener{
+		CommandRunner: func(_ context.Context, bin string, args ...string) error {
+			seenBin = bin
+			seenArgs = append([]string(nil), args...)
+
+			return nil
+		},
+	}
+
+	err := opener.Open(context.Background(), "https://example.com")
+	require.NoError(t, err)
+
+	// We can't assert the exact binary cross-platform, but we can assert
+	// the URL made it through to the runner intact.
+	assert.NotEmpty(t, seenBin)
+	require.Len(t, seenArgs, 1)
+	assert.Equal(t, "https://example.com", seenArgs[0])
+}
+
+func TestDefaultOpener_runnerErrorPropagates(t *testing.T) {
+	opener := DefaultOpener{
+		CommandRunner: func(context.Context, string, ...string) error {
+			return errors.New("simulated exec failure")
+		},
+	}
+
+	err := opener.Open(context.Background(), "https://example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "simulated exec failure")
+}

--- a/internal/browse/url.go
+++ b/internal/browse/url.go
@@ -15,13 +15,9 @@ import (
 type BuildURLParams struct {
 	WorkspaceID  string
 	InvocationID string
-	// SourceFilter sets the dashboard's `source` query param ("local" /
-	// "ci"). Empty omits the param. The dashboard currently ignores it —
-	// sending it is forward-compatible with F4 (ACI-5047, BE accepts the
-	// field).
+	// SourceFilter sets the dashboard's `source` query param ("local" / "ci"). Empty omits.
 	SourceFilter string
-	// BaseURL overrides consts.BitriseWebsiteBaseURL. Set in tests; empty
-	// falls back to the production constant.
+	// BaseURL overrides consts.BitriseWebsiteBaseURL; empty falls back to the production constant.
 	BaseURL string
 }
 

--- a/internal/browse/url.go
+++ b/internal/browse/url.go
@@ -1,20 +1,30 @@
 package browse
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
 )
 
+// ErrMissingWorkspace is returned by BuildURL when WorkspaceID is empty.
+// Callers should resolve the workspace upstream — `pkg/browse` does so via
+// the --workspace flag, the env var, and the configured auth config.
+var ErrMissingWorkspace = errors.New("BuildURL: WorkspaceID is required")
+
 type BuildURLParams struct {
-	WorkspaceID  string
-	InvocationID string
-	SourceFilter string
-	BaseURL      string
+	WorkspaceID      string
+	InvocationID     string
+	CIProviderFilter string
+	BaseURL          string
 }
 
 func BuildURL(p BuildURLParams) (string, error) {
+	if p.WorkspaceID == "" {
+		return "", ErrMissingWorkspace
+	}
+
 	base := p.BaseURL
 	if base == "" {
 		base = consts.BitriseWebsiteBaseURL
@@ -29,23 +39,20 @@ func BuildURL(p BuildURLParams) (string, error) {
 	ws := url.PathEscape(p.WorkspaceID)
 	inv := url.PathEscape(p.InvocationID)
 
-	switch {
-	case p.WorkspaceID == "":
-		u.Path = "/build-cache"
-		u.RawPath = ""
-
-	case p.InvocationID != "":
+	if p.InvocationID != "" {
 		u.Path = "/build-cache/" + p.WorkspaceID + "/invocations/" + p.InvocationID
 		u.RawPath = "/build-cache/" + ws + "/invocations/" + inv
 
-	default:
-		u.Path = "/build-cache/" + p.WorkspaceID + "/invocations"
-		u.RawPath = "/build-cache/" + ws + "/invocations"
-		if p.SourceFilter != "" {
-			q := u.Query()
-			q.Set("source", p.SourceFilter)
-			u.RawQuery = q.Encode()
-		}
+		return u.String(), nil
+	}
+
+	u.Path = "/build-cache/" + p.WorkspaceID + "/invocations"
+	u.RawPath = "/build-cache/" + ws + "/invocations"
+
+	if p.CIProviderFilter != "" {
+		q := u.Query()
+		q.Set("ci_provider", p.CIProviderFilter)
+		u.RawQuery = q.Encode()
 	}
 
 	return u.String(), nil

--- a/internal/browse/url.go
+++ b/internal/browse/url.go
@@ -1,0 +1,83 @@
+// Package browse builds the Bitrise dashboard URL that the
+// `bitrise-build-cache browse` subcommand opens. Splits cleanly into a
+// pure URL builder (url.go, easy to test) and an OS-specific opener
+// (open.go).
+package browse
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
+)
+
+// BuildURLParams controls what BuildURL emits. WorkspaceID is required;
+// everything else is optional.
+type BuildURLParams struct {
+	// WorkspaceID is the Bitrise workspace slug — required for any
+	// per-workspace dashboard URL. Empty workspace falls back to the
+	// generic /build-cache landing page, useful as a graceful-degrade
+	// behaviour when the user hasn't configured auth yet.
+	WorkspaceID string
+
+	// InvocationID, when non-empty, deep-links to the specific invocation
+	// page. Combined with WorkspaceID it produces a /build-cache/<ws>/
+	// invocations/<id> URL. Without an InvocationID the URL points at the
+	// per-workspace invocations list.
+	InvocationID string
+
+	// SourceFilter is the value of the dashboard's `source` query param,
+	// today either "local" or "ci". Empty omits the param. The dashboard
+	// currently ignores unknown values gracefully — sending it now is
+	// harmless and forward-compatible with F4 / ACI-5047 (BE accepts the
+	// field).
+	SourceFilter string
+
+	// BaseURL overrides the dashboard host. Tests use this to assert URLs
+	// against a fixture host without touching the production constant.
+	// Empty falls back to consts.BitriseWebsiteBaseURL.
+	BaseURL string
+}
+
+// BuildURL returns the dashboard URL the browse subcommand should open.
+//
+// Examples (with WorkspaceID="ws_abc"):
+//
+//	BuildURL(WorkspaceID="ws_abc")
+//	 → https://app.bitrise.io/build-cache/ws_abc/invocations?source=local
+//
+//	BuildURL(WorkspaceID="ws_abc", InvocationID="inv_xyz")
+//	 → https://app.bitrise.io/build-cache/ws_abc/invocations/inv_xyz
+//
+//	BuildURL(WorkspaceID="")
+//	 → https://app.bitrise.io/build-cache
+func BuildURL(p BuildURLParams) (string, error) {
+	base := p.BaseURL
+	if base == "" {
+		base = consts.BitriseWebsiteBaseURL
+	}
+
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parse base URL %q: %w", base, err)
+	}
+
+	switch {
+	case p.WorkspaceID == "":
+		u.Path = "/build-cache"
+
+	case p.InvocationID != "":
+		u.Path = "/build-cache/" + p.WorkspaceID + "/invocations/" + p.InvocationID
+
+	default:
+		u.Path = "/build-cache/" + p.WorkspaceID + "/invocations"
+		if p.SourceFilter != "" {
+			q := u.Query()
+			q.Set("source", p.SourceFilter)
+			u.RawQuery = q.Encode()
+		}
+	}
+
+	return strings.TrimSuffix(u.String(), "?"), nil
+}

--- a/internal/browse/url.go
+++ b/internal/browse/url.go
@@ -1,7 +1,3 @@
-// Package browse builds the Bitrise dashboard URL that the
-// `bitrise-build-cache browse` subcommand opens. Splits cleanly into a
-// pure URL builder (url.go, easy to test) and an OS-specific opener
-// (open.go).
 package browse
 
 import (
@@ -11,31 +7,13 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
 )
 
-// BuildURLParams controls what BuildURL emits.
 type BuildURLParams struct {
 	WorkspaceID  string
 	InvocationID string
-	// SourceFilter sets the dashboard's `source` query param ("local" / "ci"). Empty omits.
 	SourceFilter string
-	// BaseURL overrides consts.BitriseWebsiteBaseURL; empty falls back to the production constant.
-	BaseURL string
+	BaseURL      string
 }
 
-// BuildURL returns the dashboard URL the browse subcommand should open.
-//
-// Examples (with WorkspaceID="ws_abc"):
-//
-//	BuildURL(WorkspaceID="ws_abc")
-//	 → https://app.bitrise.io/build-cache/ws_abc/invocations?source=local
-//
-//	BuildURL(WorkspaceID="ws_abc", InvocationID="inv_xyz")
-//	 → https://app.bitrise.io/build-cache/ws_abc/invocations/inv_xyz
-//
-//	BuildURL(WorkspaceID="")
-//	 → https://app.bitrise.io/build-cache
-//
-// Workspace + invocation IDs are PathEscape'd defensively — they're slugs
-// today, but escape keeps a stray `/` or `#` from breaking the URL.
 func BuildURL(p BuildURLParams) (string, error) {
 	base := p.BaseURL
 	if base == "" {
@@ -47,9 +25,7 @@ func BuildURL(p BuildURLParams) (string, error) {
 		return "", fmt.Errorf("parse base URL %q: %w", base, err)
 	}
 
-	// Set Path (decoded) + RawPath (encoded) so URL.String uses RawPath
-	// verbatim. PathEscape on each segment keeps a stray `/` or `#` in a
-	// workspace / invocation slug from splitting or fragmenting the URL.
+	// PathEscape per segment + RawPath so a stray `/` or `#` in a workspace/invocation slug can't break the URL.
 	ws := url.PathEscape(p.WorkspaceID)
 	inv := url.PathEscape(p.InvocationID)
 

--- a/internal/browse/url.go
+++ b/internal/browse/url.go
@@ -7,36 +7,21 @@ package browse
 import (
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
 )
 
-// BuildURLParams controls what BuildURL emits. WorkspaceID is required;
-// everything else is optional.
+// BuildURLParams controls what BuildURL emits.
 type BuildURLParams struct {
-	// WorkspaceID is the Bitrise workspace slug — required for any
-	// per-workspace dashboard URL. Empty workspace falls back to the
-	// generic /build-cache landing page, useful as a graceful-degrade
-	// behaviour when the user hasn't configured auth yet.
-	WorkspaceID string
-
-	// InvocationID, when non-empty, deep-links to the specific invocation
-	// page. Combined with WorkspaceID it produces a /build-cache/<ws>/
-	// invocations/<id> URL. Without an InvocationID the URL points at the
-	// per-workspace invocations list.
+	WorkspaceID  string
 	InvocationID string
-
-	// SourceFilter is the value of the dashboard's `source` query param,
-	// today either "local" or "ci". Empty omits the param. The dashboard
-	// currently ignores unknown values gracefully — sending it now is
-	// harmless and forward-compatible with F4 / ACI-5047 (BE accepts the
+	// SourceFilter sets the dashboard's `source` query param ("local" /
+	// "ci"). Empty omits the param. The dashboard currently ignores it —
+	// sending it is forward-compatible with F4 (ACI-5047, BE accepts the
 	// field).
 	SourceFilter string
-
-	// BaseURL overrides the dashboard host. Tests use this to assert URLs
-	// against a fixture host without touching the production constant.
-	// Empty falls back to consts.BitriseWebsiteBaseURL.
+	// BaseURL overrides consts.BitriseWebsiteBaseURL. Set in tests; empty
+	// falls back to the production constant.
 	BaseURL string
 }
 
@@ -52,6 +37,9 @@ type BuildURLParams struct {
 //
 //	BuildURL(WorkspaceID="")
 //	 → https://app.bitrise.io/build-cache
+//
+// Workspace + invocation IDs are PathEscape'd defensively — they're slugs
+// today, but escape keeps a stray `/` or `#` from breaking the URL.
 func BuildURL(p BuildURLParams) (string, error) {
 	base := p.BaseURL
 	if base == "" {
@@ -63,15 +51,24 @@ func BuildURL(p BuildURLParams) (string, error) {
 		return "", fmt.Errorf("parse base URL %q: %w", base, err)
 	}
 
+	// Set Path (decoded) + RawPath (encoded) so URL.String uses RawPath
+	// verbatim. PathEscape on each segment keeps a stray `/` or `#` in a
+	// workspace / invocation slug from splitting or fragmenting the URL.
+	ws := url.PathEscape(p.WorkspaceID)
+	inv := url.PathEscape(p.InvocationID)
+
 	switch {
 	case p.WorkspaceID == "":
 		u.Path = "/build-cache"
+		u.RawPath = ""
 
 	case p.InvocationID != "":
 		u.Path = "/build-cache/" + p.WorkspaceID + "/invocations/" + p.InvocationID
+		u.RawPath = "/build-cache/" + ws + "/invocations/" + inv
 
 	default:
 		u.Path = "/build-cache/" + p.WorkspaceID + "/invocations"
+		u.RawPath = "/build-cache/" + ws + "/invocations"
 		if p.SourceFilter != "" {
 			q := u.Query()
 			q.Set("source", p.SourceFilter)
@@ -79,5 +76,5 @@ func BuildURL(p BuildURLParams) (string, error) {
 		}
 	}
 
-	return strings.TrimSuffix(u.String(), "?"), nil
+	return u.String(), nil
 }

--- a/internal/browse/url.go
+++ b/internal/browse/url.go
@@ -8,9 +8,6 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
 )
 
-// ErrMissingWorkspace is returned by BuildURL when WorkspaceID is empty.
-// Callers should resolve the workspace upstream — `pkg/browse` does so via
-// the --workspace flag, the env var, and the configured auth config.
 var ErrMissingWorkspace = errors.New("BuildURL: WorkspaceID is required")
 
 type BuildURLParams struct {

--- a/internal/browse/url_test.go
+++ b/internal/browse/url_test.go
@@ -1,0 +1,72 @@
+//go:build unit
+
+package browse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildURL_workspaceOnly_addsSourceLocalFilter(t *testing.T) {
+	got, err := BuildURL(BuildURLParams{
+		WorkspaceID:  "ws_abc",
+		SourceFilter: "local",
+		BaseURL:      "https://app.bitrise.io",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations?source=local", got)
+}
+
+func TestBuildURL_workspacePlusInvocationID_deepLinks(t *testing.T) {
+	got, err := BuildURL(BuildURLParams{
+		WorkspaceID:  "ws_abc",
+		InvocationID: "inv_xyz",
+		BaseURL:      "https://app.bitrise.io",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations/inv_xyz", got)
+}
+
+func TestBuildURL_invocationIDIgnoresSourceFilter(t *testing.T) {
+	// Source filter is a list-page concern; a deep link to a specific
+	// invocation page doesn't need it. Confirm the param doesn't leak in.
+	got, err := BuildURL(BuildURLParams{
+		WorkspaceID:  "ws_abc",
+		InvocationID: "inv_xyz",
+		SourceFilter: "local",
+		BaseURL:      "https://app.bitrise.io",
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, got, "source=")
+}
+
+func TestBuildURL_noWorkspace_landsOnGenericPage(t *testing.T) {
+	got, err := BuildURL(BuildURLParams{BaseURL: "https://app.bitrise.io"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.bitrise.io/build-cache", got)
+}
+
+func TestBuildURL_defaultsBaseToConst(t *testing.T) {
+	got, err := BuildURL(BuildURLParams{WorkspaceID: "ws_abc"})
+	require.NoError(t, err)
+	assert.Contains(t, got, "https://app.bitrise.io/build-cache/ws_abc/invocations")
+}
+
+func TestBuildURL_omitsSourceFilterWhenEmpty(t *testing.T) {
+	got, err := BuildURL(BuildURLParams{
+		WorkspaceID: "ws_abc",
+		BaseURL:     "https://app.bitrise.io",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations", got)
+}
+
+func TestBuildURL_badBaseURLIsError(t *testing.T) {
+	_, err := BuildURL(BuildURLParams{
+		WorkspaceID: "ws_abc",
+		BaseURL:     "://not-a-url",
+	})
+	require.Error(t, err)
+}

--- a/internal/browse/url_test.go
+++ b/internal/browse/url_test.go
@@ -70,3 +70,16 @@ func TestBuildURL_badBaseURLIsError(t *testing.T) {
 	})
 	require.Error(t, err)
 }
+
+func TestBuildURL_pathEscapesSegments(t *testing.T) {
+	got, err := BuildURL(BuildURLParams{
+		WorkspaceID:  "ws/abc",
+		InvocationID: "inv with space",
+		BaseURL:      "https://app.bitrise.io",
+	})
+	require.NoError(t, err)
+
+	// Slash in workspace must not split into another path segment;
+	// space in invocation must be percent-encoded.
+	assert.Equal(t, "https://app.bitrise.io/build-cache/ws%2Fabc/invocations/inv%20with%20space", got)
+}

--- a/internal/browse/url_test.go
+++ b/internal/browse/url_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildURL_workspaceOnly_addsSourceLocalFilter(t *testing.T) {
+func TestBuildURL_workspaceOnly_addsCIProviderUnknownFilter(t *testing.T) {
 	got, err := BuildURL(BuildURLParams{
-		WorkspaceID:  "ws_abc",
-		SourceFilter: "local",
-		BaseURL:      "https://app.bitrise.io",
+		WorkspaceID:      "ws_abc",
+		CIProviderFilter: "unknown",
+		BaseURL:          "https://app.bitrise.io",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations?source=local", got)
+	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations?ci_provider=unknown", got)
 }
 
 func TestBuildURL_workspacePlusInvocationID_deepLinks(t *testing.T) {
@@ -29,21 +29,20 @@ func TestBuildURL_workspacePlusInvocationID_deepLinks(t *testing.T) {
 	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations/inv_xyz", got)
 }
 
-func TestBuildURL_invocationIDIgnoresSourceFilter(t *testing.T) {
+func TestBuildURL_invocationIDIgnoresCIProviderFilter(t *testing.T) {
 	got, err := BuildURL(BuildURLParams{
-		WorkspaceID:  "ws_abc",
-		InvocationID: "inv_xyz",
-		SourceFilter: "local",
-		BaseURL:      "https://app.bitrise.io",
+		WorkspaceID:      "ws_abc",
+		InvocationID:     "inv_xyz",
+		CIProviderFilter: "unknown",
+		BaseURL:          "https://app.bitrise.io",
 	})
 	require.NoError(t, err)
-	assert.NotContains(t, got, "source=")
+	assert.NotContains(t, got, "ci_provider=")
 }
 
-func TestBuildURL_noWorkspace_landsOnGenericPage(t *testing.T) {
-	got, err := BuildURL(BuildURLParams{BaseURL: "https://app.bitrise.io"})
-	require.NoError(t, err)
-	assert.Equal(t, "https://app.bitrise.io/build-cache", got)
+func TestBuildURL_noWorkspace_errors(t *testing.T) {
+	_, err := BuildURL(BuildURLParams{BaseURL: "https://app.bitrise.io"})
+	require.ErrorIs(t, err, ErrMissingWorkspace)
 }
 
 func TestBuildURL_defaultsBaseToConst(t *testing.T) {
@@ -52,7 +51,7 @@ func TestBuildURL_defaultsBaseToConst(t *testing.T) {
 	assert.Contains(t, got, "https://app.bitrise.io/build-cache/ws_abc/invocations")
 }
 
-func TestBuildURL_omitsSourceFilterWhenEmpty(t *testing.T) {
+func TestBuildURL_omitsCIProviderFilterWhenEmpty(t *testing.T) {
 	got, err := BuildURL(BuildURLParams{
 		WorkspaceID: "ws_abc",
 		BaseURL:     "https://app.bitrise.io",

--- a/internal/browse/url_test.go
+++ b/internal/browse/url_test.go
@@ -30,8 +30,6 @@ func TestBuildURL_workspacePlusInvocationID_deepLinks(t *testing.T) {
 }
 
 func TestBuildURL_invocationIDIgnoresSourceFilter(t *testing.T) {
-	// Source filter is a list-page concern; a deep link to a specific
-	// invocation page doesn't need it. Confirm the param doesn't leak in.
 	got, err := BuildURL(BuildURLParams{
 		WorkspaceID:  "ws_abc",
 		InvocationID: "inv_xyz",
@@ -79,7 +77,5 @@ func TestBuildURL_pathEscapesSegments(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Slash in workspace must not split into another path segment;
-	// space in invocation must be percent-encoded.
 	assert.Equal(t, "https://app.bitrise.io/build-cache/ws%2Fabc/invocations/inv%20with%20space", got)
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/auth"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/bazel"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/browse"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/ccache"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/daemon"

--- a/pkg/browse/browser.go
+++ b/pkg/browse/browser.go
@@ -8,21 +8,19 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/browse"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
-
-const WorkspaceIDEnvVar = "BITRISE_BUILD_CACHE_WORKSPACE_ID"
 
 // ciProviderUnknown filters the dashboard's invocation list to local runs
 // (anything not produced by a recognised CI). Until the FE/BE add a username
 // filter this is the closest "show only my local invocations" proxy.
 const ciProviderUnknown = "unknown"
 
-var ErrWorkspaceNotConfigured = errors.New(WorkspaceIDEnvVar + " not set — pass --workspace, export the env var, or run `bitrise-build-cache auth set` so the dashboard can pick a workspace")
+var ErrWorkspaceNotConfigured = errors.New(configcommon.EnvWorkspaceID + " not set — pass --workspace, export the env var, or run `bitrise-build-cache auth set` so the dashboard can pick a workspace")
 
-// WorkspaceResolver returns the workspace ID configured for local use.
-// Browser calls it after the flag / env var fallbacks fail.
+// WorkspaceResolver is called when --workspace + env var have both come up empty.
 type WorkspaceResolver func(envs map[string]string) (string, error)
 
 type Params struct {
@@ -42,7 +40,7 @@ type Browser struct {
 func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 	workspaceID := p.WorkspaceID
 	if workspaceID == "" {
-		workspaceID = p.Envs[WorkspaceIDEnvVar]
+		workspaceID = p.Envs[configcommon.EnvWorkspaceID]
 	}
 
 	if workspaceID == "" {
@@ -102,10 +100,8 @@ func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 	return dashboardURL, nil
 }
 
-// defaultWorkspaceFromAuth pulls the WorkspaceID out of the multiplatform
-// analytics config on disk — the canonical local source written by every
-// `activate` flow. Returns an empty string + nil err when the config is
-// absent so Browser.Open's caller-facing error stays specific.
+// defaultWorkspaceFromAuth reads the WorkspaceID from the multiplatform
+// analytics config, which every `activate` flow writes.
 func defaultWorkspaceFromAuth(_ map[string]string) (string, error) {
 	cfg, err := multiplatformconfig.ReadConfig(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
 	if err != nil {

--- a/pkg/browse/browser.go
+++ b/pkg/browse/browser.go
@@ -1,6 +1,3 @@
-// Package browse exposes the public API for the `bitrise-build-cache
-// browse` subcommand. External Go consumers (Bitrise steps, custom
-// tooling) construct a Browser and call Open without depending on cobra.
 package browse
 
 import (
@@ -15,18 +12,14 @@ import (
 
 const WorkspaceIDEnvVar = "BITRISE_BUILD_CACHE_WORKSPACE_ID"
 
-// ErrWorkspaceNotConfigured is returned when no workspace ID is supplied via Params or env-var.
 var ErrWorkspaceNotConfigured = errors.New(WorkspaceIDEnvVar + " not set — pass --workspace or export the env var to open the dashboard for a specific workspace")
 
-// Params controls Browse behaviour.
 type Params struct {
 	WorkspaceID  string
 	InvocationID string
 	Envs         map[string]string
-	// BaseURL overrides consts.BitriseWebsiteBaseURL; empty falls back to production.
-	BaseURL string
-	// PrintOnly suppresses the auto-open step (URL is still logged).
-	PrintOnly bool
+	BaseURL      string
+	PrintOnly    bool
 }
 
 type Browser struct {
@@ -34,7 +27,6 @@ type Browser struct {
 	Opener browse.Opener
 }
 
-// Open builds the dashboard URL, logs it, and launches the user's default browser.
 func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 	workspaceID := p.WorkspaceID
 	if workspaceID == "" {
@@ -47,7 +39,6 @@ func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 
 	source := ""
 	if p.InvocationID == "" {
-		// `browse` opens the user's local invocations — pin the dashboard filter to match.
 		source = "local"
 	}
 
@@ -75,7 +66,6 @@ func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 	}
 
 	if err := opener.Open(ctx, dashboardURL); err != nil {
-		// No GUI browser shouldn't fail the command — URL is already logged.
 		if b.Logger != nil {
 			switch {
 			case errors.Is(err, browse.ErrNoOpener):

--- a/pkg/browse/browser.go
+++ b/pkg/browse/browser.go
@@ -8,11 +8,22 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/browse"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
 const WorkspaceIDEnvVar = "BITRISE_BUILD_CACHE_WORKSPACE_ID"
 
-var ErrWorkspaceNotConfigured = errors.New(WorkspaceIDEnvVar + " not set — pass --workspace or export the env var to open the dashboard for a specific workspace")
+// ciProviderUnknown filters the dashboard's invocation list to local runs
+// (anything not produced by a recognised CI). Until the FE/BE add a username
+// filter this is the closest "show only my local invocations" proxy.
+const ciProviderUnknown = "unknown"
+
+var ErrWorkspaceNotConfigured = errors.New(WorkspaceIDEnvVar + " not set — pass --workspace, export the env var, or run `bitrise-build-cache auth set` so the dashboard can pick a workspace")
+
+// WorkspaceResolver returns the workspace ID configured for local use.
+// Browser calls it after the flag / env var fallbacks fail.
+type WorkspaceResolver func(envs map[string]string) (string, error)
 
 type Params struct {
 	WorkspaceID  string
@@ -23,8 +34,9 @@ type Params struct {
 }
 
 type Browser struct {
-	Logger log.Logger
-	Opener browse.Opener
+	Logger            log.Logger
+	Opener            browse.Opener
+	WorkspaceFromAuth WorkspaceResolver
 }
 
 func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
@@ -34,19 +46,30 @@ func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 	}
 
 	if workspaceID == "" {
+		resolver := b.WorkspaceFromAuth
+		if resolver == nil {
+			resolver = defaultWorkspaceFromAuth
+		}
+
+		if id, err := resolver(p.Envs); err == nil && id != "" {
+			workspaceID = id
+		}
+	}
+
+	if workspaceID == "" {
 		return "", ErrWorkspaceNotConfigured
 	}
 
-	source := ""
+	ciProvider := ""
 	if p.InvocationID == "" {
-		source = "local"
+		ciProvider = ciProviderUnknown
 	}
 
 	dashboardURL, err := browse.BuildURL(browse.BuildURLParams{
-		WorkspaceID:  workspaceID,
-		InvocationID: p.InvocationID,
-		SourceFilter: source,
-		BaseURL:      p.BaseURL,
+		WorkspaceID:      workspaceID,
+		InvocationID:     p.InvocationID,
+		CIProviderFilter: ciProvider,
+		BaseURL:          p.BaseURL,
 	})
 	if err != nil {
 		return "", fmt.Errorf("build dashboard URL: %w", err)
@@ -77,4 +100,17 @@ func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 	}
 
 	return dashboardURL, nil
+}
+
+// defaultWorkspaceFromAuth pulls the WorkspaceID out of the multiplatform
+// analytics config on disk — the canonical local source written by every
+// `activate` flow. Returns an empty string + nil err when the config is
+// absent so Browser.Open's caller-facing error stays specific.
+func defaultWorkspaceFromAuth(_ map[string]string) (string, error) {
+	cfg, err := multiplatformconfig.ReadConfig(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
+	if err != nil {
+		return "", err //nolint:wrapcheck // surfaced only as a fallback signal, never propagated to the user
+	}
+
+	return cfg.AuthConfig.WorkspaceID, nil
 }

--- a/pkg/browse/browser.go
+++ b/pkg/browse/browser.go
@@ -1,0 +1,120 @@
+// Package browse exposes the public API for the `bitrise-build-cache
+// browse` subcommand. External Go consumers (Bitrise steps, custom
+// tooling) construct a Browser and call Open without depending on cobra.
+package browse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/browse"
+)
+
+// WorkspaceIDEnvVar is the env-var name browse reads for the workspace
+// slug fallback. Kept here as the canonical source so docs + tests can
+// reference it without duplicating the literal.
+const WorkspaceIDEnvVar = "BITRISE_BUILD_CACHE_WORKSPACE_ID"
+
+// ErrWorkspaceNotConfigured is returned when no workspace ID is supplied
+// either explicitly (Params.WorkspaceID) or via the env-var fallback.
+// browse doesn't need an auth token (the URL is opened in the user's
+// browser, which handles its own session), so this is a distinct error
+// from common.ErrWorkspaceIDNotProvided which couples workspace + token.
+var ErrWorkspaceNotConfigured = errors.New(WorkspaceIDEnvVar + " not set — pass --workspace or export the env var to open the dashboard for a specific workspace")
+
+// Params controls Browse behaviour. WorkspaceID is the only required field
+// — Envs is consulted as a fallback when it's empty.
+type Params struct {
+	// WorkspaceID overrides the workspace slug. Empty falls back to
+	// reading BITRISE_BUILD_CACHE_WORKSPACE_ID from Envs.
+	WorkspaceID string
+	// InvocationID, when non-empty, deep-links to a specific invocation
+	// page instead of the per-workspace list.
+	InvocationID string
+	// Envs is the environment snapshot the workspace fallback reads from.
+	// Production callers pass utils.AllEnvs().
+	Envs map[string]string
+	// BaseURL overrides the dashboard host. Empty falls back to the
+	// production constant. Used by tests + by anyone wanting to point at a
+	// staging dashboard.
+	BaseURL string
+	// PrintOnly skips the launcher and only logs the URL. Useful in
+	// headless environments / CI / when --print is passed at the cobra
+	// layer.
+	PrintOnly bool
+}
+
+// Browser composes the URL builder + opener. Logger is required so we can
+// surface the URL when no GUI browser is available (CI / SSH session).
+type Browser struct {
+	Logger log.Logger
+	Opener browse.Opener
+}
+
+// Open builds the dashboard URL and launches the user's default browser.
+// Falls back to printing the URL on platforms without a recognised
+// launcher, on PrintOnly=true, or when the launcher itself errors. The URL
+// is always logged at Info level so the user can copy/paste even when the
+// browser auto-launched.
+func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
+	workspaceID := p.WorkspaceID
+	if workspaceID == "" {
+		workspaceID = p.Envs[WorkspaceIDEnvVar]
+	}
+
+	if workspaceID == "" {
+		return "", ErrWorkspaceNotConfigured
+	}
+
+	source := ""
+	if p.InvocationID == "" {
+		// Source filter applies to the list page only; deep links to a
+		// specific invocation don't need it. Hard-coded to "local" today
+		// because `browse` is positioned as the "open my local
+		// invocations" command. Once F4 (BE accepts the field) lands the
+		// dashboard will honour this filter.
+		source = "local"
+	}
+
+	dashboardURL, err := browse.BuildURL(browse.BuildURLParams{
+		WorkspaceID:  workspaceID,
+		InvocationID: p.InvocationID,
+		SourceFilter: source,
+		BaseURL:      p.BaseURL,
+	})
+	if err != nil {
+		return "", fmt.Errorf("build dashboard URL: %w", err)
+	}
+
+	if b.Logger != nil {
+		b.Logger.Infof("Bitrise Build Cache dashboard: %s", dashboardURL)
+	}
+
+	if p.PrintOnly {
+		return dashboardURL, nil
+	}
+
+	opener := b.Opener
+	if opener == nil {
+		opener = browse.DefaultOpener{}
+	}
+
+	if err := opener.Open(ctx, dashboardURL); err != nil {
+		// Print-fallback rather than hard error — having no GUI browser
+		// shouldn't make the command fail. The URL has already been
+		// logged above; we just emit a hint.
+		if b.Logger != nil {
+			switch {
+			case errors.Is(err, browse.ErrNoOpener):
+				b.Logger.Warnf("No default browser launcher for this OS. Copy the URL above to open it manually.")
+			default:
+				b.Logger.Warnf("Could not auto-launch the browser (%v). Copy the URL above to open it manually.", err)
+			}
+		}
+	}
+
+	return dashboardURL, nil
+}

--- a/pkg/browse/browser.go
+++ b/pkg/browse/browser.go
@@ -13,52 +13,36 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/browse"
 )
 
-// WorkspaceIDEnvVar is the env-var name browse reads for the workspace
-// slug fallback. Kept here as the canonical source so docs + tests can
-// reference it without duplicating the literal.
 const WorkspaceIDEnvVar = "BITRISE_BUILD_CACHE_WORKSPACE_ID"
 
 // ErrWorkspaceNotConfigured is returned when no workspace ID is supplied
 // either explicitly (Params.WorkspaceID) or via the env-var fallback.
-// browse doesn't need an auth token (the URL is opened in the user's
-// browser, which handles its own session), so this is a distinct error
-// from common.ErrWorkspaceIDNotProvided which couples workspace + token.
+// Browse doesn't need an auth token (the URL is opened in the user's
+// browser, which handles its own session), so this is distinct from
+// common.ErrWorkspaceIDNotProvided which couples workspace + token.
 var ErrWorkspaceNotConfigured = errors.New(WorkspaceIDEnvVar + " not set — pass --workspace or export the env var to open the dashboard for a specific workspace")
 
-// Params controls Browse behaviour. WorkspaceID is the only required field
-// — Envs is consulted as a fallback when it's empty.
+// Params controls Browse behaviour.
 type Params struct {
-	// WorkspaceID overrides the workspace slug. Empty falls back to
-	// reading BITRISE_BUILD_CACHE_WORKSPACE_ID from Envs.
-	WorkspaceID string
-	// InvocationID, when non-empty, deep-links to a specific invocation
-	// page instead of the per-workspace list.
+	WorkspaceID  string
 	InvocationID string
-	// Envs is the environment snapshot the workspace fallback reads from.
-	// Production callers pass utils.AllEnvs().
-	Envs map[string]string
-	// BaseURL overrides the dashboard host. Empty falls back to the
-	// production constant. Used by tests + by anyone wanting to point at a
-	// staging dashboard.
+	Envs         map[string]string
+	// BaseURL overrides consts.BitriseWebsiteBaseURL. Set in tests / when
+	// pointing at a staging dashboard. Empty falls back to production.
 	BaseURL string
-	// PrintOnly skips the launcher and only logs the URL. Useful in
-	// headless environments / CI / when --print is passed at the cobra
-	// layer.
+	// PrintOnly suppresses the auto-open step. The URL is still logged at
+	// Info level either way.
 	PrintOnly bool
 }
 
-// Browser composes the URL builder + opener. Logger is required so we can
-// surface the URL when no GUI browser is available (CI / SSH session).
 type Browser struct {
 	Logger log.Logger
 	Opener browse.Opener
 }
 
 // Open builds the dashboard URL and launches the user's default browser.
-// Falls back to printing the URL on platforms without a recognised
-// launcher, on PrintOnly=true, or when the launcher itself errors. The URL
-// is always logged at Info level so the user can copy/paste even when the
-// browser auto-launched.
+// The URL is always logged at Info level, so PrintOnly + launcher errors +
+// no-recognised-launcher all degrade to "URL is in the log; copy it".
 func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 	workspaceID := p.WorkspaceID
 	if workspaceID == "" {

--- a/pkg/browse/browser.go
+++ b/pkg/browse/browser.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/browse"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
 // ciProviderUnknown filters the dashboard's invocation list to local runs
@@ -31,13 +29,19 @@ type Params struct {
 	PrintOnly    bool
 }
 
+type Result struct {
+	URL          string `json:"url"`
+	WorkspaceID  string `json:"workspace_id"`
+	InvocationID string `json:"invocation_id,omitempty"`
+}
+
 type Browser struct {
 	Logger            log.Logger
 	Opener            browse.Opener
 	WorkspaceFromAuth WorkspaceResolver
 }
 
-func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
+func (b *Browser) Open(ctx context.Context, p Params) (Result, error) {
 	workspaceID := p.WorkspaceID
 	if workspaceID == "" {
 		workspaceID = p.Envs[configcommon.EnvWorkspaceID]
@@ -55,7 +59,7 @@ func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 	}
 
 	if workspaceID == "" {
-		return "", ErrWorkspaceNotConfigured
+		return Result{}, ErrWorkspaceNotConfigured
 	}
 
 	ciProvider := ""
@@ -70,15 +74,17 @@ func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 		BaseURL:          p.BaseURL,
 	})
 	if err != nil {
-		return "", fmt.Errorf("build dashboard URL: %w", err)
+		return Result{}, fmt.Errorf("build dashboard URL: %w", err)
 	}
+
+	res := Result{URL: dashboardURL, WorkspaceID: workspaceID, InvocationID: p.InvocationID}
 
 	if b.Logger != nil {
 		b.Logger.Infof("Bitrise Build Cache dashboard: %s", dashboardURL)
 	}
 
 	if p.PrintOnly {
-		return dashboardURL, nil
+		return res, nil
 	}
 
 	opener := b.Opener
@@ -97,16 +103,14 @@ func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 		}
 	}
 
-	return dashboardURL, nil
+	return res, nil
 }
 
-// defaultWorkspaceFromAuth reads the WorkspaceID from the multiplatform
-// analytics config, which every `activate` flow writes.
-func defaultWorkspaceFromAuth(_ map[string]string) (string, error) {
-	cfg, err := multiplatformconfig.ReadConfig(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
+func defaultWorkspaceFromAuth(envs map[string]string) (string, error) {
+	cfg, _, err := configcommon.ResolveAuthConfig(envs)
 	if err != nil {
 		return "", err //nolint:wrapcheck // surfaced only as a fallback signal, never propagated to the user
 	}
 
-	return cfg.AuthConfig.WorkspaceID, nil
+	return cfg.WorkspaceID, nil
 }

--- a/pkg/browse/browser.go
+++ b/pkg/browse/browser.go
@@ -15,11 +15,7 @@ import (
 
 const WorkspaceIDEnvVar = "BITRISE_BUILD_CACHE_WORKSPACE_ID"
 
-// ErrWorkspaceNotConfigured is returned when no workspace ID is supplied
-// either explicitly (Params.WorkspaceID) or via the env-var fallback.
-// Browse doesn't need an auth token (the URL is opened in the user's
-// browser, which handles its own session), so this is distinct from
-// common.ErrWorkspaceIDNotProvided which couples workspace + token.
+// ErrWorkspaceNotConfigured is returned when no workspace ID is supplied via Params or env-var.
 var ErrWorkspaceNotConfigured = errors.New(WorkspaceIDEnvVar + " not set — pass --workspace or export the env var to open the dashboard for a specific workspace")
 
 // Params controls Browse behaviour.
@@ -27,11 +23,9 @@ type Params struct {
 	WorkspaceID  string
 	InvocationID string
 	Envs         map[string]string
-	// BaseURL overrides consts.BitriseWebsiteBaseURL. Set in tests / when
-	// pointing at a staging dashboard. Empty falls back to production.
+	// BaseURL overrides consts.BitriseWebsiteBaseURL; empty falls back to production.
 	BaseURL string
-	// PrintOnly suppresses the auto-open step. The URL is still logged at
-	// Info level either way.
+	// PrintOnly suppresses the auto-open step (URL is still logged).
 	PrintOnly bool
 }
 
@@ -40,9 +34,7 @@ type Browser struct {
 	Opener browse.Opener
 }
 
-// Open builds the dashboard URL and launches the user's default browser.
-// The URL is always logged at Info level, so PrintOnly + launcher errors +
-// no-recognised-launcher all degrade to "URL is in the log; copy it".
+// Open builds the dashboard URL, logs it, and launches the user's default browser.
 func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 	workspaceID := p.WorkspaceID
 	if workspaceID == "" {
@@ -55,11 +47,7 @@ func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 
 	source := ""
 	if p.InvocationID == "" {
-		// Source filter applies to the list page only; deep links to a
-		// specific invocation don't need it. Hard-coded to "local" today
-		// because `browse` is positioned as the "open my local
-		// invocations" command. Once F4 (BE accepts the field) lands the
-		// dashboard will honour this filter.
+		// `browse` opens the user's local invocations — pin the dashboard filter to match.
 		source = "local"
 	}
 
@@ -87,9 +75,7 @@ func (b *Browser) Open(ctx context.Context, p Params) (string, error) {
 	}
 
 	if err := opener.Open(ctx, dashboardURL); err != nil {
-		// Print-fallback rather than hard error — having no GUI browser
-		// shouldn't make the command fail. The URL has already been
-		// logged above; we just emit a hint.
+		// No GUI browser shouldn't fail the command — URL is already logged.
 		if b.Logger != nil {
 			switch {
 			case errors.Is(err, browse.ErrNoOpener):

--- a/pkg/browse/browser_test.go
+++ b/pkg/browse/browser_test.go
@@ -50,8 +50,10 @@ func TestBrowse_workspaceFromEnv_buildsListURLWithCIProviderUnknown(t *testing.T
 		BaseURL: "https://app.bitrise.io",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations?ci_provider=unknown", got)
-	assert.Equal(t, got, op.seenURL)
+	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations?ci_provider=unknown", got.URL)
+	assert.Equal(t, "ws_abc", got.WorkspaceID)
+	assert.Empty(t, got.InvocationID)
+	assert.Equal(t, got.URL, op.seenURL)
 }
 
 func TestBrowse_invocationID_deepLinks_noFilter(t *testing.T) {
@@ -64,8 +66,9 @@ func TestBrowse_invocationID_deepLinks_noFilter(t *testing.T) {
 		BaseURL:      "https://app.bitrise.io",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations/inv_xyz", got)
-	assert.NotContains(t, got, "ci_provider=")
+	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations/inv_xyz", got.URL)
+	assert.Equal(t, "inv_xyz", got.InvocationID)
+	assert.NotContains(t, got.URL, "ci_provider=")
 }
 
 func TestBrowse_authConfigFallback_resolvesWorkspaceID(t *testing.T) {
@@ -83,7 +86,8 @@ func TestBrowse_authConfigFallback_resolvesWorkspaceID(t *testing.T) {
 		BaseURL: "https://app.bitrise.io",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_from_auth/invocations?ci_provider=unknown", got)
+	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_from_auth/invocations?ci_provider=unknown", got.URL)
+	assert.Equal(t, "ws_from_auth", got.WorkspaceID)
 }
 
 func TestBrowse_authConfigFallback_errorFallsThroughToSentinel(t *testing.T) {
@@ -109,7 +113,7 @@ func TestBrowse_printOnlySkipsOpener(t *testing.T) {
 		BaseURL:     "https://app.bitrise.io",
 	})
 	require.NoError(t, err)
-	assert.NotEmpty(t, got)
+	assert.NotEmpty(t, got.URL)
 	assert.Empty(t, op.seenURL, "PrintOnly must not invoke the opener")
 }
 
@@ -139,7 +143,7 @@ func TestBrowse_openerErrNoOpener_emitsNoSupportedLauncherWarn(t *testing.T) {
 		BaseURL:     "https://app.bitrise.io",
 	})
 	require.NoError(t, err)
-	assert.NotEmpty(t, got)
+	assert.NotEmpty(t, got.URL)
 	assert.Contains(t, buf.String(), "No default browser launcher for this OS")
 }
 
@@ -155,7 +159,7 @@ func TestBrowse_openerGenericError_emitsCouldNotAutoLaunchWarn(t *testing.T) {
 		BaseURL:     "https://app.bitrise.io",
 	})
 	require.NoError(t, err)
-	assert.NotEmpty(t, got)
+	assert.NotEmpty(t, got.URL)
 	assert.Contains(t, buf.String(), "Could not auto-launch the browser")
 	// Generic-error message should include the underlying error text so
 	// post-mortem isn't blind.

--- a/pkg/browse/browser_test.go
+++ b/pkg/browse/browser_test.go
@@ -1,0 +1,80 @@
+//go:build unit
+
+package browse
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newLogger() log.Logger {
+	return log.NewLogger(log.WithOutput(&bytes.Buffer{}))
+}
+
+// stubOpener records the URL it was asked to open and returns the
+// pre-configured error (nil by default). Used to assert that Browser.Open
+// hands off to the opener with the expected URL.
+type stubOpener struct {
+	seenURL string
+	err     error
+}
+
+func (s *stubOpener) Open(_ context.Context, url string) error {
+	s.seenURL = url
+
+	return s.err
+}
+
+func TestBrowse_workspaceFromEnv_buildsListURLWithSourceLocal(t *testing.T) {
+	op := &stubOpener{}
+	b := &Browser{Logger: newLogger(), Opener: op}
+
+	got, err := b.Open(context.Background(), Params{
+		Envs:    map[string]string{"BITRISE_BUILD_CACHE_WORKSPACE_ID": "ws_abc"},
+		BaseURL: "https://app.bitrise.io",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations?source=local", got)
+	assert.Equal(t, got, op.seenURL)
+}
+
+func TestBrowse_invocationID_deepLinks_noSourceFilter(t *testing.T) {
+	op := &stubOpener{}
+	b := &Browser{Logger: newLogger(), Opener: op}
+
+	got, err := b.Open(context.Background(), Params{
+		WorkspaceID:  "ws_abc",
+		InvocationID: "inv_xyz",
+		BaseURL:      "https://app.bitrise.io",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations/inv_xyz", got)
+	assert.NotContains(t, got, "source=")
+}
+
+func TestBrowse_printOnlySkipsOpener(t *testing.T) {
+	op := &stubOpener{}
+	b := &Browser{Logger: newLogger(), Opener: op}
+
+	got, err := b.Open(context.Background(), Params{
+		WorkspaceID: "ws_abc",
+		PrintOnly:   true,
+		BaseURL:     "https://app.bitrise.io",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, got)
+	assert.Empty(t, op.seenURL, "PrintOnly must not invoke the opener")
+}
+
+func TestBrowse_missingWorkspaceReturnsSentinel(t *testing.T) {
+	b := &Browser{Logger: newLogger(), Opener: &stubOpener{}}
+
+	_, err := b.Open(context.Background(), Params{Envs: map[string]string{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrWorkspaceNotConfigured)
+}

--- a/pkg/browse/browser_test.go
+++ b/pkg/browse/browser_test.go
@@ -41,7 +41,7 @@ func (s *stubOpener) Open(_ context.Context, url string) error {
 	return s.err
 }
 
-func TestBrowse_workspaceFromEnv_buildsListURLWithSourceLocal(t *testing.T) {
+func TestBrowse_workspaceFromEnv_buildsListURLWithCIProviderUnknown(t *testing.T) {
 	op := &stubOpener{}
 	b := &Browser{Logger: newLogger(), Opener: op}
 
@@ -50,11 +50,11 @@ func TestBrowse_workspaceFromEnv_buildsListURLWithSourceLocal(t *testing.T) {
 		BaseURL: "https://app.bitrise.io",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations?source=local", got)
+	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations?ci_provider=unknown", got)
 	assert.Equal(t, got, op.seenURL)
 }
 
-func TestBrowse_invocationID_deepLinks_noSourceFilter(t *testing.T) {
+func TestBrowse_invocationID_deepLinks_noFilter(t *testing.T) {
 	op := &stubOpener{}
 	b := &Browser{Logger: newLogger(), Opener: op}
 
@@ -65,7 +65,38 @@ func TestBrowse_invocationID_deepLinks_noSourceFilter(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_abc/invocations/inv_xyz", got)
-	assert.NotContains(t, got, "source=")
+	assert.NotContains(t, got, "ci_provider=")
+}
+
+func TestBrowse_authConfigFallback_resolvesWorkspaceID(t *testing.T) {
+	op := &stubOpener{}
+	b := &Browser{
+		Logger: newLogger(),
+		Opener: op,
+		WorkspaceFromAuth: func(_ map[string]string) (string, error) {
+			return "ws_from_auth", nil
+		},
+	}
+
+	got, err := b.Open(context.Background(), Params{
+		Envs:    map[string]string{},
+		BaseURL: "https://app.bitrise.io",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.bitrise.io/build-cache/ws_from_auth/invocations?ci_provider=unknown", got)
+}
+
+func TestBrowse_authConfigFallback_errorFallsThroughToSentinel(t *testing.T) {
+	b := &Browser{
+		Logger: newLogger(),
+		Opener: &stubOpener{},
+		WorkspaceFromAuth: func(_ map[string]string) (string, error) {
+			return "", errors.New("no config on disk")
+		},
+	}
+
+	_, err := b.Open(context.Background(), Params{Envs: map[string]string{}})
+	require.ErrorIs(t, err, ErrWorkspaceNotConfigured)
 }
 
 func TestBrowse_printOnlySkipsOpener(t *testing.T) {
@@ -83,7 +114,13 @@ func TestBrowse_printOnlySkipsOpener(t *testing.T) {
 }
 
 func TestBrowse_missingWorkspaceReturnsSentinel(t *testing.T) {
-	b := &Browser{Logger: newLogger(), Opener: &stubOpener{}}
+	b := &Browser{
+		Logger: newLogger(),
+		Opener: &stubOpener{},
+		WorkspaceFromAuth: func(_ map[string]string) (string, error) {
+			return "", nil
+		},
+	}
 
 	_, err := b.Open(context.Background(), Params{Envs: map[string]string{}})
 	require.Error(t, err)

--- a/pkg/browse/browser_test.go
+++ b/pkg/browse/browser_test.go
@@ -5,12 +5,23 @@ package browse
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/browse"
 )
+
+// browse_ErrNoOpener returns the internal sentinel so the public-API
+// test can drive the warn-path branch without importing the internal
+// package in line.
+func browse_ErrNoOpener() error { return browse.ErrNoOpener }
+
+//nolint:gochecknoglobals
+var errSimulatedExecFailure = errors.New("simulated exec failure")
 
 func newLogger() log.Logger {
 	return log.NewLogger(log.WithOutput(&bytes.Buffer{}))
@@ -77,4 +88,39 @@ func TestBrowse_missingWorkspaceReturnsSentinel(t *testing.T) {
 	_, err := b.Open(context.Background(), Params{Envs: map[string]string{}})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrWorkspaceNotConfigured)
+}
+
+func TestBrowse_openerErrNoOpener_emitsNoSupportedLauncherWarn(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.NewLogger(log.WithOutput(&buf))
+
+	op := &stubOpener{err: browse_ErrNoOpener()}
+	b := &Browser{Logger: logger, Opener: op}
+
+	got, err := b.Open(context.Background(), Params{
+		WorkspaceID: "ws_abc",
+		BaseURL:     "https://app.bitrise.io",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, got)
+	assert.Contains(t, buf.String(), "No default browser launcher for this OS")
+}
+
+func TestBrowse_openerGenericError_emitsCouldNotAutoLaunchWarn(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.NewLogger(log.WithOutput(&buf))
+
+	op := &stubOpener{err: errSimulatedExecFailure}
+	b := &Browser{Logger: logger, Opener: op}
+
+	got, err := b.Open(context.Background(), Params{
+		WorkspaceID: "ws_abc",
+		BaseURL:     "https://app.bitrise.io",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, got)
+	assert.Contains(t, buf.String(), "Could not auto-launch the browser")
+	// Generic-error message should include the underlying error text so
+	// post-mortem isn't blind.
+	assert.Contains(t, buf.String(), "simulated exec failure")
 }


### PR DESCRIPTION
## Summary

- Adds `bitrise-build-cache browse [invocation-id]` so users can jump from the terminal to the Bitrise Build Cache dashboard in one command.
- Standalone PR — no daemon / xcelerate / xcode-app stack dependency. Bases off `main`.

## Behaviour

| Invocation                                            | URL emitted                                                                              |
| ----------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| `bitrise-build-cache browse`                          | `https://app.bitrise.io/build-cache/<workspace>/invocations?source=local`                |
| `bitrise-build-cache browse inv_xyz`                  | `https://app.bitrise.io/build-cache/<workspace>/invocations/inv_xyz`                     |
| `bitrise-build-cache browse --print`                  | (URL printed only; no launcher)                                                          |

- Workspace ID resolved from `BITRISE_BUILD_CACHE_WORKSPACE_ID` env var. Browse doesn't need an auth token — the URL opens in the user's browser, which handles its own session. Missing-workspace returns a sentinel `pkg/browse.ErrWorkspaceNotConfigured` (distinct from `common.ErrWorkspaceIDNotProvided`, which couples workspace + token).
- Launcher: `/usr/bin/open` on darwin, `xdg-open` on linux/BSD. Unknown platforms or a launcher-side error degrade to "URL was logged — copy it" rather than hard-failing the command.

## `source=local` note

The dashboard ignores the `source` query param today — F4 (ACI-5047) is the BE-side ticket that wires it up. Sending it now is forward-compatible and harmless on the current dashboard.

## Layout

- `cmd/browse/browse.go` — thin cobra wrapper, registered via blank import in `main.go`
- `pkg/browse/browser.go` — public `Browser` struct + `Params` + sentinel error
- `internal/browse/`:
  - `url.go` — pure URL builder, dispatched on (workspace, invocationID, sourceFilter)
  - `open.go` — opener interface + DefaultOpener (exec the platform launcher)

## Test plan

- [x] `make check` (lint + unit) passes locally.
- [x] Manual smoke:
  - `BITRISE_BUILD_CACHE_WORKSPACE_ID=ws_test go run . browse --print` → `…/build-cache/ws_test/invocations?source=local`
  - `BITRISE_BUILD_CACHE_WORKSPACE_ID=ws_test go run . browse --print inv_xyz` → `…/build-cache/ws_test/invocations/inv_xyz`
- [ ] Quick darwin smoke without `--print` — should pop the default browser.

## Out of scope

- F4 (BE accepts `source` field) — separate ticket (ACI-5047).
- Mac OS keychain workspace fallback — separate ticket (ACI-5028, on the M1 stack); env-var is the canonical source for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)