### PR TITLE
feat: bump ccache CRSH data-timeout 2s -> 5s

### DIFF
--- a/internal/config/ccache/config.go
+++ b/internal/config/ccache/config.go
@@ -20,7 +20,7 @@ const (
 	defaultLogFile            = "ccache-%s.log"
 	defaultErrLogFile         = "ccache-err.log"
 	defaultIdleTimeout        = "15m"
-	defaultCRSHDataTimeout    = "2s"
+	defaultCRSHDataTimeout    = "5s"
 	defaultCRSHRequestTimeout = "20s"
 
 	ErrFmtOpenConfigFile   = "open ccache config file (%s): %w"


### PR DESCRIPTION
## What

Raise the default ccache CRSH **`data-timeout`** from **2s → 5s** in `internal/config/ccache/config.go` (`defaultCRSHDataTimeout`). This value is baked into `CCACHE_REMOTE_STORAGE=crsh:<sock> data-timeout=5s request-timeout=20s` by `CRSHRemoteStorageURL()`, which the ccache activation (and therefore `activate-build-cache-for-react-native`) exports.

`CCACHE_REMOTE_ONLY=true` and `request-timeout=20s` are intentionally **unchanged**.

## Why

Surfaced by a Build Cache trial audit. On large native React-Native builds (thousands of `RelWithDebInfo` object files), a **2s per-operation data timeout against a remote-only cache** scores slow fetches as misses — so objects get recompiled and **re-uploaded every build** instead of reused.

Evidence:
- **Pagaleve**: ccache effectively **upload-only** (~1.7 GB up / ~0 down per build, download/upload ratio ≈ 0) with a hit rate stuck at ~23% build-over-build, despite stable keys (`CCACHE_BASEDIR` + `CCACHE_NOHASHDIR` set).
- **E.ON Next**: ccache upload-only as well (32.8 GB up / ~6 MB down across the trial).

Cache keys were stable in the Pagaleve case, so the misses point at fetch timeouts rather than key invalidation. A 5s data timeout gives the storage helper room to serve hits on larger objects without re-uploading.

## Scope / non-goals

- Does **not** address ccache thrash caused by *rotating absolute paths* (a separate key-invalidation bug, e.g. the E.ON Next iOS leg) — that needs path canonicalization, not a timeout bump.
- `REMOTE_ONLY` left as-is: on ephemeral CI VMs the local ccache dir is wiped each build, so a local tier would mostly burn disk for little gain.

## Verification

- `make test-unit` — pass (no test asserts the literal `2s`; `pkg/ccache/activator_test.go` only checks the `crsh:` prefix).
- `make lint` — 0 issues.
- Suggested follow-up: confirm `RemoteStorageTimeout%` (already collected in `internal/ccache/analytics`) drops for these RN customers after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)