### PR TITLE
feat: ACI-5089 doctor — BC backend auth probe via sentinel KV PUT

### DIFF
--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -33,7 +33,7 @@ var (
 var doctorCmd = &cobra.Command{
 	Use:          "doctor",
 	Short:        "Diagnose + optionally repair the local Bitrise Build Cache setup",
-	Long:         `doctor runs every health check the CLI knows about — auth, proxy, ccache helper, keychain, log dirs, CLI version — and optionally repairs the safe ones with --fix. The only network call (GitHub release lookup) can be skipped with --no-update-check.`,
+	Long:         `doctor runs every health check the CLI knows about — auth, proxy, ccache helper, keychain, log dirs, CLI version — and optionally repairs the safe ones with --fix. Network calls (GitHub release lookup, Build Cache backend probe) can be skipped with --no-update-check / --no-backend-probe.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		out := cmd.OutOrStdout()

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -23,9 +23,10 @@ const (
 
 //nolint:gochecknoglobals
 var (
-	fixFlag             bool
-	jsonOutput          bool
-	skipUpdateCheckFlag bool
+	fixFlag              bool
+	jsonOutput           bool
+	skipUpdateCheckFlag  bool
+	skipBackendProbeFlag bool
 )
 
 //nolint:gochecknoglobals
@@ -38,8 +39,9 @@ var doctorCmd = &cobra.Command{
 		out := cmd.OutOrStdout()
 
 		report := doctorpkg.NewDoctor().Run(cmd.Context(), doctorpkg.Options{
-			ApplyFixes:      fixFlag,
-			SkipUpdateCheck: skipUpdateCheckFlag,
+			ApplyFixes:       fixFlag,
+			SkipUpdateCheck:  skipUpdateCheckFlag,
+			SkipBackendProbe: skipBackendProbeFlag,
 		})
 
 		if jsonOutput {
@@ -154,6 +156,7 @@ func (c colorPalette) forState(state doctorpkg.State) string {
 func init() {
 	doctorCmd.Flags().BoolVar(&fixFlag, "fix", false, "Apply safe repairs in addition to diagnosing")
 	doctorCmd.Flags().BoolVar(&jsonOutput, "json", false, "Emit report as JSON instead of human-readable text")
-	doctorCmd.Flags().BoolVar(&skipUpdateCheckFlag, "no-update-check", false, "Skip the GitHub release lookup (the only network call doctor makes)")
+	doctorCmd.Flags().BoolVar(&skipUpdateCheckFlag, "no-update-check", false, "Skip the GitHub release lookup")
+	doctorCmd.Flags().BoolVar(&skipBackendProbeFlag, "no-backend-probe", false, "Skip the Build Cache backend auth probe (sentinel KV PUT)")
 	common.RootCmd.AddCommand(doctorCmd)
 }

--- a/internal/build_cache/kv/client.go
+++ b/internal/build_cache/kv/client.go
@@ -23,6 +23,7 @@ import (
 //go:generate moq -rm -stub -pkg mocks -out ./mocks/kv_storage.go ./../../../proto/kv_storage KVStorageClient
 
 type Client struct {
+	conn                *grpc.ClientConn // nil when test-injected via BitriseKVClient / CapabilitiesClient.
 	bitriseKVClient     kv_storage.KVStorageClient
 	capabilitiesClient  remoteexecution.CapabilitiesClient
 	casClient           remoteexecution.ContentAddressableStorageClient
@@ -91,6 +92,7 @@ func NewClient(p NewClientParams) (*Client, error) {
 	}
 
 	return &Client{
+		conn:                conn,
 		bitriseKVClient:     bitriseKVClient,
 		capabilitiesClient:  capabilitiesClient,
 		casClient:           remoteexecution.NewContentAddressableStorageClient(conn),
@@ -109,6 +111,20 @@ func NewClient(p NewClientParams) (*Client, error) {
 
 func (c *Client) SetLogger(logger log.Logger) {
 	c.logger = logger
+}
+
+// Close releases the gRPC connection. Safe to call when the client was built
+// with injected stubs (no conn) — returns nil in that case.
+func (c *Client) Close() error {
+	if c.conn == nil {
+		return nil
+	}
+
+	if err := c.conn.Close(); err != nil {
+		return fmt.Errorf("close kv grpc conn: %w", err)
+	}
+
+	return nil
 }
 
 type writer struct {

--- a/internal/doctor/check_auth_backend.go
+++ b/internal/doctor/check_auth_backend.go
@@ -20,6 +20,7 @@ import (
 const (
 	backendProbeTimeout  = 5 * time.Second
 	backendProbeKeyBytes = 4 // 4 bytes → 8 hex chars in the sentinel key
+	backendProbeHint     = " — re-run `bitrise-build-cache activate --interactive` to refresh credentials"
 )
 
 // BackendProbeFunc returns latency (always populated, even on error so callers can surface "took N ms then failed").
@@ -67,7 +68,7 @@ func defaultBackendProbe(ctx context.Context, cfg common.CacheAuthConfig, envs m
 	client, err := kv.NewClient(kv.NewClientParams{
 		UseInsecure: insecureGRPC,
 		Host:        host,
-		ClientName:  "doctor",
+		ClientName:  "doctor-backend-probe",
 		AuthConfig:  cfg,
 		Logger:      log.NewLogger(),
 	})
@@ -132,15 +133,15 @@ func backendErrorDetail(err error, cfg common.CacheAuthConfig, source common.Aut
 	// The kv client converts gRPC Unauthenticated into a plain sentinel error
 	// before returning, so status.FromError can't see it. Check the sentinel first.
 	if errors.Is(err, kv.ErrCacheUnauthenticated) {
-		return prefix + "auth-failed: token rejected by Build Cache (expired / revoked / wrong workspace)"
+		return prefix + "auth-failed: token rejected by Build Cache (expired / revoked / wrong workspace)" + backendProbeHint
 	}
 
 	if s, ok := status.FromError(err); ok {
 		switch s.Code() { //nolint:exhaustive // only auth + transport-class codes have specific handling; all others fall through.
 		case codes.Unauthenticated:
-			return prefix + "auth-failed: token rejected by Build Cache (expired / revoked / wrong workspace)"
+			return prefix + "auth-failed: token rejected by Build Cache (expired / revoked / wrong workspace)" + backendProbeHint
 		case codes.PermissionDenied:
-			return prefix + "workspace-misconfig: token accepted but no access to this workspace"
+			return prefix + "workspace-misconfig: token accepted but no access to this workspace" + backendProbeHint
 		case codes.Unavailable, codes.DeadlineExceeded:
 			return prefix + "network: " + s.Message()
 		}

--- a/internal/doctor/check_auth_backend.go
+++ b/internal/doctor/check_auth_backend.go
@@ -7,6 +7,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
 	"time"
 
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -45,7 +47,11 @@ func (d *Doctor) authBackendCheck() Check {
 
 			latency, err := probe(probeCtx, cfg, d.Envs)
 			if err != nil {
-				return Result{State: backendErrorState(err), Detail: backendErrorDetail(err, cfg, source, latency)}
+				return Result{
+					State:   backendErrorState(err),
+					Detail:  backendErrorDetail(err, cfg, source, latency),
+					Fixable: backendErrorFixable(err),
+				}
 			}
 
 			return Result{
@@ -53,7 +59,62 @@ func (d *Doctor) authBackendCheck() Check {
 				Detail: fmt.Sprintf("latency %dms, source=%s, workspace=%s", latency.Milliseconds(), sourceLabel(source), cfg.WorkspaceID),
 			}
 		},
+		Fix: d.activateWizardFix,
 	}
+}
+
+// backendErrorFixable returns true for errors a credential refresh can repair —
+// auth-failed (token rejected) and workspace-misconfig (no access). Transport
+// blips (Unavailable / DeadlineExceeded) are not fixable by re-running the wizard.
+func backendErrorFixable(err error) bool {
+	if errors.Is(err, kv.ErrCacheUnauthenticated) {
+		return true
+	}
+
+	if s, ok := status.FromError(err); ok {
+		switch s.Code() { //nolint:exhaustive // only the two auth-related codes are fixable.
+		case codes.Unauthenticated, codes.PermissionDenied:
+			return true
+		}
+	}
+
+	return false
+}
+
+func (d *Doctor) activateWizardFix() (string, error) {
+	launcher := d.LaunchActivateWizard
+	if launcher == nil {
+		launcher = defaultLaunchActivateWizard
+	}
+
+	if err := launcher(); err != nil {
+		return "", fmt.Errorf("launch activate --interactive: %w", err)
+	}
+
+	return "ran `bitrise-build-cache activate --interactive`", nil
+}
+
+// defaultLaunchActivateWizard re-execs the running CLI binary as a child process.
+// The wizard takes over stdin/stdout/stderr and runs to completion before returning.
+// context.Background is correct here: the wizard's lifetime is the user's interactive
+// session, not the parent's check timeout. Signals (SIGINT) reach the child via the
+// shared controlling terminal's process group.
+func defaultLaunchActivateWizard() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate cli executable: %w", err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), exe, "activate", "--interactive")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("activate --interactive: %w", err)
+	}
+
+	return nil
 }
 
 func defaultBackendProbe(ctx context.Context, cfg common.CacheAuthConfig, envs map[string]string) (time.Duration, error) {

--- a/internal/doctor/check_auth_backend.go
+++ b/internal/doctor/check_auth_backend.go
@@ -1,0 +1,144 @@
+package doctor
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+)
+
+const (
+	backendProbeTimeout  = 5 * time.Second
+	backendProbeKeyBytes = 8
+)
+
+// BackendProbeFunc performs the network round-trip the auth-backend check uses.
+// Returns the round-trip latency (always populated, even on error so callers can
+// surface "took N ms then failed") and the gRPC-shaped error.
+type BackendProbeFunc func(ctx context.Context, cfg common.CacheAuthConfig, envs map[string]string) (time.Duration, error)
+
+func (d *Doctor) authBackendCheck() Check {
+	return Check{
+		Name: "auth-backend",
+		Diagnose: func(ctx context.Context) Result {
+			cfg, source, err := common.ResolveAuthConfig(d.Envs)
+			if err != nil {
+				return Result{State: StateOK, Detail: "skipped (no credentials resolvable)"}
+			}
+
+			probe := d.BackendProbe
+			if probe == nil {
+				probe = defaultBackendProbe
+			}
+
+			probeCtx, cancel := context.WithTimeout(ctx, backendProbeTimeout)
+			defer cancel()
+
+			latency, err := probe(probeCtx, cfg, d.Envs)
+			if err != nil {
+				return Result{State: backendErrorState(err), Detail: backendErrorDetail(err, cfg, source, latency)}
+			}
+
+			return Result{
+				State:  StateOK,
+				Detail: fmt.Sprintf("latency %dms, source=%s, workspace=%s", latency.Milliseconds(), sourceLabel(source), cfg.WorkspaceID),
+			}
+		},
+	}
+}
+
+func defaultBackendProbe(ctx context.Context, cfg common.CacheAuthConfig, envs map[string]string) (time.Duration, error) {
+	endpoint := common.SelectCacheEndpointURL("", envs)
+	host, insecureGRPC, err := kv.ParseURLGRPC(endpoint)
+	if err != nil {
+		return 0, fmt.Errorf("parse endpoint %q: %w", endpoint, err)
+	}
+
+	client, err := kv.NewClient(kv.NewClientParams{
+		UseInsecure: insecureGRPC,
+		Host:        host,
+		DialTimeout: backendProbeTimeout,
+		ClientName:  "doctor",
+		AuthConfig:  cfg,
+		Logger:      log.NewLogger(),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("dial %s: %w", host, err)
+	}
+
+	payload := []byte{0}
+
+	start := time.Now()
+	uploadErr := client.UploadStreamToBuildCache(ctx, bytes.NewReader(payload), probeKey(), int64(len(payload)))
+
+	return time.Since(start), uploadErr //nolint:wrapcheck // caller classifies via status.FromError
+}
+
+func probeKey() string {
+	var b [backendProbeKeyBytes]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "doctor-probe-fallback"
+	}
+
+	return "doctor-probe-" + hex.EncodeToString(b[:])
+}
+
+func backendErrorState(err error) State {
+	if s, ok := status.FromError(err); ok {
+		switch s.Code() { //nolint:exhaustive // only auth + transport-class codes have specific handling; all others fall through.
+		case codes.Unauthenticated, codes.PermissionDenied:
+			return StateError
+		case codes.Unavailable, codes.DeadlineExceeded:
+			return StateWarn
+		}
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return StateWarn
+	}
+
+	return StateError
+}
+
+func backendErrorDetail(err error, cfg common.CacheAuthConfig, source common.AuthSource, latency time.Duration) string {
+	prefix := fmt.Sprintf("latency %dms, source=%s, workspace=%s — ", latency.Milliseconds(), sourceLabel(source), cfg.WorkspaceID)
+
+	if s, ok := status.FromError(err); ok {
+		switch s.Code() { //nolint:exhaustive // only auth + transport-class codes have specific handling; all others fall through.
+		case codes.Unauthenticated:
+			return prefix + "auth-failed: token rejected by Build Cache (expired / revoked / wrong workspace)"
+		case codes.PermissionDenied:
+			return prefix + "workspace-misconfig: token accepted but no access to this workspace"
+		case codes.Unavailable, codes.DeadlineExceeded:
+			return prefix + "network: " + s.Message()
+		}
+	}
+
+	return prefix + err.Error()
+}
+
+func sourceLabel(s common.AuthSource) string {
+	switch s {
+	case common.AuthSourceKeychain:
+		return "keychain"
+	case common.AuthSourceEnvVars:
+		return "env"
+	case common.AuthSourceJWT:
+		return "jwt"
+	case common.AuthSourceMultiplatform:
+		return "multiplatform-config"
+	case common.AuthSourceNone:
+		return "none"
+	}
+
+	return "unknown"
+}

--- a/internal/doctor/check_auth_backend.go
+++ b/internal/doctor/check_auth_backend.go
@@ -74,6 +74,7 @@ func defaultBackendProbe(ctx context.Context, cfg common.CacheAuthConfig, envs m
 	if err != nil {
 		return 0, fmt.Errorf("dial %s: %w", host, err)
 	}
+	defer func() { _ = client.Close() }()
 
 	key, err := probeKey()
 	if err != nil {

--- a/internal/doctor/check_auth_backend.go
+++ b/internal/doctor/check_auth_backend.go
@@ -19,12 +19,12 @@ import (
 
 const (
 	backendProbeTimeout  = 5 * time.Second
-	backendProbeKeyBytes = 8
+	backendProbeKeyBytes = 4 // 4 bytes → 8 hex chars in the sentinel key
 )
 
 // BackendProbeFunc performs the network round-trip the auth-backend check uses.
 // Returns the round-trip latency (always populated, even on error so callers can
-// surface "took N ms then failed") and the gRPC-shaped error.
+// surface "took N ms then failed") and the wrapped error.
 type BackendProbeFunc func(ctx context.Context, cfg common.CacheAuthConfig, envs map[string]string) (time.Duration, error)
 
 func (d *Doctor) authBackendCheck() Check {
@@ -33,7 +33,7 @@ func (d *Doctor) authBackendCheck() Check {
 		Diagnose: func(ctx context.Context) Result {
 			cfg, source, err := common.ResolveAuthConfig(d.Envs)
 			if err != nil {
-				return Result{State: StateOK, Detail: "skipped (no credentials resolvable)"}
+				return Result{State: StateOK, Detail: "skipped (source=none, no credentials resolvable: " + err.Error() + ")"}
 			}
 
 			probe := d.BackendProbe
@@ -64,10 +64,11 @@ func defaultBackendProbe(ctx context.Context, cfg common.CacheAuthConfig, envs m
 		return 0, fmt.Errorf("parse endpoint %q: %w", endpoint, err)
 	}
 
+	// kv.NewClient ignores DialTimeout — grpc.NewClient is lazy. The probeCtx
+	// deadline on the caller is the real budget for dial + handshake + RPC.
 	client, err := kv.NewClient(kv.NewClientParams{
 		UseInsecure: insecureGRPC,
 		Host:        host,
-		DialTimeout: backendProbeTimeout,
 		ClientName:  "doctor",
 		AuthConfig:  cfg,
 		Logger:      log.NewLogger(),
@@ -76,24 +77,43 @@ func defaultBackendProbe(ctx context.Context, cfg common.CacheAuthConfig, envs m
 		return 0, fmt.Errorf("dial %s: %w", host, err)
 	}
 
+	key, err := probeKey()
+	if err != nil {
+		return 0, err
+	}
+
 	payload := []byte{0}
 
 	start := time.Now()
-	uploadErr := client.UploadStreamToBuildCache(ctx, bytes.NewReader(payload), probeKey(), int64(len(payload)))
+	uploadErr := client.UploadStreamToBuildCache(ctx, bytes.NewReader(payload), key, int64(len(payload)))
+	latency := time.Since(start)
 
-	return time.Since(start), uploadErr //nolint:wrapcheck // caller classifies via status.FromError
-}
-
-func probeKey() string {
-	var b [backendProbeKeyBytes]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return "doctor-probe-fallback"
+	if uploadErr != nil {
+		return latency, uploadErr //nolint:wrapcheck // caller classifies via kv sentinel + status.FromError.
 	}
 
-	return "doctor-probe-" + hex.EncodeToString(b[:])
+	// Best-effort cleanup so the probe stays a drop in the ocean even if the BE
+	// doesn't TTL-evict by-prefix. Smoke-tests DELETE auth as a bonus. Failure
+	// here doesn't taint the OK verdict — auth + workspace already passed.
+	_ = client.Delete(ctx, key)
+
+	return latency, nil
+}
+
+func probeKey() (string, error) {
+	var b [backendProbeKeyBytes]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("read random bytes for probe key: %w", err)
+	}
+
+	return "doctor-probe-" + hex.EncodeToString(b[:]), nil
 }
 
 func backendErrorState(err error) State {
+	if errors.Is(err, kv.ErrCacheUnauthenticated) {
+		return StateError
+	}
+
 	if s, ok := status.FromError(err); ok {
 		switch s.Code() { //nolint:exhaustive // only auth + transport-class codes have specific handling; all others fall through.
 		case codes.Unauthenticated, codes.PermissionDenied:
@@ -111,6 +131,12 @@ func backendErrorState(err error) State {
 
 func backendErrorDetail(err error, cfg common.CacheAuthConfig, source common.AuthSource, latency time.Duration) string {
 	prefix := fmt.Sprintf("latency %dms, source=%s, workspace=%s — ", latency.Milliseconds(), sourceLabel(source), cfg.WorkspaceID)
+
+	// The kv client converts gRPC Unauthenticated into a plain sentinel error
+	// before returning, so status.FromError can't see it. Check the sentinel first.
+	if errors.Is(err, kv.ErrCacheUnauthenticated) {
+		return prefix + "auth-failed: token rejected by Build Cache (expired / revoked / wrong workspace)"
+	}
 
 	if s, ok := status.FromError(err); ok {
 		switch s.Code() { //nolint:exhaustive // only auth + transport-class codes have specific handling; all others fall through.

--- a/internal/doctor/check_auth_backend.go
+++ b/internal/doctor/check_auth_backend.go
@@ -22,9 +22,7 @@ const (
 	backendProbeKeyBytes = 4 // 4 bytes → 8 hex chars in the sentinel key
 )
 
-// BackendProbeFunc performs the network round-trip the auth-backend check uses.
-// Returns the round-trip latency (always populated, even on error so callers can
-// surface "took N ms then failed") and the wrapped error.
+// BackendProbeFunc returns latency (always populated, even on error so callers can surface "took N ms then failed").
 type BackendProbeFunc func(ctx context.Context, cfg common.CacheAuthConfig, envs map[string]string) (time.Duration, error)
 
 func (d *Doctor) authBackendCheck() Check {
@@ -92,9 +90,7 @@ func defaultBackendProbe(ctx context.Context, cfg common.CacheAuthConfig, envs m
 		return latency, uploadErr //nolint:wrapcheck // caller classifies via kv sentinel + status.FromError.
 	}
 
-	// Best-effort cleanup so the probe stays a drop in the ocean even if the BE
-	// doesn't TTL-evict by-prefix. Smoke-tests DELETE auth as a bonus. Failure
-	// here doesn't taint the OK verdict — auth + workspace already passed.
+	// Best-effort cleanup.
 	_ = client.Delete(ctx, key)
 
 	return latency, nil

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -69,17 +69,18 @@ type Options struct {
 }
 
 type Doctor struct {
-	OsProxy            utils.OsProxy
-	Envs               map[string]string
-	CLIVersion         string
-	HTTPClient         *http.Client
-	AuthLoader         common.AuthLoader
-	Keyring            keychain.Backend
-	LookPath           func(string) (string, error)
-	StateDirCandidates []string
-	LatestReleaseTag   func(ctx context.Context, c *http.Client) (string, error)
-	ActivatedTools     func() map[toolconfig.Tool]bool
-	BackendProbe       BackendProbeFunc
+	OsProxy              utils.OsProxy
+	Envs                 map[string]string
+	CLIVersion           string
+	HTTPClient           *http.Client
+	AuthLoader           common.AuthLoader
+	Keyring              keychain.Backend
+	LookPath             func(string) (string, error)
+	StateDirCandidates   []string
+	LatestReleaseTag     func(ctx context.Context, c *http.Client) (string, error)
+	ActivatedTools       func() map[toolconfig.Tool]bool
+	BackendProbe         BackendProbeFunc
+	LaunchActivateWizard func() error
 }
 
 func NewDoctor() *Doctor {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -63,8 +63,9 @@ func (r Report) Overall() State {
 }
 
 type Options struct {
-	ApplyFixes      bool
-	SkipUpdateCheck bool
+	ApplyFixes       bool
+	SkipUpdateCheck  bool
+	SkipBackendProbe bool
 }
 
 type Doctor struct {
@@ -78,6 +79,7 @@ type Doctor struct {
 	StateDirCandidates []string
 	LatestReleaseTag   func(ctx context.Context, c *http.Client) (string, error)
 	ActivatedTools     func() map[toolconfig.Tool]bool
+	BackendProbe       BackendProbeFunc
 }
 
 func NewDoctor() *Doctor {
@@ -131,7 +133,7 @@ func defaultStateDirCandidates() []string {
 }
 
 func (d *Doctor) Run(ctx context.Context, opts Options) Report {
-	checks := d.checks(opts.SkipUpdateCheck)
+	checks := d.checks(opts)
 	items := make([]ReportItem, 0, len(checks))
 
 	for _, c := range checks {
@@ -153,18 +155,25 @@ func (d *Doctor) Run(ctx context.Context, opts Options) Report {
 	return Report{Items: items, Version: d.CLIVersion}
 }
 
-func (d *Doctor) checks(skipUpdateCheck bool) []Check {
+func (d *Doctor) checks(opts Options) []Check {
 	checks := []Check{
 		d.authCheck(),
 		d.keychainSmokeCheck(),
+	}
+
+	if !opts.SkipBackendProbe {
+		checks = append(checks, d.authBackendCheck())
+	}
+
+	checks = append(checks,
 		d.xcelerateProxyCheck(),
 		d.ccacheHelperCheck(),
 		d.ccacheBinaryCheck(),
 		d.logDirsCheck(),
 		d.xcelerateXcconfigCheck(),
-	}
+	)
 
-	if !skipUpdateCheck {
+	if !opts.SkipUpdateCheck {
 		checks = append(checks, d.cliVersionCheck())
 	}
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -509,9 +509,6 @@ func TestRun_skipBackendProbeOmitsItem(t *testing.T) {
 	}
 }
 
-// Covers the seam between the kv client and the classifier: kv upload/download
-// converts gRPC codes.Unauthenticated into a plain sentinel error before
-// returning, so a status.FromError check alone misses it.
 func TestBackendErrorState_kvSentinelUnauthenticated(t *testing.T) {
 	assert.Equal(t, StateError, backendErrorState(kv.ErrCacheUnauthenticated))
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -524,6 +524,71 @@ func TestBackendErrorDetail_kvSentinelUnauthenticated(t *testing.T) {
 	assert.Contains(t, got, "activate --interactive")
 }
 
+func TestAuthBackendCheck_authFailureIsFixable(t *testing.T) {
+	envs := map[string]string{common.EnvAuthToken: "tok", common.EnvWorkspaceID: "ws-1"}
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"kv sentinel Unauthenticated", kv.ErrCacheUnauthenticated},
+		{"status Unauthenticated", status.Error(codes.Unauthenticated, "bad token")},
+		{"status PermissionDenied", status.Error(codes.PermissionDenied, "no access")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Doctor{
+				Envs: envs,
+				BackendProbe: func(_ context.Context, _ common.CacheAuthConfig, _ map[string]string) (time.Duration, error) {
+					return 10 * time.Millisecond, tc.err
+				},
+			}
+
+			res := r.authBackendCheck().Diagnose(context.Background())
+			assert.True(t, res.Fixable, "auth-class failures must be marked Fixable so doctor --fix can offer the wizard")
+		})
+	}
+}
+
+func TestAuthBackendCheck_transientErrorNotFixable(t *testing.T) {
+	envs := map[string]string{common.EnvAuthToken: "tok", common.EnvWorkspaceID: "ws-1"}
+
+	r := &Doctor{
+		Envs: envs,
+		BackendProbe: func(_ context.Context, _ common.CacheAuthConfig, _ map[string]string) (time.Duration, error) {
+			return 5 * time.Second, status.Error(codes.Unavailable, "connection refused")
+		},
+	}
+
+	res := r.authBackendCheck().Diagnose(context.Background())
+	assert.False(t, res.Fixable, "transport blips must not trigger a wizard re-launch")
+}
+
+func TestActivateWizardFix_invokesInjectedLauncher(t *testing.T) {
+	called := false
+	r := &Doctor{LaunchActivateWizard: func() error {
+		called = true
+
+		return nil
+	}}
+
+	detail, err := r.activateWizardFix()
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Contains(t, detail, "activate --interactive")
+}
+
+func TestActivateWizardFix_propagatesLauncherError(t *testing.T) {
+	r := &Doctor{LaunchActivateWizard: func() error {
+		return errors.New("user aborted")
+	}}
+
+	_, err := r.activateWizardFix()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user aborted")
+}
+
 func TestProbeKey_lengthAndPrefix(t *testing.T) {
 	k, err := probeKey()
 	require.NoError(t, err)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
 )
@@ -411,15 +413,17 @@ func TestRun_includesVersionByDefault(t *testing.T) {
 // ──────────────────────────── auth-backend ────────────────────────────
 
 func TestAuthBackendCheck_skippedWhenNoCreds(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv(common.EnvAuthToken, "")
-	t.Setenv(common.EnvWorkspaceID, "")
-	t.Setenv(common.EnvJWT, "")
+	common.RegisterMultiplatformReader(nil) // keep test hermetic
+	if _, ok := common.GetKeychainCredentials(); ok {
+		t.Skip("dev keychain has creds — ResolveAuthConfig would succeed; can't exercise the skip branch here")
+	}
 
 	r := &Doctor{Envs: map[string]string{}}
 	res := r.authBackendCheck().Diagnose(context.Background())
 	assert.Equal(t, StateOK, res.State)
 	assert.Contains(t, res.Detail, "skipped")
+	assert.Contains(t, res.Detail, "source=none", "skip detail must surface the source for parity with non-skip output")
+	assert.Contains(t, res.Detail, "BITRISE_BUILD_CACHE_AUTH_TOKEN", "skip detail must surface the underlying resolver error")
 }
 
 func TestAuthBackendCheck_okOnSuccessfulProbe(t *testing.T) {
@@ -503,4 +507,26 @@ func TestRun_skipBackendProbeOmitsItem(t *testing.T) {
 	for _, it := range report.Items {
 		assert.NotEqual(t, "auth-backend", it.Name, "auth-backend should be omitted when SkipBackendProbe=true")
 	}
+}
+
+// Covers the seam between the kv client and the classifier: kv upload/download
+// converts gRPC codes.Unauthenticated into a plain sentinel error before
+// returning, so a status.FromError check alone misses it.
+func TestBackendErrorState_kvSentinelUnauthenticated(t *testing.T) {
+	assert.Equal(t, StateError, backendErrorState(kv.ErrCacheUnauthenticated))
+}
+
+func TestBackendErrorDetail_kvSentinelUnauthenticated(t *testing.T) {
+	cfg := common.CacheAuthConfig{WorkspaceID: "ws-1"}
+	got := backendErrorDetail(kv.ErrCacheUnauthenticated, cfg, common.AuthSourceKeychain, 30*time.Millisecond)
+	assert.Contains(t, got, "auth-failed")
+	assert.Contains(t, got, "source=keychain")
+	assert.Contains(t, got, "ws-1")
+}
+
+func TestProbeKey_lengthAndPrefix(t *testing.T) {
+	k, err := probeKey()
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(k, "doctor-probe-"), "got %q", k)
+	assert.Len(t, k, len("doctor-probe-")+2*backendProbeKeyBytes, "8 hex chars expected for 4 random bytes")
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -10,11 +10,15 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
 )
 
@@ -125,6 +129,10 @@ func newMinimalDoctor(t *testing.T) *Doctor {
 		LatestReleaseTag:   func(context.Context, *http.Client) (string, error) { return "", nil },
 		LookPath:           func(string) (string, error) { return "/usr/local/bin/ccache", nil },
 		StateDirCandidates: []string{},
+		// Inert stub so Run tests don't reach the real BC backend.
+		BackendProbe: func(context.Context, common.CacheAuthConfig, map[string]string) (time.Duration, error) {
+			return time.Millisecond, nil
+		},
 	}
 }
 
@@ -398,4 +406,101 @@ func TestRun_includesVersionByDefault(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "cli-version check should run by default")
+}
+
+// ──────────────────────────── auth-backend ────────────────────────────
+
+func TestAuthBackendCheck_skippedWhenNoCreds(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(common.EnvAuthToken, "")
+	t.Setenv(common.EnvWorkspaceID, "")
+	t.Setenv(common.EnvJWT, "")
+
+	r := &Doctor{Envs: map[string]string{}}
+	res := r.authBackendCheck().Diagnose(context.Background())
+	assert.Equal(t, StateOK, res.State)
+	assert.Contains(t, res.Detail, "skipped")
+}
+
+func TestAuthBackendCheck_okOnSuccessfulProbe(t *testing.T) {
+	envs := map[string]string{
+		common.EnvAuthToken:   "tok",
+		common.EnvWorkspaceID: "ws-1",
+	}
+
+	r := &Doctor{
+		Envs: envs,
+		BackendProbe: func(_ context.Context, _ common.CacheAuthConfig, _ map[string]string) (time.Duration, error) {
+			return 47 * time.Millisecond, nil
+		},
+	}
+
+	res := r.authBackendCheck().Diagnose(context.Background())
+	assert.Equal(t, StateOK, res.State)
+	assert.Contains(t, res.Detail, "latency 47ms")
+	assert.Contains(t, res.Detail, "ws-1")
+}
+
+func TestAuthBackendCheck_unauthenticatedIsError(t *testing.T) {
+	envs := map[string]string{
+		common.EnvAuthToken:   "tok",
+		common.EnvWorkspaceID: "ws-1",
+	}
+
+	r := &Doctor{
+		Envs: envs,
+		BackendProbe: func(_ context.Context, _ common.CacheAuthConfig, _ map[string]string) (time.Duration, error) {
+			return 30 * time.Millisecond, status.Error(codes.Unauthenticated, "bad token")
+		},
+	}
+
+	res := r.authBackendCheck().Diagnose(context.Background())
+	assert.Equal(t, StateError, res.State)
+	assert.Contains(t, res.Detail, "auth-failed")
+}
+
+func TestAuthBackendCheck_permissionDeniedIsWorkspaceMisconfig(t *testing.T) {
+	envs := map[string]string{
+		common.EnvAuthToken:   "tok",
+		common.EnvWorkspaceID: "ws-1",
+	}
+
+	r := &Doctor{
+		Envs: envs,
+		BackendProbe: func(_ context.Context, _ common.CacheAuthConfig, _ map[string]string) (time.Duration, error) {
+			return 30 * time.Millisecond, status.Error(codes.PermissionDenied, "no access")
+		},
+	}
+
+	res := r.authBackendCheck().Diagnose(context.Background())
+	assert.Equal(t, StateError, res.State)
+	assert.Contains(t, res.Detail, "workspace-misconfig")
+}
+
+func TestAuthBackendCheck_unavailableIsWarn(t *testing.T) {
+	envs := map[string]string{
+		common.EnvAuthToken:   "tok",
+		common.EnvWorkspaceID: "ws-1",
+	}
+
+	r := &Doctor{
+		Envs: envs,
+		BackendProbe: func(_ context.Context, _ common.CacheAuthConfig, _ map[string]string) (time.Duration, error) {
+			return 5 * time.Second, status.Error(codes.Unavailable, "connection refused")
+		},
+	}
+
+	res := r.authBackendCheck().Diagnose(context.Background())
+	assert.Equal(t, StateWarn, res.State)
+	assert.Contains(t, res.Detail, "network")
+}
+
+func TestRun_skipBackendProbeOmitsItem(t *testing.T) {
+	r := newMinimalDoctor(t)
+
+	report := r.Run(context.Background(), Options{SkipUpdateCheck: true, SkipBackendProbe: true})
+
+	for _, it := range report.Items {
+		assert.NotEqual(t, "auth-backend", it.Name, "auth-backend should be omitted when SkipBackendProbe=true")
+	}
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -461,6 +461,7 @@ func TestAuthBackendCheck_unauthenticatedIsError(t *testing.T) {
 	res := r.authBackendCheck().Diagnose(context.Background())
 	assert.Equal(t, StateError, res.State)
 	assert.Contains(t, res.Detail, "auth-failed")
+	assert.Contains(t, res.Detail, "activate --interactive")
 }
 
 func TestAuthBackendCheck_permissionDeniedIsWorkspaceMisconfig(t *testing.T) {
@@ -479,6 +480,7 @@ func TestAuthBackendCheck_permissionDeniedIsWorkspaceMisconfig(t *testing.T) {
 	res := r.authBackendCheck().Diagnose(context.Background())
 	assert.Equal(t, StateError, res.State)
 	assert.Contains(t, res.Detail, "workspace-misconfig")
+	assert.Contains(t, res.Detail, "activate --interactive")
 }
 
 func TestAuthBackendCheck_unavailableIsWarn(t *testing.T) {
@@ -519,6 +521,7 @@ func TestBackendErrorDetail_kvSentinelUnauthenticated(t *testing.T) {
 	assert.Contains(t, got, "auth-failed")
 	assert.Contains(t, got, "source=keychain")
 	assert.Contains(t, got, "ws-1")
+	assert.Contains(t, got, "activate --interactive")
 }
 
 func TestProbeKey_lengthAndPrefix(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a new `auth-backend` doctor check that exercises the Bitrise Build Cache backend with the resolved credentials via a single 1-byte sentinel KV PUT (key: `doctor-probe-<8 hex>`).

Per Zsolt's 2026-06-03 review point on ACI-5034 — closed without being addressed; tracked separately as ACI-5089. Sibling tickets: ACI-5088 (gating, folded into #355).

## What the check reports

| gRPC outcome | State | Detail |
|---|---|---|
| `OK` | StateOK | `latency 47ms, source=keychain, workspace=ws_abc` |
| `Unauthenticated` | StateError | `auth-failed: token rejected by Build Cache (expired / revoked / wrong workspace)` |
| `PermissionDenied` | StateError | `workspace-misconfig: token accepted but no access to this workspace` |
| `Unavailable` / `DeadlineExceeded` | StateWarn | `network: <message>` |
| Other | StateError | raw error |
| No resolvable creds | StateOK | `skipped (no credentials resolvable)` |

The detail string always includes `source=keychain|env|jwt|multiplatform-config` so a misconfig where credentials resolve to the wrong place is immediately visible without running `auth list`.

## Flag

`--no-backend-probe` skips it, parallel to the existing `--no-update-check`.

## Why a sentinel PUT instead of GetCapabilities

Per discussion: a PUT exercises the full auth + workspace plumbing, while GetCapabilities only validates the gRPC connection + service discovery. The 1-byte payload is a drop in the ocean of real invocations.

## Test plan

- [x] `make check` (lint + unit) passes locally.
- [x] New unit tests cover: skip-no-creds, OK, Unauthenticated, PermissionDenied, Unavailable, and the `--no-backend-probe` Options path.
- [ ] Manual: `bitrise-build-cache doctor` on a machine with valid creds, then with a deliberately bad token, then with the network down.

## Stacked on

[#355 (ACI-5035 doctor)](https://github.com/bitrise-io/bitrise-build-cache-cli/pull/355) — base branch `aci-5035-doctor-subcmd`. GitHub auto-retargets to `aci-4337-cli` once #355 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)