### PR TITLE
fix: init-script compile failure + tier-1 robolectric classpath probe

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1328,6 +1328,24 @@ workflows:
               echo "=== bitrise-gradle-mirrors.init.gradle.kts ==="
               cat ~/.gradle/init.d/bitrise-gradle-mirrors.init.gradle.kts
     - script:
+        title: Guard - init script compiles clean under allWarningsAsErrors
+        inputs:
+        - content: |-
+            set -exo pipefail
+            # Some customers' Gradle promotes Kotlin DSL warnings to errors via
+            # org.gradle.kotlin.dsl.allWarningsAsErrors; under that setting an init-script
+            # warning fails compilation and thus every gradle build (the v2.8.10 regression).
+            # Compile our init script in an isolated GRADLE_USER_HOME + empty project so the
+            # property applies only to our script, not DuckDuckGo's build scripts.
+            GUARD_HOME=$(mktemp -d)
+            GUARD_PROJ=$(mktemp -d)
+            mkdir -p "$GUARD_HOME/init.d"
+            cp ~/.gradle/init.d/bitrise-gradle-mirrors.init.gradle.kts "$GUARD_HOME/init.d/"
+            printf 'org.gradle.kotlin.dsl.allWarningsAsErrors=true\n' > "$GUARD_HOME/gradle.properties"
+            printf 'rootProject.name = "init-compile-guard"\n' > "$GUARD_PROJ/settings.gradle.kts"
+            GRADLE_USER_HOME="$GUARD_HOME" ./gradlew --project-dir "$GUARD_PROJ" help --stacktrace
+            echo "SUCCESS: init script compiles clean under allWarningsAsErrors"
+    - script:
         title: Build and capture logs
         inputs:
         - content: |-

--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -91,6 +91,8 @@ func TestActivate(t *testing.T) {
 				`displayMetrics=present(${e.getSize()}) entries=${zf.size()}`,
 				`java.util.zip.ZipFile(jar).use`,
 				`getLogger().lifecycle("[bitrise-robolectric-jar-audit] ERROR cli=v0.0.0-test `,
+				`getLogger().lifecycle("[robolectric-classpath-probe] cli=v0.0.0-test ${getPath()} android/util/DisplayMetrics from: `,
+				`z.getEntry("android/util/DisplayMetrics.class") != null`,
 			},
 			expectNotContain: []string{
 				"https://repository-manager.services.bitrise.io:8090/maven/jitpack",

--- a/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -140,6 +140,22 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                         systemProperty("robolectric.dependency.repo.url", "{{ .MirrorURL }}")
                         if (auditTask{{ .ID }} != null) {
                             finalizedBy(auditTask{{ .ID }})
+                            // Classpath probe: lists the jars on the test runtime classpath that provide android/util/DisplayMetrics.class, in classpath order. >1 entry (e.g. a mockable-android/stub jar alongside android-all) names a shadow that produces NoSuchFieldError on an otherwise-correct jar. Runs before the test (so it's captured on failing builds), never fails the build.
+                            doFirst {
+                                try {
+                                    val dmSources = getClasspath().getFiles()
+                                        .filter { it.isFile() && it.getName().endsWith(".jar") }
+                                        .filter {
+                                            try { java.util.zip.ZipFile(it).use { z -> z.getEntry("android/util/DisplayMetrics.class") != null } } catch (e: Throwable) { false }
+                                        }
+                                        .map { "${it.getName()}(${it.length()})" }
+                                    if (dmSources.isNotEmpty()) {
+                                        getLogger().lifecycle("[robolectric-classpath-probe] cli={{ $.CLIVersion }} ${getPath()} android/util/DisplayMetrics from: ${dmSources.joinToString(", ")}")
+                                    }
+                                } catch (t: Throwable) {
+                                    getLogger().lifecycle("[robolectric-classpath-probe] ERROR cli={{ $.CLIVersion }} ${t.javaClass.getName()}: ${t.message}")
+                                }
+                            }
                         }
                     }
                 }

--- a/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -115,14 +115,13 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                                         }
                                         val sha1 = md.digest().joinToString("") { String.format("%02x", it.toInt() and 0xFF) }
                                         // Structural check: an intact-but-wrong jar (or a truncated one) shows up as MISSING/zip-error or an off DisplayMetrics size, distinguishing it from a correct jar that fails for classpath/version reasons.
-                                        var dm = "displayMetrics=?"
-                                        try {
+                                        val dm = try {
                                             java.util.zip.ZipFile(jar).use { zf ->
                                                 val e = zf.getEntry("android/util/DisplayMetrics.class")
-                                                dm = if (e != null) "displayMetrics=present(${e.getSize()}) entries=${zf.size()}" else "displayMetrics=MISSING entries=${zf.size()}"
+                                                if (e != null) "displayMetrics=present(${e.getSize()}) entries=${zf.size()}" else "displayMetrics=MISSING entries=${zf.size()}"
                                             }
                                         } catch (z: Throwable) {
-                                            dm = "displayMetrics=zip-error(${z.javaClass.getSimpleName()})"
+                                            "displayMetrics=zip-error(${z.javaClass.getSimpleName()})"
                                         }
                                         getLogger().lifecycle("[bitrise-robolectric-jar-audit] cli={{ $.CLIVersion }} robolectric=$roboVer name=${jar.getName()} sha1=$sha1 size=${jar.length()} mtime=${jar.lastModified()} $dm")
                                     }


### PR DESCRIPTION
## What's Changed

**P1 fix (v2.8.10 regression):** the audit's `var dm = "displayMetrics=?"` was unconditionally reassigned. Kotlin flags it as a redundant initializer, and strict Gradle/Kotlin treats that warning as an **error** — failing init-script *compilation* and thus **every** gradle build on affected VMs (not just Robolectric). The `BITRISE_ROBOLECTRIC_JAR_AUDIT=false` opt-out can't help (compile precedes the runtime env check). Rewritten as a `val` from a try-expression. Preboot already rolled back to v2.8.9 to stop the bleeding; this is the forward fix.

**Tier-1 classpath probe:** logs which jar on the Test classpath carries `android/util/DisplayMetrics.class`, to name the shadow behind the SSW-3019 `NoSuchFieldError`. Note: Tier-1 sees `android.jar` even on passing builds (android-all is loaded in Robolectric's sandbox classloader, not the test classpath), so it confirms the shadow source on the build classpath but a sandbox-level (Tier-2) probe is still needed to fully discriminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)