### PR TITLE
feat: enable Clang prefix mapping for XCC cache keys

### DIFF
--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -25,6 +25,9 @@ var CacheArgs = map[string]string{
 	"SWIFT_USE_INTEGRATED_DRIVER":                   "YES",
 	"CLANG_ENABLE_COMPILE_CACHE":                    "YES",
 	"CLANG_ENABLE_MODULES":                          "YES",
+	// Need these to have relative paths for cache keys; pulling into a tmp folder would invalidate cache on every build.
+	"CLANG_ENABLE_PREFIX_MAPPING": "YES",
+	"SWIFT_ENABLE_PREFIX_MAPPING": "YES",
 }
 
 var actions = []string{

--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -25,9 +25,8 @@ var CacheArgs = map[string]string{
 	"SWIFT_USE_INTEGRATED_DRIVER":                   "YES",
 	"CLANG_ENABLE_COMPILE_CACHE":                    "YES",
 	"CLANG_ENABLE_MODULES":                          "YES",
-	// Need these to have relative paths for cache keys; pulling into a tmp folder would invalidate cache on every build.
+	// Need this to have relative paths for cache keys; pulling into a tmp folder would invalidate cache on every build.
 	"CLANG_ENABLE_PREFIX_MAPPING": "YES",
-	"SWIFT_ENABLE_PREFIX_MAPPING": "YES",
 }
 
 var actions = []string{


### PR DESCRIPTION
## Why

XCC (Xcode compilation caching) cache keys embed the **absolute** compile paths, because the CLI enables the caching plugin (`COMPILATION_CACHE_ENABLE_PLUGIN`, `CLANG_ENABLE_COMPILE_CACHE`, …) but never enables **prefix mapping**. For any workspace that does not build from a byte-identical absolute path on every run, the keys differ each build → near-total cache miss → re-upload instead of reuse.

### Evidence (trial audit — E.ON Next, RN app)

- The RN app uses `pull-intermediate-files`, which restores source into a per-build temp root: `$BITRISE_SOURCE_DIR = /var/folders/.../T/_artifact_pull<rand>/git` (different `<rand>` every build).
- Compile commands therefore carry rotating absolute paths, e.g.:
  ```
  cd /var/folders/.../T/_artifact_pull3460249848/git/ios/Pods
  clang ... -c .../_artifact_pull3460249848/.../libwebp/.../sharpyuv_csp.c
  Cache miss
  ```
- xcelerate proxy log for one archive: **3,088 cache misses vs 340 hits (~10%)** → ~0.09 download/upload ratio (writes ~165 GB, reads ~14 GB). The ccache (C++) leg was 0.0. The Gradle leg of the same app reused at ~2× because Gradle keys are relocatable.
- Resolved build settings showed prefix mapping **empty**; `grep PREFIX_MAPPING` over the repo had zero hits.

## What

Add to `CacheArgs` (`internal/xcelerate/xcodeargs/args.go`):

```go
"CLANG_ENABLE_PREFIX_MAPPING": "YES",
```

This canonicalizes the toolchain/SDK/working-directory prefixes in the **Clang** (C/C++/ObjC) + ccache cache keys — exactly where the absolute-path invalidation is worst — so keys are path-stable across builds and machines.

**Swift prefix mapping is intentionally NOT enabled.** `SWIFT_ENABLE_PREFIX_MAPPING=YES` breaks Swift IR generation on Xcode 26 (`IR generation failure: Cannot read legacy layout file ... layouts-arm64.yaml` — the toolchain prefix remap makes IRGen's lookup of the prebuilt type-layout resource fail, aborting every SwiftCompile). The `xcode-cache` e2e caught this; see build history on this PR. Swift compile-key path-sensitivity remains a known, smaller gap — revisit if/when the toolchain supports it.

## Test plan

- `make test-unit` — green. The `cmd/xcode` test iterates `CacheArgs` dynamically, so the new key is asserted present-when-enabled / absent-when-skipped.
- `make lint` — 0 issues.
- `xcode-cache` e2e on CI — the real validator for the build-setting change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)