### PR TITLE
fix: robolectric audit icu= grabs 0-byte dir entry (prints misleading icu=(0))

### DIFF
--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -89,7 +89,8 @@ func TestActivate(t *testing.T) {
 				`getLogger().lifecycle("[bitrise-robolectric-jar-audit] cli=v0.0.0-test robolectric=$roboVer name=`,
 				`getLogger().lifecycle("[bitrise-robolectric-jar-audit] cli=v0.0.0-test components $components")`,
 				`val dmStr = if (e != null) "displayMetrics=present(${e.getSize()})" else "displayMetrics=MISSING"`,
-				`if (nm.contains("icudt")) { icu = "icu=${nm.substringAfterLast('/')}(${n.getSize()})"; break }`,
+				`if (nm.contains("icudt") && n.getSize() > icuSize) { icuName = nm.substringAfterLast('/'); icuSize = n.getSize() }`,
+				`val icu = if (icuSize >= 0) "icu=${icuName}(${icuSize})" else "icu=none"`,
 				`java.util.zip.ZipFile(jar).use`,
 				// Native-runtime capture: testLogging FULL on FAILED, opt-in stdout logging, combined -Xlog, native-lib re-emit
 				`testLogging.setExceptionFormat(org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL)`,

--- a/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -123,14 +123,17 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                                             java.util.zip.ZipFile(jar).use { zf ->
                                                 val e = zf.getEntry("android/util/DisplayMetrics.class")
                                                 val dmStr = if (e != null) "displayMetrics=present(${e.getSize()})" else "displayMetrics=MISSING"
-                                                // icu=none is normal for older android-all (pre-native-runtime SDKs don't bundle ICU); it's only a signal when a NEWER jar that should carry icudt shows none/short on a failing build.
-                                                var icu = "icu=none"
+                                                // icu=none is normal for older android-all (pre-native-runtime SDKs don't bundle ICU); it's only a signal when a NEWER jar that should carry icudt shows none/short on a failing build. Pick the LARGEST non-directory icudt entry: jars contain a 0-byte `usr/icu/` dir entry whose name also matches, so a plain first-match grabs it and prints a misleading icu=(0).
+                                                var icuName = ""
+                                                var icuSize = -1L
                                                 val en = zf.entries()
                                                 while (en.hasMoreElements()) {
                                                     val n = en.nextElement()
+                                                    if (n.isDirectory()) continue
                                                     val nm = n.getName()
-                                                    if (nm.contains("icudt")) { icu = "icu=${nm.substringAfterLast('/')}(${n.getSize()})"; break }
+                                                    if (nm.contains("icudt") && n.getSize() > icuSize) { icuName = nm.substringAfterLast('/'); icuSize = n.getSize() }
                                                 }
+                                                val icu = if (icuSize >= 0) "icu=${icuName}(${icuSize})" else "icu=none"
                                                 "$dmStr $icu entries=${zf.size()}"
                                             }
                                         } catch (z: Throwable) {


### PR DESCRIPTION
## Why
Post-release monitoring of **v2.8.13** on live builds (Getir, app `e66be489`) showed the new ICU-entry audit prints `icu=(0)` on **every** android-all jar:

\`\`\`
[bitrise-robolectric-jar-audit] cli=2.8.13 robolectric=4.14.1 name=android-all-instrumented-15-robolectric-12650502-i7.jar sha1=4a72756411af… size=199527464 displayMetrics=present(6716) icu=(0) entries=71466
\`\`\`

The v2.8.13 broadened match (`contains("icudt")`, the `.dat` requirement was dropped) grabs the **0-byte `usr/icu/` directory entry** (name ends in `/` → empty basename, size 0) on first match, instead of the real `icudt*.dat` data file. So `icu=(0)` reads like "ICU present but empty/corrupt" when the jar's ICU is actually fine — the exact false signal the ICU audit was added to avoid (it's meant to flag a *genuinely* missing/short ICU on a bucket-A failing build).

## What
Skip directory entries and pick the **largest** `icudt` entry (the data file):
\`\`\`kotlin
var icuName = ""; var icuSize = -1L
// … skip n.isDirectory(); track largest icudt file …
val icu = if (icuSize >= 0) "icu=${icuName}(${icuSize})" else "icu=none"
\`\`\`

Diagnostic-only line; it never failed a build. No other behavior change.

## Verified
- `make lint` clean, `make test-unit` green.
- Rendered init script compiles clean under `org.gradle.kotlin.dsl.allWarningsAsErrors=true` (Gradle 9.3 / JDK 17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)