### PR TITLE
feat: audit logs DisplayMetrics jar integrity + robolectric component inventory

### DIFF
--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -87,6 +87,9 @@ func TestActivate(t *testing.T) {
 				`allprojects {`,
 				`finalizedBy(auditTaskCentral)`,
 				`getLogger().lifecycle("[bitrise-robolectric-jar-audit] cli=v0.0.0-test robolectric=$roboVer name=`,
+				`getLogger().lifecycle("[bitrise-robolectric-jar-audit] cli=v0.0.0-test components $components")`,
+				`displayMetrics=present(${e.getSize()}) entries=${zf.size()}`,
+				`java.util.zip.ZipFile(jar).use`,
 				`getLogger().lifecycle("[bitrise-robolectric-jar-audit] ERROR cli=v0.0.0-test `,
 			},
 			expectNotContain: []string{

--- a/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -91,8 +91,15 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                         doLast {
                             try {
                                 val gradleHome = System.getenv("GRADLE_USER_HOME") ?: (System.getProperty("user.home") + "/.gradle")
-                                val roboVer = java.io.File(gradleHome, "caches/modules-2/files-2.1/org.robolectric/robolectric")
+                                val roboRoot = java.io.File(gradleHome, "caches/modules-2/files-2.1/org.robolectric")
+                                val roboVer = java.io.File(roboRoot, "robolectric")
                                     .listFiles()?.filter { it.isDirectory() }?.map { it.getName() }?.sorted()?.lastOrNull() ?: "unknown"
+                                // Component inventory: catches Robolectric version skew (shadows-framework/nativeruntime/annotations resolving to a different version than the core).
+                                val components = roboRoot.listFiles()?.filter { it.isDirectory() }?.sortedBy { it.getName() }?.joinToString(" ") { comp ->
+                                    val v = comp.listFiles()?.filter { it.isDirectory() }?.map { it.getName() }?.sorted()?.lastOrNull() ?: "?"
+                                    "${comp.getName()}=$v"
+                                } ?: "none"
+                                getLogger().lifecycle("[bitrise-robolectric-jar-audit] cli={{ $.CLIVersion }} components $components")
                                 java.io.File(System.getProperty("user.home"), ".m2/repository/org/robolectric")
                                     .walkTopDown()
                                     .filter { it.isFile() && it.getName().startsWith("android-all") && it.getName().endsWith(".jar") }
@@ -107,7 +114,17 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                                             }
                                         }
                                         val sha1 = md.digest().joinToString("") { String.format("%02x", it.toInt() and 0xFF) }
-                                        getLogger().lifecycle("[bitrise-robolectric-jar-audit] cli={{ $.CLIVersion }} robolectric=$roboVer name=${jar.getName()} sha1=$sha1 size=${jar.length()} mtime=${jar.lastModified()}")
+                                        // Structural check: an intact-but-wrong jar (or a truncated one) shows up as MISSING/zip-error or an off DisplayMetrics size, distinguishing it from a correct jar that fails for classpath/version reasons.
+                                        var dm = "displayMetrics=?"
+                                        try {
+                                            java.util.zip.ZipFile(jar).use { zf ->
+                                                val e = zf.getEntry("android/util/DisplayMetrics.class")
+                                                dm = if (e != null) "displayMetrics=present(${e.getSize()}) entries=${zf.size()}" else "displayMetrics=MISSING entries=${zf.size()}"
+                                            }
+                                        } catch (z: Throwable) {
+                                            dm = "displayMetrics=zip-error(${z.javaClass.getSimpleName()})"
+                                        }
+                                        getLogger().lifecycle("[bitrise-robolectric-jar-audit] cli={{ $.CLIVersion }} robolectric=$roboVer name=${jar.getName()} sha1=$sha1 size=${jar.length()} mtime=${jar.lastModified()} $dm")
                                     }
                             } catch (t: Throwable) {
                                 getLogger().lifecycle("[bitrise-robolectric-jar-audit] ERROR cli={{ $.CLIVersion }} ${t.javaClass.getName()}: ${t.message}")


### PR DESCRIPTION
## What

Extends the gradle-mirrors Robolectric jar audit (follow-up to #381) with two diagnostics that distinguish a *corrupt* jar from an *intact-but-wrong-classpath* failure — the distinction the live e66be489 / SSW-3019 investigation now hinges on.

Both stay in the root-once finalizer, wrapped in the existing never-fail try/catch.

### 1. Per android-all jar — structural check
Appends to each audit line: whether `android/util/DisplayMetrics.class` is present, its uncompressed size, and the jar's zip entry count:
```
[bitrise-robolectric-jar-audit] cli=… robolectric=… name=…-i7.jar sha1=… size=… mtime=… displayMetrics=present(6716) entries=6740
```
`displayMetrics=MISSING` / `zip-error(...)` ⇒ truncated/corrupt; `present(N)` with a sane size ⇒ structurally intact (so a `NoSuchFieldError` is classpath/version, not corruption).

### 2. Robolectric component inventory (once)
```
[bitrise-robolectric-jar-audit] cli=… components annotations=4.14.1 nativeruntime=4.14.1 robolectric=4.14.1 sandbox=4.14.1 shadows-framework=4.14.1 …
```
Catches Robolectric component version skew (a `shadows-framework`/`nativeruntime` mismatch produces `NoSuchFieldError` with an otherwise-correct jar).

## Why now
The captured e66be489 failures show byte-correct android-all jars (`sha1` cross-org consistent) failing at `DeviceConfig:253` on `noncompatWidthPixels` — and that field **is present** in the loaded jar. So the cause is a different `DisplayMetrics` on the classpath / version skew, not corruption. These two signals confirm jar integrity + surface skew on the next failure.

## Test
`make lint` clean; mirror unit tests updated + passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)