### PR TITLE
feat: ACI-5128 e2e-daemon-keepalive-rde workflow (manual)

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1295,13 +1295,13 @@ workflows:
 
       Requires Bitrise app secrets:
         - RDE_BITRISE_PAT: PAT for codespaces-api.services.bitrise.io
-        - RDE_WORKSPACE_ID: workspace slug to host the RDE session
+        - WORKSPACE_SLUG: workspace slug to host the RDE session
     envs:
     - SESSION_NAME: bbc-keepalive-${BITRISE_BUILD_NUMBER}
     - RDE_STACK: osx-xcode-26.0.x-edge
     - RDE_MACHINE_TYPE: g2.mac.m2pro.6c-14g
     - BITRISE_TOKEN: $RDE_BITRISE_PAT
-    - BITRISE_WORKSPACE_ID: $RDE_WORKSPACE_ID
+    - BITRISE_WORKSPACE_ID: $WORKSPACE_SLUG
     steps:
     - activate-ssh-key:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1380,12 +1380,13 @@ workflows:
               if [[ -n "$FAIL" ]]; then
                 echo "=== DIAGNOSTICS ==="
                 for label in $FAIL; do
+                  short=${label#io.bitrise.build-cache.}
                   echo "--- launchctl print $label ---"
                   launchctl print "gui/$uid/$label" 2>&1 | head -60 || true
-                  echo "--- supervisor stderr ($label) ---"
-                  tail -40 "$HOME/.local/state/bitrise-build-cache/logs/$(basename $label io.bitrise.build-cache.).err.log" 2>&1 || true
-                  echo "--- supervisor stdout ($label) ---"
-                  tail -40 "$HOME/.local/state/bitrise-build-cache/logs/$(basename $label io.bitrise.build-cache.).out.log" 2>&1 || true
+                  echo "--- $short.err.log (last 60) ---"
+                  tail -60 "$HOME/.local/state/bitrise-build-cache/logs/$short.err.log" 2>&1 || true
+                  echo "--- $short.out.log (last 60) ---"
+                  tail -60 "$HOME/.local/state/bitrise-build-cache/logs/$short.out.log" 2>&1 || true
                 done
                 exit 1
               fi

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1357,6 +1357,7 @@ workflows:
               CLI=/Users/vagrant/.local/bin/bitrise-build-cache-cli
               "$CLI" auth set --workspace-id "'"$BITRISE_WORKSPACE_ID"'" --token "'"$BITRISE_TOKEN"'" >/dev/null
               "$CLI" activate xcode --cache
+              "$CLI" activate c++
               "$CLI" daemon install
               "$CLI" daemon restart
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1317,8 +1317,7 @@ workflows:
         inputs:
         - content: |-
             set -exo pipefail
-            curl --retry 5 -sSfL https://raw.githubusercontent.com/bitrise-io/bitrise-cli/main/install/installer.sh \
-              | sh -s -- -b "$HOME/.local/bin"
+            curl --retry 5 -fsSL https://app.bitrise.io/cli/install.sh | bash
             envman add --key PATH --value "$HOME/.local/bin:$PATH"
     - script:
         title: create RDE session

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1324,25 +1324,21 @@ workflows:
         inputs:
         - content: |-
             set -exo pipefail
-            SID=$(bitrise-cli rde session create "$SESSION_NAME" \
-              --stack "$RDE_STACK" --machine-type "$RDE_MACHINE_TYPE" \
-              --wait --output json | jq -r .id)
-            [[ -n "$SID" ]] || { echo "FAIL: session create returned no id"; exit 1; }
-            envman add --key RDE_SESSION_ID --value "$SID"
-            echo "RDE session: $SID"
+            bitrise-cli rde session create "$SESSION_NAME" \
+              --stack "$RDE_STACK" --machine-type "$RDE_MACHINE_TYPE" --wait
     - script:
         title: upload patched CLI
         inputs:
         - content: |-
             set -exo pipefail
-            bitrise-cli rde session upload "$RDE_SESSION_ID" \
+            bitrise-cli rde session upload "$SESSION_NAME" \
               ./bitrise-build-cache-cli /Users/vagrant/.local/bin
     - script:
         title: daemon lifecycle + keepalive asserts
         inputs:
         - content: |-
             set -exo pipefail
-            bitrise-cli rde session exec "$RDE_SESSION_ID" -- bash -c '
+            bitrise-cli rde session exec "$SESSION_NAME" -- bash -c '
               set -exo pipefail
               CLI=/Users/vagrant/.local/bin/bitrise-build-cache-cli
               "$CLI" auth set --workspace-id "'"$BITRISE_WORKSPACE_ID"'" --token "'"$BITRISE_TOKEN"'"
@@ -1366,12 +1362,11 @@ workflows:
         inputs:
         - content: |-
             set -exo pipefail
-            [[ -n "$RDE_SESSION_ID" ]] || exit 0
             mkdir -p "$BITRISE_DEPLOY_DIR/rde-logs"
-            bitrise-cli rde session download "$RDE_SESSION_ID" \
+            bitrise-cli rde session download "$SESSION_NAME" \
               /Users/vagrant/.local/state/bitrise-build-cache/logs \
               "$BITRISE_DEPLOY_DIR/rde-logs" || true
-            bitrise-cli rde session terminate "$RDE_SESSION_ID" || true
+            bitrise-cli rde session terminate "$SESSION_NAME" || true
     - deploy-to-bitrise-io: {}
 
   e2e-mavencentral-mirror-duckduck:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1307,11 +1307,11 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone: {}
     - script:
-        title: build CLI
+        title: build CLI (darwin/arm64 for RDE)
         inputs:
         - content: |-
             set -exo pipefail
-            go build -o bitrise-build-cache-cli
+            GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o bitrise-build-cache-cli
     - script:
         title: install bitrise-cli
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1303,7 +1303,15 @@ workflows:
     - BITRISE_TOKEN: $RDE_BITRISE_PAT
     - BITRISE_WORKSPACE_ID: $RDE_WORKSPACE_ID
     steps:
-    - bundle::feature-e2e-setup: {}
+    - activate-ssh-key:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone: {}
+    - script:
+        title: build CLI
+        inputs:
+        - content: |-
+            set -exo pipefail
+            go build -o bitrise-build-cache-cli
     - script:
         title: install bitrise-cli
         inputs:
@@ -1329,7 +1337,7 @@ workflows:
         - content: |-
             set -exo pipefail
             bitrise-cli rde session upload "$RDE_SESSION_ID" \
-              ../bitrise-build-cache-cli /Users/vagrant/.local/bin
+              ./bitrise-build-cache-cli /Users/vagrant/.local/bin
     - script:
         title: daemon lifecycle + keepalive asserts
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1353,22 +1353,42 @@ workflows:
         - content: |-
             set -exo pipefail
             bitrise-cli rde session exec "$SESSION_NAME" -- bash -c '
-              set -exo pipefail
+              set -eo pipefail
               CLI=/Users/vagrant/.local/bin/bitrise-build-cache-cli
-              "$CLI" auth set --workspace-id "'"$BITRISE_WORKSPACE_ID"'" --token "'"$BITRISE_TOKEN"'"
+              "$CLI" auth set --workspace-id "'"$BITRISE_WORKSPACE_ID"'" --token "'"$BITRISE_TOKEN"'" >/dev/null
               "$CLI" activate xcode --cache
               "$CLI" daemon install
               "$CLI" daemon restart
 
               uid=$(id -u)
+              FAIL=""
               for label in io.bitrise.build-cache.xcelerate-proxy io.bitrise.build-cache.ccache-helper; do
+                alive=1
                 for i in 1 2 3 4 5; do
                   sleep 2
-                  pid=$(launchctl print "gui/$uid/$label" | awk "/^[[:space:]]*pid =/{print \$3}")
-                  [[ -n "$pid" ]] || { echo "FAIL: $label dead at t+$((i*2))s"; exit 1; }
+                  pid=$(launchctl print "gui/$uid/$label" 2>/dev/null | awk "/^[[:space:]]*pid =/{print \$3}")
+                  if [[ -z "$pid" ]]; then
+                    echo "FAIL: $label dead at t+$((i*2))s"
+                    alive=0
+                    FAIL="${FAIL} $label"
+                    break
+                  fi
                 done
-                echo "OK: $label alive 10s post-restart"
+                [[ "$alive" == 1 ]] && echo "OK: $label alive 10s post-restart"
               done
+
+              if [[ -n "$FAIL" ]]; then
+                echo "=== DIAGNOSTICS ==="
+                for label in $FAIL; do
+                  echo "--- launchctl print $label ---"
+                  launchctl print "gui/$uid/$label" 2>&1 | head -60 || true
+                  echo "--- supervisor stderr ($label) ---"
+                  tail -40 "$HOME/.local/state/bitrise-build-cache/logs/$(basename $label io.bitrise.build-cache.).err.log" 2>&1 || true
+                  echo "--- supervisor stdout ($label) ---"
+                  tail -40 "$HOME/.local/state/bitrise-build-cache/logs/$(basename $label io.bitrise.build-cache.).out.log" 2>&1 || true
+                done
+                exit 1
+              fi
             '
     - script:
         title: collect logs + terminate

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1327,6 +1327,20 @@ workflows:
             bitrise-cli rde session create "$SESSION_NAME" \
               --stack "$RDE_STACK" --machine-type "$RDE_MACHINE_TYPE" --wait
     - script:
+        title: wait for SSH ready
+        inputs:
+        - content: |-
+            set -exo pipefail
+            for i in $(seq 1 60); do
+              if bitrise-cli rde session view "$SESSION_NAME" --output json | jq -e '.ssh_connection_open == true' >/dev/null; then
+                echo "OK: SSH ready after ${i}*5s"
+                exit 0
+              fi
+              sleep 5
+            done
+            echo "FAIL: SSH not ready after 5min"
+            exit 1
+    - script:
         title: upload patched CLI
         inputs:
         - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1286,6 +1286,87 @@ workflows:
             echo "OK: uninstall is idempotent"
     - deploy-to-bitrise-io: {}
 
+  e2e-daemon-keepalive-rde:
+    description: |
+      Validate `daemon install/up/restart` keeps the supervised services
+      alive on a fresh Bitrise RDE macOS VM — more representative GUI/Aqua
+      session semantics than the headless CI VM in
+      `e2e-daemon-install-macos`. Manual trigger only.
+
+      Requires Bitrise app secrets:
+        - RDE_BITRISE_PAT: PAT for codespaces-api.services.bitrise.io
+        - RDE_WORKSPACE_ID: workspace slug to host the RDE session
+    envs:
+    - SESSION_NAME: bbc-keepalive-${BITRISE_BUILD_NUMBER}
+    - RDE_STACK: osx-xcode-26.0.x-edge
+    - RDE_MACHINE_TYPE: g2.mac.m2pro.6c-14g
+    - BITRISE_TOKEN: $RDE_BITRISE_PAT
+    - BITRISE_WORKSPACE_ID: $RDE_WORKSPACE_ID
+    steps:
+    - bundle::feature-e2e-setup: {}
+    - script:
+        title: install bitrise-cli
+        inputs:
+        - content: |-
+            set -exo pipefail
+            curl --retry 5 -sSfL https://raw.githubusercontent.com/bitrise-io/bitrise-cli/main/install/installer.sh \
+              | sh -s -- -b "$HOME/.local/bin"
+            envman add --key PATH --value "$HOME/.local/bin:$PATH"
+    - script:
+        title: create RDE session
+        inputs:
+        - content: |-
+            set -exo pipefail
+            SID=$(bitrise-cli rde session create "$SESSION_NAME" \
+              --stack "$RDE_STACK" --machine-type "$RDE_MACHINE_TYPE" \
+              --wait --output json | jq -r .id)
+            [[ -n "$SID" ]] || { echo "FAIL: session create returned no id"; exit 1; }
+            envman add --key RDE_SESSION_ID --value "$SID"
+            echo "RDE session: $SID"
+    - script:
+        title: upload patched CLI
+        inputs:
+        - content: |-
+            set -exo pipefail
+            bitrise-cli rde session upload "$RDE_SESSION_ID" \
+              ../bitrise-build-cache-cli /Users/vagrant/.local/bin
+    - script:
+        title: daemon lifecycle + keepalive asserts
+        inputs:
+        - content: |-
+            set -exo pipefail
+            bitrise-cli rde session exec "$RDE_SESSION_ID" -- bash -c '
+              set -exo pipefail
+              CLI=/Users/vagrant/.local/bin/bitrise-build-cache-cli
+              "$CLI" auth set --workspace-id "'"$BITRISE_WORKSPACE_ID"'" --token "'"$BITRISE_TOKEN"'"
+              "$CLI" activate xcode --cache
+              "$CLI" daemon install
+              "$CLI" daemon restart
+
+              uid=$(id -u)
+              for label in io.bitrise.build-cache.xcelerate-proxy io.bitrise.build-cache.ccache-helper; do
+                for i in 1 2 3 4 5; do
+                  sleep 2
+                  pid=$(launchctl print "gui/$uid/$label" | awk "/^[[:space:]]*pid =/{print \$3}")
+                  [[ -n "$pid" ]] || { echo "FAIL: $label dead at t+$((i*2))s"; exit 1; }
+                done
+                echo "OK: $label alive 10s post-restart"
+              done
+            '
+    - script:
+        title: collect logs + terminate
+        is_always_run: true
+        inputs:
+        - content: |-
+            set -exo pipefail
+            [[ -n "$RDE_SESSION_ID" ]] || exit 0
+            mkdir -p "$BITRISE_DEPLOY_DIR/rde-logs"
+            bitrise-cli rde session download "$RDE_SESSION_ID" \
+              /Users/vagrant/.local/state/bitrise-build-cache/logs \
+              "$BITRISE_DEPLOY_DIR/rde-logs" || true
+            bitrise-cli rde session terminate "$RDE_SESSION_ID" || true
+    - deploy-to-bitrise-io: {}
+
   e2e-mavencentral-mirror-duckduck:
     envs:
     - TEST_APP_URL: git@github.com:duckduckgo/Android.git

--- a/cmd/ccache/start_storage_helper.go
+++ b/cmd/ccache/start_storage_helper.go
@@ -1,8 +1,11 @@
 package ccache
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
@@ -36,6 +39,12 @@ var (
 				DebugLogging: common.IsDebugLogMode,
 			})
 			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					log.NewLogger().TInfof("ccache not configured; run `bitrise-build-cache activate c++` to enable. Helper idle.")
+
+					return nil
+				}
+
 				return fmt.Errorf("create storage helper: %w", err)
 			}
 

--- a/internal/daemon/launchd_plist.go
+++ b/internal/daemon/launchd_plist.go
@@ -21,7 +21,10 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>
-	<true/>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>StandardOutPath</key>


### PR DESCRIPTION
## Summary

Adds a Bitrise workflow that spins up a fresh **Bitrise RDE** macOS session, uploads the patched CLI, runs \`daemon install / restart\`, and asserts the supervised LaunchAgents stay alive for 10 seconds post-restart.

## Why a separate workflow

The existing \`e2e-daemon-install-macos\` runs on a headless \`g2.mac.large\` CI VM. Empirical observation showed \`daemon restart\` registering the agent but launchd not actually spawning the helper despite \`RunAtLoad+KeepAlive=true\` — a session/Aqua-context issue that a fresh RDE VM is better suited to reproduce.

## Shape

- Manual trigger only — not in \`build-cache-cli-test\` pipeline auto-runs.
- Parameterized: \`RDE_STACK\`, \`RDE_MACHINE_TYPE\`, \`SESSION_NAME\` are workflow envs so we can run a matrix against multiple stacks later.
- Requires Bitrise app secrets:
  - \`RDE_BITRISE_PAT\` → \`BITRISE_TOKEN\` for codespaces-api
  - \`RDE_WORKSPACE_ID\` → \`BITRISE_WORKSPACE_ID\`
- Cleanup: \`is_always_run\` step downloads logs + terminates the session.

## Test plan

- [ ] Wire \`RDE_BITRISE_PAT\` + \`RDE_WORKSPACE_ID\` in Bitrise app secrets.
- [ ] Trigger workflow manually from Bitrise UI.
- [ ] Confirm helper pid is non-empty 10s after restart.
- [ ] If FAIL → adds the kickstart-after-bootstrap fix in \`internal/daemon/launchd.go\` (separate commit on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)