### PR TITLE
feat: auto-bump gradle-mirrors step on each CLI release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -67,7 +67,7 @@ A release can be triggered by:
 | Xcode step (unified CI) | `48fa8fbee698622c` | `bitrise-steplib/bitrise-step-activate-build-cache-for-xcode` |
 | Gradle features step (unified CI) | `48fa8fbee698622c` | `bitrise-steplib/bitrise-step-activate-gradle-features` |
 | React Native features step (unified CI) | `48fa8fbee698622c` | `bitrise-steplib/bitrise-step-activate-react-native-features` |
-| Gradle mirrors step (pinned-version consumer) | _verify_ | `bitrise-steplib/bitrise-step-activate-gradle-mirrors` |
+| Gradle mirrors step (unified CI) | `48fa8fbee698622c` | `bitrise-steplib/bitrise-step-activate-gradle-mirrors` |
 | Steplib | — | `bitrise-io/bitrise-steplib` |
 
 ## Steps
@@ -123,13 +123,13 @@ The `release-and-verify` pipeline chains a `bump-prebooting` workflow after `ver
 
 ### 7. Wait for step auto-update PRs
 
-The CLI release triggers auto-update PRs in **five** consumer repos. Monitor CI, then approve and merge each. The first four use unified CI app `48fa8fbee698622c` and the PR title "feat: Release new CLI":
+The CLI release triggers auto-update PRs in **five** consumer repos. Monitor CI, then approve and merge each. All five are bumped by `bundle::update-step` in the `release` workflow (push-based, after the binaries publish), use unified CI app `48fa8fbee698622c`, and the PR title "feat: Release new CLI":
 
 1. **Gradle step:** `bitrise-steplib/bitrise-step-activate-gradle-remote-cache` — released for every CLI version.
 2. **Xcode step:** `bitrise-steplib/bitrise-step-activate-build-cache-for-xcode` — released for every CLI version.
 3. **React Native features step:** `bitrise-steplib/bitrise-step-activate-react-native-features` — released, but releases are **not 1:1 with CLI releases** (each step release usually catches up across several intervening CLI patch versions; release when CLI changes matter for RN, e.g. an Xcode or Gradle-side improvement that RN builds benefit from).
 4. **Gradle features step:** `bitrise-steplib/bitrise-step-activate-gradle-features` — truly experimental, no GitHub release flow yet (only a single early steplib PR exists). Merge the auto-update PR but do not cut a GitHub release until that changes.
-5. **Gradle mirrors step:** `bitrise-steplib/bitrise-step-activate-gradle-mirrors` — used by customers who **pin a specific CLI version** (the default fleet gets the mirror init script via provisioning/preboot instead, so this step is the delivery channel only for pinned-version builds). ⚠ Do **not** assume its auto-update fires — it has lagged the CLI badly (stuck at v2.6.1 / release 0.2.1 while the CLI was at v2.8.x). If no auto-update PR appears, **open the bump PR manually**. Its bump PR title is `chore: bump bitrise-build-cache-cli to vX.Y.Z` (not "feat: Release new CLI"), and it uses 0.x step versioning.
+5. **Gradle mirrors step:** `bitrise-steplib/bitrise-step-activate-gradle-mirrors` — used by customers who **pin a specific CLI version** (the default fleet gets the mirror init script via provisioning/preboot instead, so this step is the delivery channel only for pinned-version builds). It's a Go-module consumer (bumped via `go get`/`go mod tidy`/`go mod vendor`, same as the gradle features step). Now push-bumped by the `release` workflow like the others — historically it lagged badly (stuck at v2.6.1 / release 0.2.1 while the CLI was at v2.8.x) because it relied only on Renovate polling; the `bundle::update-step` push removes that lag. It uses 0.x step versioning, so cut a `0.x` GitHub release when you ship it.
 
 ```bash
 # For each step repo:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -141,6 +141,10 @@ workflows:
         envs:
         - STEP_NAME: bitrise-step-activate-react-native-features
         - UPDATE_SCRIPT_PATH: ../scripts/update_activate_react_native_features.sh
+    - bundle::update-step:
+        envs:
+        - STEP_NAME: bitrise-step-activate-gradle-mirrors
+        - UPDATE_SCRIPT_PATH: ../scripts/update_activate_gradle_mirrors.sh
     - slack@4:
         inputs:
           - channel: "#team-advanced-ci-alerts-website"
@@ -1453,6 +1457,10 @@ workflows:
           envs:
             - STEP_NAME: bitrise-step-activate-react-native-features
             - UPDATE_SCRIPT_PATH: ../scripts/update_activate_react_native_features.sh
+      - bundle::update-step:
+          envs:
+            - STEP_NAME: bitrise-step-activate-gradle-mirrors
+            - UPDATE_SCRIPT_PATH: ../scripts/update_activate_gradle_mirrors.sh
 
 step_bundles:
   release-flow-check:

--- a/scripts/update_activate_gradle_mirrors.sh
+++ b/scripts/update_activate_gradle_mirrors.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+go get github.com/bitrise-io/bitrise-build-cache-cli/v2@${BITRISE_GIT_TAG}
+go mod tidy
+go mod vendor


### PR DESCRIPTION
## What

Auto-bumps `bitrise-steplib/bitrise-step-activate-gradle-mirrors` to the new CLI version on every CLI release, bringing it to parity with the other four consumer step repos.

## Why

The gradle-mirrors step is a pinned-version delivery channel (customers who pin a specific CLI version; the default fleet gets the mirror init script via preboot). Until now it had **no push-based bump** — it relied only on Renovate polling, which lagged badly (stuck at v2.6.1 / release 0.2.1 while the CLI was at v2.8.x).

## How

- New `scripts/update_activate_gradle_mirrors.sh` — `go get @${BITRISE_GIT_TAG}` + `go mod tidy` + `go mod vendor`. The step is a Go-module consumer (pins `github.com/bitrise-io/bitrise-build-cache-cli/v2` in `go.mod`), so this mirrors the gradle-features step exactly.
- Adds a `bundle::update-step` invocation for it in both the `release` workflow (fires after binaries publish) and the standalone `update-steps` workflow.
- It now goes through the shared `update_step.sh`, opening a `feat: Release new CLI vX.Y.Z` PR against the step's `main` — same as the other four.

## Merge behavior

Parity with the other four steps: the bot opens the PR, the releaser self-approves + merges (`--auto`). Branch protection on the step repo still requires one approving review + code-owner review (`enforce_admins: true`), and the authoring bot can't approve its own PR, so a single self-approval click remains — this is unchanged from the existing four steps.

## Docs

Updated `.claude/skills/release/SKILL.md` — moved gradle-mirrors to unified-CI parity and dropped the "lagged badly / open the PR manually" caution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)