### PR TITLE
feat: ACI-5124 doctor — group OK items separately from issues

### DIFF
--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -70,15 +70,18 @@ func itemDisplay(it doctorpkg.ReportItem) (doctorpkg.State, string) {
 	return it.Result.State, it.Result.Detail
 }
 
+func effectiveState(it doctorpkg.ReportItem) doctorpkg.State {
+	if it.FixResult != nil {
+		return doctorpkg.StateOK
+	}
+
+	return it.Result.State
+}
+
 func effectiveOverall(r doctorpkg.Report) doctorpkg.State {
 	worst := doctorpkg.StateOK
 	for _, it := range r.Items {
-		s := it.Result.State
-		if it.FixResult != nil {
-			s = doctorpkg.StateOK
-		}
-
-		switch s {
+		switch effectiveState(it) {
 		case doctorpkg.StateError:
 			return doctorpkg.StateError
 		case doctorpkg.StateWarn:
@@ -123,20 +126,53 @@ func writeHuman(w io.Writer, r doctorpkg.Report, fixed bool, overall doctorpkg.S
 	}
 	fmt.Fprintf(w, "CLI version: %s\n\n", r.Version)
 
-	for _, it := range r.Items {
-		state, detail := itemDisplay(it)
-		fmt.Fprintf(w, "  %s %-22s %s\n", c.icon(state), it.Name, detail)
+	issues, healthy := partitionItems(r.Items)
 
-		switch {
-		case it.FixError != "":
-			fmt.Fprintf(w, "      %s↳ fix failed:%s %s\n", c.red, c.reset, it.FixError)
-		case !fixed && it.Result.Fixable:
-			fmt.Fprintf(w, "      %s↳%s rerun with --fix to repair\n", c.yellow, c.reset)
+	if len(issues) > 0 {
+		fmt.Fprintln(w, "Issues:")
+		for _, it := range issues {
+			writeItem(w, c, it, fixed)
+		}
+
+		fmt.Fprintln(w)
+	}
+
+	if len(healthy) > 0 {
+		fmt.Fprintln(w, "Healthy:")
+		for _, it := range healthy {
+			writeItem(w, c, it, fixed)
+		}
+
+		fmt.Fprintln(w)
+	}
+
+	fmt.Fprintf(w, "Overall: %s%s%s\n", c.forState(overall), overall, c.reset)
+}
+
+func partitionItems(items []doctorpkg.ReportItem) ([]doctorpkg.ReportItem, []doctorpkg.ReportItem) {
+	var issues, healthy []doctorpkg.ReportItem
+
+	for _, it := range items {
+		if effectiveState(it) == doctorpkg.StateOK {
+			healthy = append(healthy, it)
+		} else {
+			issues = append(issues, it)
 		}
 	}
 
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "Overall: %s%s%s\n", c.forState(overall), overall, c.reset)
+	return issues, healthy
+}
+
+func writeItem(w io.Writer, c colorPalette, it doctorpkg.ReportItem, fixed bool) {
+	state, detail := itemDisplay(it)
+	fmt.Fprintf(w, "  %s %-22s %s\n", c.icon(state), it.Name, detail)
+
+	switch {
+	case it.FixError != "":
+		fmt.Fprintf(w, "      %s↳ fix failed:%s %s\n", c.red, c.reset, it.FixError)
+	case !fixed && it.Result.Fixable:
+		fmt.Fprintf(w, "      %s↳%s rerun with --fix to repair\n", c.yellow, c.reset)
+	}
 }
 
 type colorPalette struct {

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -1,0 +1,132 @@
+//go:build unit
+
+package doctor
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	doctorpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/doctor"
+)
+
+func okItem(name string) doctorpkg.ReportItem {
+	return doctorpkg.ReportItem{
+		Name:   name,
+		Result: doctorpkg.Result{State: doctorpkg.StateOK, Detail: "fine"},
+	}
+}
+
+func warnItem(name string, fixable bool) doctorpkg.ReportItem {
+	return doctorpkg.ReportItem{
+		Name:   name,
+		Result: doctorpkg.Result{State: doctorpkg.StateWarn, Detail: "needs attention", Fixable: fixable},
+	}
+}
+
+func errorItem(name string) doctorpkg.ReportItem {
+	return doctorpkg.ReportItem{
+		Name:   name,
+		Result: doctorpkg.Result{State: doctorpkg.StateError, Detail: "broken"},
+	}
+}
+
+func render(t *testing.T, items []doctorpkg.ReportItem, fixed bool) string {
+	t.Helper()
+
+	r := doctorpkg.Report{Items: items, Version: "v2.8.6"}
+	var buf bytes.Buffer
+	writeHuman(&buf, r, fixed, effectiveOverall(r), false)
+
+	return buf.String()
+}
+
+func TestWriteHuman_groupsIssuesBeforeHealthy(t *testing.T) {
+	out := render(t, []doctorpkg.ReportItem{
+		okItem("keychain"),
+		warnItem("xcelerate-proxy", true),
+		okItem("ccache-helper"),
+		errorItem("auth"),
+	}, false)
+
+	issuesAt := strings.Index(out, "Issues:")
+	healthyAt := strings.Index(out, "Healthy:")
+	require.NotEqual(t, -1, issuesAt)
+	require.NotEqual(t, -1, healthyAt)
+	assert.Less(t, issuesAt, healthyAt, "Issues section must precede Healthy")
+
+	issuesSec := out[issuesAt:healthyAt]
+	assert.Contains(t, issuesSec, "xcelerate-proxy")
+	assert.Contains(t, issuesSec, "auth")
+	assert.NotContains(t, issuesSec, "keychain")
+	assert.NotContains(t, issuesSec, "ccache-helper")
+
+	healthySec := out[healthyAt:]
+	assert.Contains(t, healthySec, "keychain")
+	assert.Contains(t, healthySec, "ccache-helper")
+	assert.NotContains(t, healthySec, "xcelerate-proxy")
+	assert.NotContains(t, healthySec, "auth")
+}
+
+func TestWriteHuman_allHealthy_noIssuesHeader(t *testing.T) {
+	out := render(t, []doctorpkg.ReportItem{okItem("a"), okItem("b")}, false)
+
+	assert.NotContains(t, out, "Issues:")
+	assert.Contains(t, out, "Healthy:")
+	assert.Contains(t, out, "Overall: ok")
+}
+
+func TestWriteHuman_allIssues_noHealthyHeader(t *testing.T) {
+	out := render(t, []doctorpkg.ReportItem{errorItem("a"), warnItem("b", false)}, false)
+
+	assert.Contains(t, out, "Issues:")
+	assert.NotContains(t, out, "Healthy:")
+	assert.Contains(t, out, "Overall: error")
+}
+
+func TestWriteHuman_fixedItemMovesToHealthy(t *testing.T) {
+	fixed := "restored socket"
+	items := []doctorpkg.ReportItem{
+		{
+			Name:      "xcelerate-proxy",
+			Result:    doctorpkg.Result{State: doctorpkg.StateError, Detail: "socket gone"},
+			FixResult: &fixed,
+		},
+	}
+
+	out := render(t, items, true)
+	assert.NotContains(t, out, "Issues:")
+	assert.Contains(t, out, "Healthy:")
+	assert.Contains(t, out, "fixed: restored socket")
+	assert.Contains(t, out, "Overall: ok")
+}
+
+func TestWriteHuman_fixErrorStaysInIssues(t *testing.T) {
+	items := []doctorpkg.ReportItem{
+		{
+			Name:     "auth",
+			Result:   doctorpkg.Result{State: doctorpkg.StateError, Detail: "no token", Fixable: true},
+			FixError: "prompt cancelled",
+		},
+	}
+
+	out := render(t, items, true)
+	issuesAt := strings.Index(out, "Issues:")
+	require.NotEqual(t, -1, issuesAt)
+	assert.Contains(t, out[issuesAt:], "fix failed:")
+	assert.Contains(t, out[issuesAt:], "prompt cancelled")
+	assert.NotContains(t, out, "Healthy:")
+}
+
+func TestWriteHuman_fixableHintOnlyWithoutFix(t *testing.T) {
+	items := []doctorpkg.ReportItem{warnItem("xcelerate-proxy", true)}
+
+	withoutFix := render(t, items, false)
+	assert.Contains(t, withoutFix, "rerun with --fix to repair")
+
+	withFix := render(t, items, true)
+	assert.NotContains(t, withFix, "rerun with --fix to repair")
+}


### PR DESCRIPTION
## Summary

Doctor output partitioned into two sections so attention items stand out at a glance:

- **Issues** — warn/error items rendered first.
- **Healthy** — OK items below.

Empty sections are omitted. `--fix`-resolved items move to Healthy (their `fixed: …` detail preserved); items with a `FixError` keep their original state and stay in Issues with the `↳ fix failed:` line.

Implements [ACI-5124](https://bitrise.atlassian.net/browse/ACI-5124). Targets the epic branch `aci-4337-cli`.

## Before / after

```
Bitrise Build Cache - doctor
CLI version: v2.8.6

Issues:
  ! xcelerate-proxy        socket missing
      ↳ rerun with --fix to repair
  ✗ auth                   token invalid

Healthy:
  ✓ keychain               fine
  ✓ ccache-helper          fine
  ✓ ccache-binary          fine
  ✓ log-dirs               fine
  ✓ xcelerate-xcconfig     fine
  ✓ cli-version            fine

Overall: error
```

JSON output (`--json`) unchanged — only the human renderer regroups.

## Test plan

- [x] `go test -tags unit -race ./cmd/doctor/... ./internal/doctor/...` green.
- [x] `make lint` clean.
- [x] New `cmd/doctor/doctor_test.go` covers: mixed grouping order, all-healthy (no Issues header), all-issues (no Healthy header), `--fix` moves item to Healthy, `FixError` keeps item in Issues, fixable hint suppressed under `--fix`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5124]: https://bitrise.atlassian.net/browse/ACI-5124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ