### PR TITLE
feat: tier-2 robolectric sandbox probe (-Xlog:class+load), on by default + guarded

### DIFF
--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -81,7 +81,7 @@ func TestActivate(t *testing.T) {
 				`log("prepending pluginManagement mirror https://repository-manager.services.bitrise.io:8090/maven/gradle-plugins")`,
 				`val loggedReplacements = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()`,
 				`if (loggedReplacements.add("${getName()}|${getUrl()}|$mirrorUrl"))`,
-				`log("setting robolectric.dependency.repo.url=\"https://repository-manager.services.bitrise.io:8090/maven/central\" on all Test tasks (audit=${auditTaskCentral != null})")`,
+				`log("setting robolectric.dependency.repo.url=\"https://repository-manager.services.bitrise.io:8090/maven/central\" on all Test tasks (audit=${auditTaskCentral != null}, sandboxProbe=${sandboxProbeCentral})")`,
 				`if (System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false") {`,
 				`tasks.register("bitriseRobolectricJarAuditCentral") {`,
 				`allprojects {`,
@@ -93,6 +93,12 @@ func TestActivate(t *testing.T) {
 				`getLogger().lifecycle("[bitrise-robolectric-jar-audit] ERROR cli=v0.0.0-test `,
 				`getLogger().lifecycle("[robolectric-classpath-probe] cli=v0.0.0-test ${getPath()} android/util/DisplayMetrics from: `,
 				`z.getEntry("android/util/DisplayMetrics.class") != null`,
+				// Tier-2 sandbox probe (opt-in via BITRISE_ROBOLECTRIC_SANDBOX_PROBE, -Xlog:class+load)
+				`val sandboxProbeCentral = System.getenv("BITRISE_ROBOLECTRIC_SANDBOX_PROBE") == "true"`,
+				`jvmArgs("-Xlog:class+load=info:file=${probeLog.getAbsolutePath()}")`,
+				`getPath().replace(':', '_').trim('_') + "-%p.classload.log"`,
+				`lf.readLines().filter { it.contains("android.util.DisplayMetrics") }.forEach { ln ->`,
+				`getLogger().lifecycle("[robolectric-sandbox-probe] cli=v0.0.0-test ${ln.trim()}")`,
 			},
 			expectNotContain: []string{
 				"https://repository-manager.services.bitrise.io:8090/maven/jitpack",

--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -81,7 +81,7 @@ func TestActivate(t *testing.T) {
 				`log("prepending pluginManagement mirror https://repository-manager.services.bitrise.io:8090/maven/gradle-plugins")`,
 				`val loggedReplacements = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()`,
 				`if (loggedReplacements.add("${getName()}|${getUrl()}|$mirrorUrl"))`,
-				`log("setting robolectric.dependency.repo.url=\"https://repository-manager.services.bitrise.io:8090/maven/central\" on all Test tasks (audit=${auditTaskCentral != null}, sandboxProbe=${sandboxProbeCentral})")`,
+				`log("setting robolectric.dependency.repo.url=\"https://repository-manager.services.bitrise.io:8090/maven/central\" on all Test tasks (audit=${auditTaskCentral != null}, sandboxProbe=${auditTaskCentral != null})")`,
 				`if (System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false") {`,
 				`tasks.register("bitriseRobolectricJarAuditCentral") {`,
 				`allprojects {`,
@@ -93,11 +93,12 @@ func TestActivate(t *testing.T) {
 				`getLogger().lifecycle("[bitrise-robolectric-jar-audit] ERROR cli=v0.0.0-test `,
 				`getLogger().lifecycle("[robolectric-classpath-probe] cli=v0.0.0-test ${getPath()} android/util/DisplayMetrics from: `,
 				`z.getEntry("android/util/DisplayMetrics.class") != null`,
-				// Tier-2 sandbox probe (opt-in via BITRISE_ROBOLECTRIC_SANDBOX_PROBE, -Xlog:class+load)
-				`val sandboxProbeCentral = System.getenv("BITRISE_ROBOLECTRIC_SANDBOX_PROBE") == "true"`,
-				`jvmArgs("-Xlog:class+load=info:file=${probeLog.getAbsolutePath()}")`,
+				// Tier-2 sandbox probe (opt-OUT: shares BITRISE_ROBOLECTRIC_JAR_AUDIT kill-switch; -Xlog:class+load, JDK9+ + Android-task gated)
+				`val testJvmMajor = (try { getJavaLauncher().getOrNull()?.getMetadata()?.getLanguageVersion()?.asInt() } catch (e: Throwable) { null }) ?: org.gradle.api.JavaVersion.current().getMajorVersion().toIntOrNull()`,
+				`if (testJvmMajor != null && testJvmMajor >= 9 && dirOk) {`,
+				`jvmArgs("-Xlog:class+load=info:file=${probeLog.getAbsolutePath()}::filesize=16m,filecount=1")`,
 				`getPath().replace(':', '_').trim('_') + "-%p.classload.log"`,
-				`lf.readLines().filter { it.contains("android.util.DisplayMetrics") }.forEach { ln ->`,
+				`seq.filter { it.contains("android.util.DisplayMetrics") }.forEach { ln ->`,
 				`getLogger().lifecycle("[robolectric-sandbox-probe] cli=v0.0.0-test ${ln.trim()}")`,
 			},
 			expectNotContain: []string{

--- a/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -85,6 +85,9 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
             {{- range .Mirrors }}{{ if .UseAsRobolectricRepo }}
             // Root-only: wire the Robolectric android-all redirect + jar audit across every Test task in the build, registered and logged once (avoids per-subproject flooding).
             if (getParent() == null) {
+                // Tier-2 sandbox probe (opt-in: BITRISE_ROBOLECTRIC_SANDBOX_PROBE=true). The Tier-1 classpath probe only sees the Gradle test runtime classpath; android.util.DisplayMetrics is actually loaded inside Robolectric's sandbox classloader. When enabled we add -Xlog:class+load to each Test JVM so the VM itself records the source jar / defining loader of every class it loads (to a per-fork file); the audit finalizer then greps the android.util.DisplayMetrics lines out and re-emits them — naming the loader/jar behind the NoSuchFieldError. No agent, no compile; never fails the build.
+                val sandboxProbe{{ .ID }} = System.getenv("BITRISE_ROBOLECTRIC_SANDBOX_PROBE") == "true"
+                val sandboxLogDir{{ .ID }} = java.io.File(System.getenv("GRADLE_USER_HOME") ?: (System.getProperty("user.home") + "/.gradle"), "bitrise-robolectric-sandbox-probe")
                 // Finalizer task (runs even when tests FAIL) logs the resolved android-all jar's sha1 once; set BITRISE_ROBOLECTRIC_JAR_AUDIT=false to opt out. Wrapped so it never fails the build.
                 val auditTask{{ .ID }} = if (System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false") {
                     tasks.register("bitriseRobolectricJarAudit{{ .ID }}") {
@@ -125,6 +128,16 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                                         }
                                         getLogger().lifecycle("[bitrise-robolectric-jar-audit] cli={{ $.CLIVersion }} robolectric=$roboVer name=${jar.getName()} sha1=$sha1 size=${jar.length()} mtime=${jar.lastModified()} $dm")
                                     }
+                                // Tier-2: grep android.util.DisplayMetrics out of the per-fork -Xlog:class+load files (each line records the source jar / defining loader), re-emit, then delete (large, per-VM).
+                                sandboxLogDir{{ .ID }}.listFiles()?.filter { it.isFile() && it.getName().endsWith(".classload.log") }?.forEach { lf ->
+                                    try {
+                                        lf.readLines().filter { it.contains("android.util.DisplayMetrics") }.forEach { ln ->
+                                            getLogger().lifecycle("[robolectric-sandbox-probe] cli={{ $.CLIVersion }} ${ln.trim()}")
+                                        }
+                                        lf.delete()
+                                    } catch (e: Throwable) {
+                                    }
+                                }
                             } catch (t: Throwable) {
                                 getLogger().lifecycle("[bitrise-robolectric-jar-audit] ERROR cli={{ $.CLIVersion }} ${t.javaClass.getName()}: ${t.message}")
                             }
@@ -133,10 +146,16 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                 } else {
                     null
                 }
-                log("setting robolectric.dependency.repo.url=\"{{ .MirrorURL }}\" on all Test tasks (audit=${auditTask{{ .ID }} != null})")
+                log("setting robolectric.dependency.repo.url=\"{{ .MirrorURL }}\" on all Test tasks (audit=${auditTask{{ .ID }} != null}, sandboxProbe=${sandboxProbe{{ .ID }}})")
                 allprojects {
                     tasks.withType(Test::class.java).configureEach {
                         systemProperty("robolectric.dependency.repo.url", "{{ .MirrorURL }}")
+                        if (sandboxProbe{{ .ID }}) {
+                            // -Xlog:class+load makes the test JVM record the source jar / defining loader of every class it loads (incl. Robolectric's sandbox loader) to a per-fork file (%p = pid). Requires JDK 9+; opt-in, so only enabled for targeted diagnosis.
+                            sandboxLogDir{{ .ID }}.mkdirs()
+                            val probeLog = java.io.File(sandboxLogDir{{ .ID }}, getPath().replace(':', '_').trim('_') + "-%p.classload.log")
+                            jvmArgs("-Xlog:class+load=info:file=${probeLog.getAbsolutePath()}")
+                        }
                         if (auditTask{{ .ID }} != null) {
                             finalizedBy(auditTask{{ .ID }})
                             // Classpath probe: lists the jars on the test runtime classpath that provide android/util/DisplayMetrics.class, in classpath order. >1 entry (e.g. a mockable-android/stub jar alongside android-all) names a shadow that produces NoSuchFieldError on an otherwise-correct jar. Runs before the test (so it's captured on failing builds), never fails the build.

--- a/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -85,8 +85,8 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
             {{- range .Mirrors }}{{ if .UseAsRobolectricRepo }}
             // Root-only: wire the Robolectric android-all redirect + jar audit across every Test task in the build, registered and logged once (avoids per-subproject flooding).
             if (getParent() == null) {
-                // Tier-2 sandbox probe (opt-in: BITRISE_ROBOLECTRIC_SANDBOX_PROBE=true). The Tier-1 classpath probe only sees the Gradle test runtime classpath; android.util.DisplayMetrics is actually loaded inside Robolectric's sandbox classloader. When enabled we add -Xlog:class+load to each Test JVM so the VM itself records the source jar / defining loader of every class it loads (to a per-fork file); the audit finalizer then greps the android.util.DisplayMetrics lines out and re-emits them — naming the loader/jar behind the NoSuchFieldError. No agent, no compile; never fails the build.
-                val sandboxProbe{{ .ID }} = System.getenv("BITRISE_ROBOLECTRIC_SANDBOX_PROBE") == "true"
+                // Tier-2 sandbox probe (opt-OUT: shares the BITRISE_ROBOLECTRIC_JAR_AUDIT=false kill-switch with the audit — no separate env). The Tier-1 classpath probe only sees the Gradle test runtime classpath; android.util.DisplayMetrics is actually loaded inside Robolectric's sandbox classloader. So — only on test tasks that actually carry android/util/DisplayMetrics (i.e. Robolectric/Android) and only on a JDK 9+ test JVM — we add -Xlog:class+load routed to a size-capped per-fork FILE (never stdout); the audit finalizer greps the android.util.DisplayMetrics lines out and re-emits them, naming the loader/jar behind the NoSuchFieldError.
+                // Safety (it is on by default, fleet-wide): file= output can't pollute test stdout; filesize/filecount caps disk; the JDK 9+ gate avoids the JDK 8 "unrecognized -Xlog" abort; and the launcher-version read, dir-writability check, jvmArgs attach (in doFirst, so it's outside up-to-date inputs) and finalizer re-emit are all wrapped — any failure just skips the probe, it can never fail the build.
                 val sandboxLogDir{{ .ID }} = java.io.File(System.getenv("GRADLE_USER_HOME") ?: (System.getProperty("user.home") + "/.gradle"), "bitrise-robolectric-sandbox-probe")
                 // Finalizer task (runs even when tests FAIL) logs the resolved android-all jar's sha1 once; set BITRISE_ROBOLECTRIC_JAR_AUDIT=false to opt out. Wrapped so it never fails the build.
                 val auditTask{{ .ID }} = if (System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false") {
@@ -128,11 +128,13 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                                         }
                                         getLogger().lifecycle("[bitrise-robolectric-jar-audit] cli={{ $.CLIVersion }} robolectric=$roboVer name=${jar.getName()} sha1=$sha1 size=${jar.length()} mtime=${jar.lastModified()} $dm")
                                     }
-                                // Tier-2: grep android.util.DisplayMetrics out of the per-fork -Xlog:class+load files (each line records the source jar / defining loader), re-emit, then delete (large, per-VM).
-                                sandboxLogDir{{ .ID }}.listFiles()?.filter { it.isFile() && it.getName().endsWith(".classload.log") }?.forEach { lf ->
+                                // Tier-2: stream the per-fork -Xlog:class+load files (incl. rotated *.classload.log.N), grep the android.util.DisplayMetrics lines (each records the source jar / defining loader), re-emit, then delete (bounded, per-VM). useLines streams so a large log can't OOM the daemon.
+                                sandboxLogDir{{ .ID }}.listFiles()?.filter { it.isFile() && it.getName().contains("classload.log") }?.forEach { lf ->
                                     try {
-                                        lf.readLines().filter { it.contains("android.util.DisplayMetrics") }.forEach { ln ->
-                                            getLogger().lifecycle("[robolectric-sandbox-probe] cli={{ $.CLIVersion }} ${ln.trim()}")
+                                        lf.useLines { seq ->
+                                            seq.filter { it.contains("android.util.DisplayMetrics") }.forEach { ln ->
+                                                getLogger().lifecycle("[robolectric-sandbox-probe] cli={{ $.CLIVersion }} ${ln.trim()}")
+                                            }
                                         }
                                         lf.delete()
                                     } catch (e: Throwable) {
@@ -146,16 +148,10 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                 } else {
                     null
                 }
-                log("setting robolectric.dependency.repo.url=\"{{ .MirrorURL }}\" on all Test tasks (audit=${auditTask{{ .ID }} != null}, sandboxProbe=${sandboxProbe{{ .ID }}})")
+                log("setting robolectric.dependency.repo.url=\"{{ .MirrorURL }}\" on all Test tasks (audit=${auditTask{{ .ID }} != null}, sandboxProbe=${auditTask{{ .ID }} != null})")
                 allprojects {
                     tasks.withType(Test::class.java).configureEach {
                         systemProperty("robolectric.dependency.repo.url", "{{ .MirrorURL }}")
-                        if (sandboxProbe{{ .ID }}) {
-                            // -Xlog:class+load makes the test JVM record the source jar / defining loader of every class it loads (incl. Robolectric's sandbox loader) to a per-fork file (%p = pid). Requires JDK 9+; opt-in, so only enabled for targeted diagnosis.
-                            sandboxLogDir{{ .ID }}.mkdirs()
-                            val probeLog = java.io.File(sandboxLogDir{{ .ID }}, getPath().replace(':', '_').trim('_') + "-%p.classload.log")
-                            jvmArgs("-Xlog:class+load=info:file=${probeLog.getAbsolutePath()}")
-                        }
                         if (auditTask{{ .ID }} != null) {
                             finalizedBy(auditTask{{ .ID }})
                             // Classpath probe: lists the jars on the test runtime classpath that provide android/util/DisplayMetrics.class, in classpath order. >1 entry (e.g. a mockable-android/stub jar alongside android-all) names a shadow that produces NoSuchFieldError on an otherwise-correct jar. Runs before the test (so it's captured on failing builds), never fails the build.
@@ -169,6 +165,13 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                                         .map { "${it.getName()}(${it.length()})" }
                                     if (dmSources.isNotEmpty()) {
                                         getLogger().lifecycle("[robolectric-classpath-probe] cli={{ $.CLIVersion }} ${getPath()} android/util/DisplayMetrics from: ${dmSources.joinToString(", ")}")
+                                        // Tier-2: this is an Android/Robolectric test task. Attach -Xlog:class+load so the test JVM records where DisplayMetrics is actually defined (incl. Robolectric's sandbox loader). Guards: JDK 9+ only (the flag aborts an unrecognized-option JDK 8 JVM), writable dir, size-capped file (never stdout). jvmArgs in doFirst is read at fork time (after this action) yet stays out of up-to-date inputs.
+                                        val testJvmMajor = (try { getJavaLauncher().getOrNull()?.getMetadata()?.getLanguageVersion()?.asInt() } catch (e: Throwable) { null }) ?: org.gradle.api.JavaVersion.current().getMajorVersion().toIntOrNull()
+                                        val dirOk = try { sandboxLogDir{{ .ID }}.mkdirs(); sandboxLogDir{{ .ID }}.isDirectory() && sandboxLogDir{{ .ID }}.canWrite() } catch (e: Throwable) { false }
+                                        if (testJvmMajor != null && testJvmMajor >= 9 && dirOk) {
+                                            val probeLog = java.io.File(sandboxLogDir{{ .ID }}, getPath().replace(':', '_').trim('_') + "-%p.classload.log")
+                                            jvmArgs("-Xlog:class+load=info:file=${probeLog.getAbsolutePath()}::filesize=16m,filecount=1")
+                                        }
                                     }
                                 } catch (t: Throwable) {
                                     getLogger().lifecycle("[robolectric-classpath-probe] ERROR cli={{ $.CLIVersion }} ${t.javaClass.getName()}: ${t.message}")


### PR DESCRIPTION
## What

Adds a **Tier-2** Robolectric probe to the gradle-mirrors init script that observes `android.util.DisplayMetrics` **as Robolectric's sandbox classloader loads it** — the place the SSW-3019 `NoSuchFieldError` actually resolves. **On by default**, sharing the audit's `BITRISE_ROBOLECTRIC_JAR_AUDIT=false` kill-switch (no new env).

## Why Tier-1 wasn't enough

Tier-1 (#385) scans `Test.getClasspath()` — the Gradle **test runtime classpath** — and in production reports a single `android.jar` stub on **both** passing (DDG) and failing (Substack) builds. `android-all-instrumented` is loaded in Robolectric's **sandbox classloader**, invisible to `getClasspath()`. So Tier-1 confirms-by-elimination but can't name the shadow.

## How it works (no agent, no compile)

On a Robolectric test task, the test JVM gets:
```
-Xlog:class+load=info:file=<gradle-home>/bitrise-robolectric-sandbox-probe/<task>-%p.classload.log::filesize=16m,filecount=1
```
The JVM records, for every class it loads in **any** loader (incl. the sandbox loader), its source jar / defining loader. The audit finalizer streams that per-fork file, greps the `android.util.DisplayMetrics` lines, and re-emits them:
```
[robolectric-sandbox-probe] cli=… [class,load] android.util.DisplayMetrics source: <jar | __JVM_DefineClass__ | loader>
```
**Reading it:** `source: __JVM_DefineClass__` = Robolectric instrumented + defined the class in its sandbox (the good path, seen on green DDG); `source: <some android.jar / mockable-android jar>` = a stub supplied DisplayMetrics → that's the shadow behind the `NoSuchFieldError`. This is the discriminator Tier-1 structurally can't produce.

## On by default — why it's safe

It runs fleet-wide on Robolectric test tasks in mirror DCs, so it is hardened to never fail a build (each guard maps to a concrete failure mode):

| Failure mode | Guard |
|---|---|
| JDK 8 aborts on unrecognized `-Xlog` → whole task fails | attach only when the **test JVM is JDK 9+** (read via the task's `javaLauncher` metadata, non-deprecated; daemon-version fallback) |
| `-Xlog` polluting test stdout breaks output-parsing tests | routed to `file=` (never console) |
| disk fill (logs every class load, per fork) | `filesize=16m,filecount=1` (~32 MB/fork) **and** attach only to tasks whose classpath carries `android/util/DisplayMetrics` (skips pure-JVM unit-test tasks) |
| unwritable `GRADLE_USER_HOME` → JVM log-init failure | `mkdirs()` + `isDirectory && canWrite` check before attaching |
| daemon OOM reading a big log | finalizer streams with `useLines` (+ handles rotated `*.classload.log.N`) |
| up-to-date / cache thrash | `jvmArgs` set in `doFirst` → outside the task's input snapshot |
| init-script compile break (the v2.8.10 class) under `allWarningsAsErrors` | non-deprecated APIs only; everything wrapped |

Kill-switch: `BITRISE_ROBOLECTRIC_JAR_AUDIT=false` disables the audit **and** this probe. Any guard failure just skips the probe — it can't fail the build.

**Trade-off (called out):** on by default means a small per-test-JVM tax (`-Xlog:class+load` + bounded file I/O) on every Robolectric task in mirror DCs. The Android-task gate keeps it off the majority of (non-Android) test tasks.

## Validation

Validated end-to-end on the DDG **jarprobe** (app `9e4b8cbb`, sdk=35 Substack-jar run), default-on with no env set:
```
[robolectric-sandbox-probe] cli=… [class,load] android.util.DisplayMetrics source: __JVM_DefineClass__
```
Confirms: opt-out wiring fires with no env, `jvmArgs` set in `doFirst` reaches the fork, JDK-9+/Android-task gates pass, init script compiles on real Gradle, build SUCCESSFUL. (DDG is green / no shadow, so this proves the mechanism + safety; a failing Substack-class build is where it captures the shadow `source:`.)

`make lint` clean; mirror unit tests updated + passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)