### PR TITLE
feat: opt-in robolectric android-all jar audit in gradle mirror init script

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1329,6 +1329,8 @@ workflows:
         - content: |-
             set -exo pipefail
             ./gradlew debug --info --stacktrace > "$BITRISE_DEPLOY_DIR/logs.txt" 2>&1
+            # Robolectric unit test to exercise the android-all jar audit (tolerate failure; append logs).
+            ./gradlew :ad-click-impl:testDebugUnitTest --info --stacktrace >> "$BITRISE_DEPLOY_DIR/logs.txt" 2>&1 || true
     - script:
         title: Assert downloads from MavenCentral mirror
         inputs:
@@ -1365,6 +1367,22 @@ workflows:
             fi
 
             echo "SUCCESS: Verified $MATCH_COUNT downloads from the Google mirror."
+    - script:
+        title: Assert robolectric jar audit emitted
+        inputs:
+        - content: |-
+            set -exo pipefail
+
+            MATCH_COUNT=$(grep -cE '\[bitrise-robolectric-jar-audit\]' "$BITRISE_DEPLOY_DIR/logs.txt" || true)
+            echo "Found $MATCH_COUNT robolectric jar audit log lines:"
+            grep -E '\[bitrise-robolectric-jar-audit\]' "$BITRISE_DEPLOY_DIR/logs.txt" || true
+
+            if [[ "$MATCH_COUNT" -eq 0 ]]; then
+              echo "ERROR: no [bitrise-robolectric-jar-audit] line found — the android-all jar audit did not emit."
+              exit 1
+            fi
+
+            echo "SUCCESS: robolectric jar audit emitted $MATCH_COUNT line(s)."
     - script:
         title: Check for cache invocations
         inputs:

--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -83,6 +83,11 @@ func TestActivate(t *testing.T) {
 				`val loggedReplacements = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()`,
 				`if (loggedReplacements.add("${getName()}|${getUrl()}|$mirrorUrl"))`,
 				`log("setting robolectric.dependency.repo.url=\"https://repository-manager.services.bitrise.io:8090/maven/central\" on ${getPath()}")`,
+				`if (System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false") {`,
+				`tasks.register("bitriseRobolectricJarAuditCentral") {`,
+				`finalizedBy(auditTaskCentral)`,
+				`getLogger().lifecycle("[bitrise-robolectric-jar-audit] OK robolectric=$roboVer name=`,
+				`getLogger().lifecycle("[bitrise-robolectric-jar-audit] ERROR `,
 			},
 			expectNotContain: []string{
 				"https://repository-manager.services.bitrise.io:8090/maven/jitpack",

--- a/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -84,11 +84,46 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
         })
         {{- range .Mirrors }}{{ if .UseAsRobolectricRepo }}
         gradle.afterProject(Action {
+            // android-all jar audit: a finalizer task (runs even when tests FAIL) logs the resolved jar's sha1; set BITRISE_ROBOLECTRIC_JAR_AUDIT=false to opt out. Wrapped so it never fails the build.
+            val auditTask{{ .ID }} = if (System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false") {
+                tasks.register("bitriseRobolectricJarAudit{{ .ID }}") {
+                    doLast {
+                        try {
+                            val gradleHome = System.getenv("GRADLE_USER_HOME") ?: (System.getProperty("user.home") + "/.gradle")
+                            val roboVer = java.io.File(gradleHome, "caches/modules-2/files-2.1/org.robolectric/robolectric")
+                                .listFiles()?.filter { it.isDirectory() }?.map { it.getName() }?.sorted()?.lastOrNull() ?: "unknown"
+                            java.io.File(System.getProperty("user.home"), ".m2/repository/org/robolectric")
+                                .walkTopDown()
+                                .filter { it.isFile() && it.getName().startsWith("android-all") && it.getName().endsWith(".jar") }
+                                .forEach { jar ->
+                                    val md = java.security.MessageDigest.getInstance("SHA-1")
+                                    jar.inputStream().use { ins ->
+                                        val buf = ByteArray(1 shl 16)
+                                        while (true) {
+                                            val n = ins.read(buf)
+                                            if (n < 0) break
+                                            md.update(buf, 0, n)
+                                        }
+                                    }
+                                    val sha1 = md.digest().joinToString("") { String.format("%02x", it.toInt() and 0xFF) }
+                                    getLogger().lifecycle("[bitrise-robolectric-jar-audit] OK robolectric=$roboVer name=${jar.getName()} sha1=$sha1 size=${jar.length()} mtime=${jar.lastModified()}")
+                                }
+                        } catch (t: Throwable) {
+                            getLogger().lifecycle("[bitrise-robolectric-jar-audit] ERROR ${t.javaClass.getName()}: ${t.message}")
+                        }
+                    }
+                }
+            } else {
+                null
+            }
             tasks.withType(Test::class.java).configureEach {
                 if (getProject().getParent() == null) {
                     log("setting robolectric.dependency.repo.url=\"{{ .MirrorURL }}\" on ${getPath()}")
                 }
                 systemProperty("robolectric.dependency.repo.url", "{{ .MirrorURL }}")
+                if (auditTask{{ .ID }} != null) {
+                    finalizedBy(auditTask{{ .ID }})
+                }
             }
         })
         {{- end }}{{ end }}


### PR DESCRIPTION
## What
The gradle-mirrors init script registers a **finalizer task** on `Test` tasks that logs the **Robolectric version** and the **sha1 / size / mtime** of the resolved `android-all` jar(s) under `~/.m2/repository/org/robolectric`.

Real line emitted in CI (`e2e-mavencentral-mirror-duckduck`, build #20261):
```
[bitrise-robolectric-jar-audit] OK robolectric=4.16.1 name=android-all-instrumented-6.0.1_r3-robolectric-r1-i7.jar sha1=12ae655788742f8c1b312295fac530e40c57532e size=79180251 mtime=1782387034300
```

## Why
Diagnostic for **SSW-3019** (Substack + ~7 other apps intermittently failing ~90–250 Robolectric tests with `NoSuchFieldError at DeviceConfig` / `DefaultNativeRuntimeLoader` NPE = a wrong/corrupt `android-all`). The MavenCentral mirror is provably serving canonical jars (server-side integrity logs, force-refresh, jarprobe all clean), yet builds keep failing — and we've **never captured the actual jar bytes a failing build used**. This logs it on every Robolectric build so we can compare to canonical (`d684f4e5…` for `15-robolectric-13954326-i7`) and read the **mtime** to tell *fetched-this-build* (mirror) vs *warm `~/.m2`* (VM image / restored state).

## What we tried (and why the final shape)
1. **`doLast` on the Test task** — first attempt. Verified locally it **does not run when tests FAIL** (Gradle skips trailing actions on task failure) → it would miss *exactly the failing builds we care about*. Rejected.
2. **`finalizedBy` finalizer task** — runs even when the finalized Test task fails. Verified end-to-end on a deliberately failing test: the audit line is emitted after `> Task :test FAILED`. This is the final approach.
3. **Robolectric version source** — initially read from the Test task's `classpath` (`robolectric-<ver>.jar`), but that's only reachable from a `doLast` (passing builds). The finalizer has no test classpath, and DDG uses `refreshVersions` so *declared* deps show a `_` placeholder. Final: read the **resolved** version from the Gradle module cache (`caches/modules-2/files-2.1/org.robolectric/robolectric/<ver>`), falling back to `unknown`. The android-all jar name also encodes the Robolectric build number regardless.
4. **Capturing-on-failure was the crux** — confirmed via a local isolated Gradle repro on both passing and failing tests before wiring CI.

## Safety
- **On by default** so failing builds are captured fleet-wide without pre-arming. Set **`BITRISE_ROBOLECTRIC_JAR_AUDIT=false`** to opt out.
- **Never fails the build** — wrapped in try/catch; errors logged as `[bitrise-robolectric-jar-audit] ERROR …`, never thrown.
- Stable `[bitrise-robolectric-jar-audit]` marker (OK / ERROR) so build-analytics-router *could* match it later — intentionally **not** adding a classifier now (would be high-volume).
- Config-cache safe: finalizer body captures only `java` stdlib + the task receiver; env read at config time.

## CI
`e2e-mavencentral-mirror-duckduck` now keeps the existing `debug` build (mirror-download assertions intact) **and** runs `:ad-click-impl:testDebugUnitTest` + asserts a `[bitrise-robolectric-jar-audit]` line is emitted — so the feature is exercised and guarded end-to-end (build #20261 emitted 9 lines, assertion green).

## Verification
- `make lint` + `make test-unit` green; unit test asserts the rendered finalizer block + marker.
- Local isolated Gradle runs emit the correct version + sha1 on **both passing and failing** tests.
- CI e2e emits the line with real values and the assertion passes.

Note (separate gap, not addressed here): CI's `go-test@1` runs without `-tags unit`, so the repo's `//go:build unit` tests don't actually execute in CI — this change is covered by the e2e + local `make test-unit`.