### PR TITLE
feat: inject depscan prefix-maps to stabilize XCC clang keys

### DIFF
--- a/cmd/reactnative/activate_react_native.go
+++ b/cmd/reactnative/activate_react_native.go
@@ -11,9 +11,10 @@ import (
 
 //nolint:gochecknoglobals
 var (
-	gradleEnabled bool
-	xcodeEnabled  bool
-	cppEnabled    bool
+	gradleEnabled        bool
+	xcodeEnabled         bool
+	cppEnabled           bool
+	disablePrefixMapping bool
 )
 
 //nolint:gochecknoglobals
@@ -33,10 +34,11 @@ Note: This is a convenience activation method, if your activation requires fine-
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		a := rnpkg.NewActivator(rnpkg.ActivatorParams{
-			GradleEnabled: gradleEnabled,
-			XcodeEnabled:  xcodeEnabled,
-			CppEnabled:    cppEnabled,
-			DebugLogging:  common.IsDebugLogMode,
+			GradleEnabled:        gradleEnabled,
+			XcodeEnabled:         xcodeEnabled,
+			CppEnabled:           cppEnabled,
+			DisablePrefixMapping: disablePrefixMapping,
+			DebugLogging:         common.IsDebugLogMode,
 		})
 
 		if err := a.Activate(cmd.Context()); err != nil {
@@ -52,4 +54,5 @@ func init() {
 	activateReactNativeCmd.Flags().BoolVar(&gradleEnabled, "gradle", true, "Activate Gradle build cache (Android).")
 	activateReactNativeCmd.Flags().BoolVar(&xcodeEnabled, "xcode", true, "Activate Xcode build cache (iOS).")
 	activateReactNativeCmd.Flags().BoolVar(&cppEnabled, "cpp", true, "Activate C++ build cache via ccache (native modules).")
+	activateReactNativeCmd.Flags().BoolVar(&disablePrefixMapping, "disable-prefix-mapping", false, "Disable Clang prefix-mapping flags for the Xcode build cache (see `activate xcode --disable-prefix-mapping`).")
 }

--- a/cmd/xcode/activate_xcode.go
+++ b/cmd/xcode/activate_xcode.go
@@ -121,6 +121,10 @@ Useful if there are multiple Xcode versions installed and you want to use a spec
 		activateXcodeParams.BuildCacheSkipFlags,
 		`Skip passing cache flags to xcodebuild except the COMPILATION_CACHE_REMOTE_SERVICE_PATH.
 Cache will have to be enabled manually in the Xcode project settings.`)
+	activateXcodeCmd.Flags().BoolVar(&activateXcodeParams.DisablePrefixMapping,
+		"disable-prefix-mapping",
+		activateXcodeParams.DisablePrefixMapping,
+		`Disable injecting Clang prefix-mapping flags into xcodebuild. Prefix mapping canonicalizes rotating source/DerivedData paths so compilation cache keys stay stable; disable only if it causes issues.`)
 }
 
 // ActivateXcodeCommandFn is a backward-compatible wrapper around xcelerate.Activate.

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -543,20 +543,24 @@ func createProxySessionClient(config xcelerate.Config, logger log.Logger) (sessi
 func getArgsToPass(config xcelerate.Config, xcodeArgs xcodeargs.XcodeArgs) []string {
 	additional := map[string]string{}
 
-	if config.BuildCacheEnabled {
-		additional["COMPILATION_CACHE_REMOTE_SERVICE_PATH"] = config.ProxySocketPath
-
-		if !config.BuildCacheSkipFlags {
-			maps.Copy(additional, xcodeargs.CacheArgs)
-			diagnosticRemarks := "NO"
-			if config.DebugLogging {
-				diagnosticRemarks = "YES"
-			}
-			maps.Copy(additional, map[string]string{
-				"COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS": diagnosticRemarks,
-			})
-		}
+	if !config.BuildCacheEnabled {
+		return xcodeArgs.Args(additional)
 	}
+
+	additional["COMPILATION_CACHE_REMOTE_SERVICE_PATH"] = config.ProxySocketPath
+	if config.BuildCacheSkipFlags {
+		return xcodeArgs.Args(additional)
+	}
+
+	maps.Copy(additional, xcodeargs.CacheArgs)
+	if !config.DisablePrefixMapping {
+		maps.Copy(additional, xcodeargs.PrefixMapArgs)
+	}
+	diagnosticRemarks := "NO"
+	if config.DebugLogging {
+		diagnosticRemarks = "YES"
+	}
+	additional["COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS"] = diagnosticRemarks
 
 	return xcodeArgs.Args(additional)
 }

--- a/cmd/xcode/xcodebuild_test.go
+++ b/cmd/xcode/xcodebuild_test.go
@@ -129,15 +129,18 @@ func Test_xcodebuildCmdFn(t *testing.T) {
 
 	t.Run("xcodebuildCmdFn adds cache flags only if build cache is enabled and skip flag is not enabled", func(t *testing.T) {
 		testCases := []struct {
-			name                string
-			buildCacheEnabled   bool
-			buildCacheSkipFlags bool
-			expectCacheFlags    bool
+			name                 string
+			buildCacheEnabled    bool
+			buildCacheSkipFlags  bool
+			disablePrefixMapping bool
+			expectCacheFlags     bool
+			expectPrefixMaps     bool
 		}{
-			{"enabled & not skipped", true, false, true},
-			{"enabled & skipped", true, true, false},
-			{"disabled & not skipped", false, false, false},
-			{"disabled & skipped", false, true, false},
+			{"enabled & not skipped", true, false, false, true, true},
+			{"enabled & skipped", true, true, false, false, false},
+			{"enabled, prefix mapping disabled", true, false, true, true, false},
+			{"disabled & not skipped", false, false, false, false, false},
+			{"disabled & skipped", false, true, false, false, false},
 		}
 
 		for _, tc := range testCases {
@@ -161,9 +164,10 @@ func Test_xcodebuildCmdFn(t *testing.T) {
 
 				SUT := &xcode.XcodebuildRunner{
 					Config: xcelerate.Config{
-						BuildCacheEnabled:   tc.buildCacheEnabled,
-						BuildCacheSkipFlags: tc.buildCacheSkipFlags,
-						ProxySocketPath:     "/tmp/proxy.sock",
+						BuildCacheEnabled:    tc.buildCacheEnabled,
+						BuildCacheSkipFlags:  tc.buildCacheSkipFlags,
+						DisablePrefixMapping: tc.disablePrefixMapping,
+						ProxySocketPath:      "/tmp/proxy.sock",
 					},
 					Metadata:           common.CacheConfigMetadata{},
 					InvocationID:       uuid.NewString(),
@@ -181,6 +185,13 @@ func Test_xcodebuildCmdFn(t *testing.T) {
 						assert.Equal(t, v, receivedAdditional[k], "Expected cache flag %s to be present", k)
 					} else {
 						assert.NotContains(t, receivedAdditional, k, "Did not expect cache flag %s", k)
+					}
+				}
+				for k, v := range xcodeargs.PrefixMapArgs {
+					if tc.expectPrefixMaps {
+						assert.Equal(t, v, receivedAdditional[k], "Expected prefix-map flag %s to be present", k)
+					} else {
+						assert.NotContains(t, receivedAdditional, k, "Did not expect prefix-map flag %s", k)
 					}
 				}
 				if tc.buildCacheEnabled {

--- a/internal/config/xcelerate/config.go
+++ b/internal/config/xcelerate/config.go
@@ -30,6 +30,7 @@ type Params struct {
 	BuildCacheEnabled           bool
 	BuildCacheEndpoint          string
 	BuildCacheSkipFlags         bool
+	DisablePrefixMapping        bool
 	DebugLogging                bool
 	Silent                      bool
 	XcodePathOverride           string
@@ -52,6 +53,7 @@ type Config struct {
 	OriginalXcrunPath      string `json:"originalXcrunPath"`
 	BuildCacheEnabled      bool   `json:"buildCacheEnabled"`
 	BuildCacheSkipFlags    bool   `json:"buildCacheSkipFlags"`
+	DisablePrefixMapping   bool   `json:"disablePrefixMapping,omitempty"`
 	BuildCacheEndpoint     string `json:"buildCacheEndpoint"`
 	PushEnabled            bool   `json:"pushEnabled"`
 	DebugLogging           bool   `json:"debugLogging,omitempty"`
@@ -98,6 +100,7 @@ func DefaultParams() Params {
 	return Params{
 		BuildCacheEnabled:           true,
 		BuildCacheSkipFlags:         false,
+		DisablePrefixMapping:        false,
 		BuildCacheEndpoint:          "",
 		Silent:                      false,
 		DebugLogging:                false,
@@ -200,6 +203,7 @@ func NewConfig(ctx context.Context,
 		OriginalXcrunPath:      xcrunPath,
 		BuildCacheEnabled:      params.BuildCacheEnabled,
 		BuildCacheSkipFlags:    params.BuildCacheSkipFlags,
+		DisablePrefixMapping:   params.DisablePrefixMapping,
 		BuildCacheEndpoint:     params.BuildCacheEndpoint,
 		PushEnabled:            params.PushEnabled,
 		DebugLogging:           params.DebugLogging,

--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -25,10 +25,13 @@ var CacheArgs = map[string]string{
 	"SWIFT_USE_INTEGRATED_DRIVER":                   "YES",
 	"CLANG_ENABLE_COMPILE_CACHE":                    "YES",
 	"CLANG_ENABLE_MODULES":                          "YES",
-	// Need this to have relative paths for cache keys; pulling into a tmp folder would invalidate cache on every build.
+}
+
+// PrefixMapArgs canonicalize the rotating dir roots in clang cache keys so a non-stable
+// checkout/DerivedData path still reuses cache. Suppressed by --disable-prefix-mapping.
+var PrefixMapArgs = map[string]string{
 	"CLANG_ENABLE_PREFIX_MAPPING": "YES",
-	// Canonicalize the rotating dir roots in clang cache keys so a non-stable checkout/DerivedData path still reuses cache.
-	"OTHER_CFLAGS": "$(inherited) -fdepscan-prefix-map=$(SRCROOT)=/^src -fdepscan-prefix-map=$(OBJROOT)=/^obj -fdepscan-prefix-map=$(SYMROOT)=/^sym -fdepscan-prefix-map=$(BUILT_PRODUCTS_DIR)=/^built -fdepscan-prefix-map=$(HOME)=/^home",
+	"OTHER_CFLAGS":                "$(inherited) -fdepscan-prefix-map=$(SRCROOT)=/^src -fdepscan-prefix-map=$(OBJROOT)=/^obj -fdepscan-prefix-map=$(SYMROOT)=/^sym -fdepscan-prefix-map=$(BUILT_PRODUCTS_DIR)=/^built -fdepscan-prefix-map=$(HOME)=/^home",
 }
 
 var actions = []string{

--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -27,6 +27,8 @@ var CacheArgs = map[string]string{
 	"CLANG_ENABLE_MODULES":                          "YES",
 	// Need this to have relative paths for cache keys; pulling into a tmp folder would invalidate cache on every build.
 	"CLANG_ENABLE_PREFIX_MAPPING": "YES",
+	// Canonicalize the rotating dir roots in clang cache keys so a non-stable checkout/DerivedData path still reuses cache.
+	"OTHER_CFLAGS": "$(inherited) -fdepscan-prefix-map=$(SRCROOT)=/^src -fdepscan-prefix-map=$(OBJROOT)=/^obj -fdepscan-prefix-map=$(SYMROOT)=/^sym -fdepscan-prefix-map=$(BUILT_PRODUCTS_DIR)=/^built -fdepscan-prefix-map=$(HOME)=/^home",
 }
 
 var actions = []string{

--- a/pkg/reactnative/activator.go
+++ b/pkg/reactnative/activator.go
@@ -30,10 +30,11 @@ import (
 
 // ActivatorParams holds the activation flags.
 type ActivatorParams struct {
-	GradleEnabled bool
-	XcodeEnabled  bool
-	CppEnabled    bool
-	DebugLogging  bool
+	GradleEnabled        bool
+	XcodeEnabled         bool
+	CppEnabled           bool
+	DisablePrefixMapping bool
+	DebugLogging         bool
 
 	// Logger overrides the default logger. If nil, a default logger is created.
 	Logger log.Logger
@@ -66,7 +67,7 @@ func NewActivator(params ActivatorParams) *Activator {
 	}
 
 	if params.XcodeEnabled {
-		a.xcode = &xcodeActivator{logger: logger, debugLogging: params.DebugLogging}
+		a.xcode = &xcodeActivator{logger: logger, debugLogging: params.DebugLogging, disablePrefixMapping: params.DisablePrefixMapping}
 	}
 
 	// ccache only meaningfully wraps the Android/Gradle native build path in
@@ -298,13 +299,15 @@ func (g *gradleActivator) activate() error {
 }
 
 type xcodeActivator struct {
-	logger       log.Logger
-	debugLogging bool
+	logger               log.Logger
+	debugLogging         bool
+	disablePrefixMapping bool
 }
 
 func (x *xcodeActivator) activate(ctx context.Context) error {
 	xcodeParams := xcelerate.DefaultParams()
 	xcodeParams.DebugLogging = x.debugLogging
+	xcodeParams.DisablePrefixMapping = x.disablePrefixMapping
 
 	if err := xcelerate.Activate(
 		ctx,


### PR DESCRIPTION
Draft — design validated, pending the open decisions below.

## What
Inject `OTHER_CFLAGS` with `-fdepscan-prefix-map` for the rotating dir roots (`SRCROOT/OBJROOT/SYMROOT/BUILT_PRODUCTS_DIR/HOME`) so XCC clang cache keys are path-independent. **DerivedData stays at its default location** (no relocation → no breakage for DD-reading tools / non-wrapping callers).

Opt-out: **`--disable-prefix-mapping`** on `activate xcode` and `activate react-native` (RN threads it into the Xcode activation). Default off (mapping on). Prefix-map settings live in `xcodeargs.PrefixMapArgs`; the wrapper injects them unless `config.DisablePrefixMapping`.

## Why
v2.8.5's `CLANG_ENABLE_PREFIX_MAPPING` only canonicalizes the *toolchain* path. Builds from a non-stable checkout (e.g. RN apps using `pull-intermediate-files` → `…/_artifact_pull<rand>/`) still embed the rotating *source* and *DerivedData* paths in the key → ~0 reuse (confirmed in prod: Dow Jones `enterprise_build_steps`).

## Evidence (probe, cross-checkout clang key-overlap /1522)
```
source-map only ............... 9%
THIS PR ($() per-target maps) . 59%
two resolved root maps ........ 90%   (follow-up, needs resolver)
pinned -derivedDataPath ....... 90%   (rejected: relocates DD)
```
Probe (manual-only workflow `probe-clang-srcroot-prefixmap`, app 4ee4b595): [populate](https://app.bitrise.io/app/4ee4b595-430f-4ba6-91c1-3157004c27c3/build/9fbb883f-b90f-495b-8589-9458ea923539) / [test](https://app.bitrise.io/app/4ee4b595-430f-4ba6-91c1-3157004c27c3/build/feb6448b-3bd3-4b1b-a0dc-9e243c894114). Discussion: #team-advanced-ci-uxws-private thread (2026-06-25).

## Release follow-up (steps)
Expose the opt-out as a step input when releasing — add `--disable-prefix-mapping` wiring to **activate-build-cache-for-xcode** and **activate-react-native-features** steps.

## Open decisions
- **Gating default:** currently opt-out (on by default when cache enabled & not `BuildCacheSkipFlags`); flag lets users turn it off.
- **Root-map upgrade (59% → 90%):** replace per-target `$()` maps with two *resolved* root maps — `<checkout-root>=/^src` + `<DerivedData>/<App>-<hash>=/^dd` (DD root via `xcodebuild -showBuildSettings`). Needs a resolver in the wrapper.
- **`OTHER_CFLAGS` already set by the user:** `Args()` skips injection if present (no clobber) → our maps dropped for those builds.
- **Swift:** clang-only here; `OTHER_SWIFT_FLAGS -Xcc …` is a separate add.

## Test
`make test-unit` + `make lint` green. `cmd/xcode` test covers prefix-map injection + the `--disable-prefix-mapping` path (present when enabled, absent when disabled/skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)