### PR TITLE
ACI-5123: activate xcode / c++ keep auth out of disk when keychain works

### DIFF
--- a/cmd/xcode/setup_test.go
+++ b/cmd/xcode/setup_test.go
@@ -4,11 +4,14 @@ package xcode_test
 import (
 	utilsMocks "github.com/bitrise-io/go-utils/v2/mocks"
 	"github.com/stretchr/testify/mock"
+	keyring "github.com/zalando/go-keyring"
 )
 
 var mockLogger = &utilsMocks.Logger{}
 
 func init() {
+	keyring.MockInit()
+
 	mockLogger.On("Debugf", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockLogger.On("Debugf", mock.Anything, mock.Anything, mock.Anything).Return()
 	mockLogger.On("Debugf", mock.Anything, mock.Anything).Return()

--- a/internal/config/ccache/config.go
+++ b/internal/config/ccache/config.go
@@ -187,12 +187,9 @@ func ReadConfig(osProxy utils.OsProxy, decoderFactory utils.DecoderFactory) (Con
 		return Config{}, fmt.Errorf(ErrFmtDecodeConfigFile, configFilePath, err)
 	}
 
-	// Auth credentials live in the multiplatform analytics config. Populate the
-	// in-memory AuthConfig from there so callers can keep using config.AuthConfig.
-	// Guard against an empty/decoded-but-unauthenticated multiplatform config —
-	// matches the xcelerate fallback so we don't silently wipe credentials when
-	// the file exists but carries no token.
-	if mpCfg, mpErr := multiplatformconfig.ReadConfig(osProxy, decoderFactory); mpErr == nil && mpCfg.AuthConfig.AuthToken != "" {
+	if kcCfg, ok := common.GetKeychainCredentials(); ok {
+		config.AuthConfig = kcCfg
+	} else if mpCfg, mpErr := multiplatformconfig.ReadConfig(osProxy, decoderFactory); mpErr == nil && mpCfg.AuthConfig.AuthToken != "" {
 		config.AuthConfig = mpCfg.AuthConfig
 	}
 

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/shirou/gopsutil/v4/process"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
@@ -88,12 +89,12 @@ func Activate(
 		return fmt.Errorf(ErrFmtCreateXcodeConfig, err)
 	}
 
-	// Auth credentials are persisted only in the multiplatform analytics config
-	// (single source of truth on disk). The xcelerate config carries auth in-memory
-	// at runtime via ReadConfig, but never to JSON.
-	mpCfg := multiplatformconfig.Config{
-		AuthConfig:   config.AuthConfig,
-		DebugLogging: config.DebugLogging,
+	mpCfg := multiplatformconfig.Config{DebugLogging: config.DebugLogging}
+	if err := keychain.New().Save(keychain.Credentials{
+		AuthToken:   config.AuthConfig.AuthToken,
+		WorkspaceID: config.AuthConfig.WorkspaceID,
+	}); err != nil {
+		mpCfg.AuthConfig = config.AuthConfig
 	}
 	if err := mpCfg.Save(osProxy, encoderFactory); err != nil {
 		return fmt.Errorf("failed to save multiplatform analytics config: %w", err)

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -3,6 +3,7 @@ package xcelerate
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -90,10 +91,14 @@ func Activate(
 	}
 
 	mpCfg := multiplatformconfig.Config{DebugLogging: config.DebugLogging}
-	if err := keychain.New().Save(keychain.Credentials{
-		AuthToken:   config.AuthConfig.AuthToken,
-		WorkspaceID: config.AuthConfig.WorkspaceID,
-	}); err != nil {
+	keychainErr := errors.New("skip-jwt")
+	if !config.AuthConfig.IsJWT {
+		keychainErr = keychain.New().Save(keychain.Credentials{
+			AuthToken:   config.AuthConfig.AuthToken,
+			WorkspaceID: config.AuthConfig.WorkspaceID,
+		})
+	}
+	if keychainErr != nil {
 		mpCfg.AuthConfig = config.AuthConfig
 	}
 	if err := mpCfg.Save(osProxy, encoderFactory); err != nil {

--- a/internal/config/xcelerate/config.go
+++ b/internal/config/xcelerate/config.go
@@ -86,11 +86,9 @@ func ReadConfig(osProxy utils.OsProxy, decoderFactory utils.DecoderFactory) (Con
 		return Config{}, fmt.Errorf("decode xcelerate config file (%s): %w", configFilePath, err)
 	}
 
-	// Auth credentials live in the multiplatform analytics config. Prefer that
-	// source so callers can keep using config.AuthConfig; fall back to whatever
-	// the legacy xcelerate config (decoded above) carried, for users upgrading
-	// from a CLI version that still persisted auth in the xcelerate config.
-	if mpCfg, mpErr := multiplatformconfig.ReadConfig(osProxy, decoderFactory); mpErr == nil && mpCfg.AuthConfig.AuthToken != "" {
+	if kcCfg, ok := common.GetKeychainCredentials(); ok {
+		config.AuthConfig = kcCfg
+	} else if mpCfg, mpErr := multiplatformconfig.ReadConfig(osProxy, decoderFactory); mpErr == nil && mpCfg.AuthConfig.AuthToken != "" {
 		config.AuthConfig = mpCfg.AuthConfig
 	}
 

--- a/pkg/ccache/activator.go
+++ b/pkg/ccache/activator.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
@@ -114,12 +115,12 @@ func (a *Activator) Activate(ctx context.Context) error {
 		return fmt.Errorf("failed to save ccache config: %w", err)
 	}
 
-	// Auth credentials are persisted only in the multiplatform analytics config
-	// (single source of truth on disk). The ccache config carries auth in-memory
-	// at runtime via ReadConfig, but never to JSON.
-	mpCfg := multiplatformconfig.Config{
-		AuthConfig:   config.AuthConfig,
-		DebugLogging: a.debugLogging,
+	mpCfg := multiplatformconfig.Config{DebugLogging: a.debugLogging}
+	if err := keychain.New().Save(keychain.Credentials{
+		AuthToken:   config.AuthConfig.AuthToken,
+		WorkspaceID: config.AuthConfig.WorkspaceID,
+	}); err != nil {
+		mpCfg.AuthConfig = config.AuthConfig
 	}
 	if err := mpCfg.Save(a.osProxy, a.encoderFactory); err != nil {
 		return fmt.Errorf("failed to save multiplatform analytics config: %w", err)

--- a/pkg/ccache/activator.go
+++ b/pkg/ccache/activator.go
@@ -2,6 +2,7 @@ package ccache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -116,10 +117,14 @@ func (a *Activator) Activate(ctx context.Context) error {
 	}
 
 	mpCfg := multiplatformconfig.Config{DebugLogging: a.debugLogging}
-	if err := keychain.New().Save(keychain.Credentials{
-		AuthToken:   config.AuthConfig.AuthToken,
-		WorkspaceID: config.AuthConfig.WorkspaceID,
-	}); err != nil {
+	keychainErr := errors.New("skip-jwt")
+	if !config.AuthConfig.IsJWT {
+		keychainErr = keychain.New().Save(keychain.Credentials{
+			AuthToken:   config.AuthConfig.AuthToken,
+			WorkspaceID: config.AuthConfig.WorkspaceID,
+		})
+	}
+	if keychainErr != nil {
 		mpCfg.AuthConfig = config.AuthConfig
 	}
 	if err := mpCfg.Save(a.osProxy, a.encoderFactory); err != nil {

--- a/pkg/ccache/activator_test.go
+++ b/pkg/ccache/activator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	keyring "github.com/zalando/go-keyring"
 
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
@@ -21,6 +22,8 @@ import (
 )
 
 var mockLogger = newMockLogger() //nolint:gochecknoglobals
+
+func init() { keyring.MockInit() }
 
 func newMockLogger() *utilsMocks.Logger {
 	l := &utilsMocks.Logger{}


### PR DESCRIPTION
## Summary
- `activate xcode` + `activate c++` now save credentials to the OS keychain first and write the multiplatform analytics config WITHOUT auth on success; only fall back to writing auth into the file when the keychain save fails (headless Linux, CI containers without dbus).
- `xcelerate.ReadConfig` + `ccache.ReadConfig` prefer the keychain over the multiplatform-file fallback when overlaying the in-memory `AuthConfig`.
- No new helper — inline `keychain.New().Save(...)` at both call sites (matches `cmd/auth/auth.go` style).

## Out of scope
- `~/.bazelrc` (ACI-5116).
- Gradle init script — already token-free on local-dev (`bitrise-build-cache auth token` via `ValueSource`).
- `auth set` — already saves to keychain + scrubs the multiplatform / xcelerate / ccache / gradle init configs (verified).

## Test plan
- [ ] Fresh box, run `bitrise-build-cache activate xcode` → verify `~/.bitrise/analytics/multiplatform/config.json` has no `authConfig.authToken`.
- [ ] Same for `activate c++`.
- [ ] Headless Linux without dbus → verify fallback writes auth into the file so the wrapper still finds it.
- [ ] `xcodebuild` wrapper + ccache helper still resolve auth at runtime.