### PR TITLE
ACI-5126: activate logs every modification it makes

### DIFF
--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -100,10 +100,13 @@ func Activate(
 	}
 	if keychainErr != nil {
 		mpCfg.AuthConfig = config.AuthConfig
+	} else {
+		logger.Infof("Saved auth credentials to the OS keychain")
 	}
 	if err := mpCfg.Save(osProxy, encoderFactory); err != nil {
 		return fmt.Errorf("failed to save multiplatform analytics config: %w", err)
 	}
+	logger.Infof("Wrote multiplatform analytics config: %s", multiplatformconfig.FilePath(osProxy))
 
 	if err := copyCLIToXcelerateBinDir(ctx, osProxy, logger); err != nil {
 		return fmt.Errorf("failed to copy xcelerate cli to ~/.bitrise-xcelerate/bin: %w", err)
@@ -113,7 +116,6 @@ func Activate(
 		return fmt.Errorf("failed to add xcelerate command: %w", err)
 	}
 
-	logger.Debugf("Xcelerate command added to ~/.bashrc and ~/.zshrc")
 	logger.TInfof(ActivateXcodeSuccessful)
 	logger.TInfof(AddXcelerateToPath)
 
@@ -250,7 +252,6 @@ func addXcelerateCommandToPathWithScriptWrapper(
 	}
 
 	scriptPath := filepath.Join(binPath, "xcodebuild")
-	logger.Debugf("Creating xcodebuild wrapper script: %s", scriptPath)
 
 	if err := osProxy.WriteFile(scriptPath,
 		[]byte(fmt.Sprintf(xcodebuildWrapperScriptContent,
@@ -258,9 +259,9 @@ func addXcelerateCommandToPathWithScriptWrapper(
 			binPath)), 0o755); err != nil {
 		return fmt.Errorf("failed to create xcodebuild wrapper script: %w", err)
 	}
+	logger.Infof("Wrote xcodebuild wrapper script: %s", scriptPath)
 
 	scriptPath = filepath.Join(binPath, "xcrun")
-	logger.Debugf("Creating xcrun wrapper script: %s", scriptPath)
 
 	if err := osProxy.WriteFile(scriptPath,
 		[]byte(fmt.Sprintf(xcrunWrapperScriptContent,
@@ -269,6 +270,7 @@ func addXcelerateCommandToPathWithScriptWrapper(
 			config.OriginalXcrunPath)), 0o755); err != nil {
 		return fmt.Errorf("failed to create xcrun wrapper script: %w", err)
 	}
+	logger.Infof("Wrote xcrun wrapper script: %s", scriptPath)
 
 	path := strings.ReplaceAll(envs["PATH"], binPath+":", "")
 	path = strings.Join([]string{binPath, path}, ":")

--- a/internal/envexport/envexport.go
+++ b/internal/envexport/envexport.go
@@ -34,6 +34,8 @@ func New(envs map[string]string, logger log.Logger) *EnvExporter {
 func (e *EnvExporter) Export(key, value string) {
 	if err := os.Setenv(key, value); err != nil {
 		e.logger.Debugf("Failed to set env var %s: %v", key, err)
+	} else {
+		e.logger.Infof("Exported %s to the current process environment", key)
 	}
 
 	e.exportViaEnvman(key, value)
@@ -44,7 +46,10 @@ func (e *EnvExporter) exportViaEnvman(key, value string) {
 	stdout, stderr, err := (exec.ExecRunner{}).RunCheck(context.Background(), "envman", "add", "--key", key, "--value", value)
 	if err != nil {
 		e.logger.Debugf("Failed to export %s via envman: %s (%v)", key, stdout+stderr, err)
+
+		return
 	}
+	e.logger.Infof("Exported %s via envman", key)
 }
 
 func (e *EnvExporter) exportViaGitHubEnv(key, value string) {
@@ -70,7 +75,10 @@ func (e *EnvExporter) exportViaGitHubEnv(key, value string) {
 
 	if err := writer.Flush(); err != nil {
 		e.logger.Debugf("Failed to flush GITHUB_ENV file: %v", err)
+
+		return
 	}
+	e.logger.Infof("Appended %s to %s", key, filePath)
 }
 
 // ExportToShellRC writes an export statement to ~/.bashrc and ~/.zshrc using a marker block.
@@ -92,7 +100,10 @@ func (e *EnvExporter) ExportToShellRC(blockName, content string) {
 		rcPath := filepath.Join(homeDir, rcFile)
 		if err := writeShellRCBlock(rcPath, blockName, content); err != nil {
 			e.logger.Debugf("Failed to update %s: %v", rcFile, err)
+
+			continue
 		}
+		e.logger.Infof("Updated %s with %q block", rcPath, blockName)
 	}
 }
 

--- a/pkg/ccache/activator.go
+++ b/pkg/ccache/activator.go
@@ -126,10 +126,13 @@ func (a *Activator) Activate(ctx context.Context) error {
 	}
 	if keychainErr != nil {
 		mpCfg.AuthConfig = config.AuthConfig
+	} else {
+		a.logger.Infof("Saved auth credentials to the OS keychain")
 	}
 	if err := mpCfg.Save(a.osProxy, a.encoderFactory); err != nil {
 		return fmt.Errorf("failed to save multiplatform analytics config: %w", err)
 	}
+	a.logger.Infof("Wrote multiplatform analytics config: %s", multiplatformconfig.FilePath(a.osProxy))
 
 	baseDir := a.baseDirOverride
 	if baseDir == "" {


### PR DESCRIPTION
## Summary
- `EnvExporter.Export` info-logs each env-var export (process env + envman + GITHUB_ENV).
- `EnvExporter.ExportToShellRC` info-logs each ~/.bashrc / ~/.zshrc update with the marker-block name.
- `xcelerate.Activate` info-logs keychain save, multiplatform analytics config write, xcodebuild + xcrun wrapper script writes.
- `pkg/ccache/Activator.Activate` info-logs keychain save + multiplatform analytics config write.

## Why
Zsh / bash profile mods were silent (only debug). Users had no visibility into PATH edits or other shell-rc changes.

## Test plan
- [ ] `make check` clean.
- [ ] Manual: run `bitrise-build-cache activate xcode` on a fresh box, confirm log output names every file touched (rc files, wrapper scripts, multiplatform config, keychain).