### PR TITLE
ACI-4264: username override for local invocations (env + keychain + wizard)

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -35,6 +35,7 @@ var authCmd = &cobra.Command{
 var (
 	setToken       string
 	setWorkspaceID string
+	setUsername    string
 )
 
 // nolint:gochecknoglobals
@@ -47,6 +48,7 @@ var authSetCmd = &cobra.Command{
 
 		setToken = strings.TrimSpace(setToken)
 		setWorkspaceID = strings.TrimSpace(setWorkspaceID)
+		setUsername = strings.TrimSpace(setUsername)
 
 		switch {
 		case setToken == "" && setWorkspaceID == "":
@@ -58,14 +60,21 @@ var authSetCmd = &cobra.Command{
 		}
 
 		kc := keychain.New()
-		if err := kc.Save(keychain.Credentials{
-			AuthToken:   setToken,
-			WorkspaceID: setWorkspaceID,
-		}); err != nil {
+		existing, err := kc.Load()
+		if err != nil && !errors.Is(err, keychain.ErrNotFound) {
+			return fmt.Errorf("load existing credentials: %w", err)
+		}
+		existing.AuthToken = setToken
+		existing.WorkspaceID = setWorkspaceID
+		existing.Username = setUsername
+		if err := kc.Save(existing); err != nil {
 			return fmt.Errorf("save credentials to keychain: %w", err)
 		}
 
 		logger.TInfof("✅ Credentials saved to the OS keychain")
+		if setUsername != "" {
+			logger.TInfof("Display name for local invocations set to %q.", setUsername)
+		}
 
 		switch scrubbed, err := scrubDiskCredentials(); {
 		case err != nil:
@@ -319,6 +328,7 @@ type credAudit struct {
 	state       credSourceState
 	workspaceID string
 	authToken   string
+	username    string
 	note        string
 	err         error
 }
@@ -377,6 +387,9 @@ func renderSource(logger log.Logger, s credSource, a credAudit) bool {
 	case sourcePopulated:
 		logger.Infof("  Workspace ID: %s", a.workspaceID)
 		logger.Infof("  Auth token:   %s", maskToken(a.authToken))
+		if a.username != "" {
+			logger.Infof("  Display name: %s", a.username)
+		}
 		if a.note != "" {
 			logger.Infof("  %s", a.note)
 		}
@@ -400,7 +413,7 @@ func probeKeychain() credAudit {
 		return credAudit{state: sourceReadError, err: err}
 	}
 
-	audit := credAudit{state: sourcePopulated, workspaceID: creds.WorkspaceID, authToken: creds.AuthToken}
+	audit := credAudit{state: sourcePopulated, workspaceID: creds.WorkspaceID, authToken: creds.AuthToken, username: creds.Username}
 	if desc := configcommon.DescribeKeychainCredentials(creds); desc.IsOAuthLogin {
 		audit.note = desc.Detail()
 	}
@@ -527,6 +540,7 @@ func maskToken(token string) string {
 func init() {
 	authSetCmd.Flags().StringVar(&setToken, "token", "", "Bitrise Build Cache auth token (required)")
 	authSetCmd.Flags().StringVar(&setWorkspaceID, "workspace-id", "", "Bitrise workspace ID (required)")
+	authSetCmd.Flags().StringVar(&setUsername, "username", "", "Display name for local invocations (optional). Overrides the OS username. Env var BITRISE_BUILD_CACHE_USERNAME takes precedence for a single run.")
 	_ = authSetCmd.MarkFlagRequired("token")
 	_ = authSetCmd.MarkFlagRequired("workspace-id")
 

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	keyring "github.com/zalando/go-keyring"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
@@ -165,4 +167,58 @@ authToken.set(providers.bitriseAuthToken())
 	scrubbed, err := scrubGradleInitKts(utils.DefaultOsProxy{})
 	require.NoError(t, err)
 	assert.Empty(t, scrubbed.path, "value-source form has no literal to scrub")
+}
+
+func TestAuthSetCmd_persistsUsernameToKeychain(t *testing.T) {
+	keyring.MockInit()
+	setToken = "tok-123"
+	setWorkspaceID = "ws-456"
+	setUsername = "alice"
+	t.Cleanup(func() { setToken, setWorkspaceID, setUsername = "", "", "" })
+
+	require.NoError(t, authSetCmd.RunE(authSetCmd, nil))
+
+	creds, err := keychain.New().Load()
+	require.NoError(t, err)
+	assert.Equal(t, "tok-123", creds.AuthToken)
+	assert.Equal(t, "ws-456", creds.WorkspaceID)
+	assert.Equal(t, "alice", creds.Username)
+}
+
+func TestAuthSetCmd_emptyUsernameLeavesFieldEmpty(t *testing.T) {
+	keyring.MockInit()
+	setToken = "tok"
+	setWorkspaceID = "ws"
+	setUsername = ""
+	t.Cleanup(func() { setToken, setWorkspaceID, setUsername = "", "", "" })
+
+	require.NoError(t, authSetCmd.RunE(authSetCmd, nil))
+
+	creds, err := keychain.New().Load()
+	require.NoError(t, err)
+	assert.Empty(t, creds.Username)
+}
+
+func TestAuthSetCmd_preservesOAuthFieldsOnUsernameEdit(t *testing.T) {
+	keyring.MockInit()
+	kc := keychain.New()
+	require.NoError(t, kc.Save(keychain.Credentials{
+		AuthToken:    "old-tok",
+		WorkspaceID:  "old-ws",
+		RefreshToken: "refresh-abc",
+		JWT:          "jwt-xyz",
+	}))
+
+	setToken = "old-tok"
+	setWorkspaceID = "old-ws"
+	setUsername = "alice"
+	t.Cleanup(func() { setToken, setWorkspaceID, setUsername = "", "", "" })
+
+	require.NoError(t, authSetCmd.RunE(authSetCmd, nil))
+
+	creds, err := kc.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "alice", creds.Username)
+	assert.Equal(t, "refresh-abc", creds.RefreshToken, "OAuth refresh token must survive auth set --username")
+	assert.Equal(t, "jwt-xyz", creds.JWT)
 }

--- a/cmd/common/activate_interactive_huh.go
+++ b/cmd/common/activate_interactive_huh.go
@@ -23,12 +23,22 @@ func (*huhWizard) Run(ctx context.Context) error {
 	kc := keychain.New()
 	envs := utils.AllEnvs()
 
-	stored, source := wizardStartingCreds(envs)
+	storedCreds, loadErr := kc.Load()
+	switch {
+	case loadErr == nil, errors.Is(loadErr, keychain.ErrNotFound):
+	default:
+		logger.Warnf("Could not read the OS keychain (%v). Wizard treats it as empty.", loadErr)
+		storedCreds = keychain.Credentials{}
+	}
+
+	stored, source := wizardStartingCreds(envs, storedCreds)
+	storedUsername := storedCreds.Username
 
 	var (
 		selectedTools []string
 		workspaceID   = stored.WorkspaceID
 		authToken     = stored.AuthToken
+		username      = storedUsername
 		pushEnabled   bool
 	)
 
@@ -58,6 +68,17 @@ func (*huhWizard) Run(ctx context.Context) error {
 		groups = append(groups, authprompt.Group(&workspaceID, &authToken))
 	}
 
+	if usernamePersistable(source) {
+		groups = append(groups,
+			huh.NewGroup(
+				huh.NewInput().
+					Title("Display name for this machine's local invocations").
+					Description("Used to tag your local invocations in the Bitrise Build Cache dashboard. Leave empty to clear any stored override and fall back to the OS username.").
+					Value(&username),
+			),
+		)
+	}
+
 	groups = append(groups,
 		huh.NewGroup(
 			huh.NewConfirm().
@@ -76,18 +97,37 @@ func (*huhWizard) Run(ctx context.Context) error {
 	switch source {
 	case configcommon.AuthSourceKeychain:
 		logger.TInfof("Using credentials from the OS keychain.")
+		if username != storedUsername {
+			if err := persistCredentials(kc, storedCreds, workspaceID, authToken, username); err != nil {
+				logger.Warnf("Could not update the OS keychain with the new display name (%v).", err)
+			} else {
+				logger.Infof("Updated display name for local invocations.")
+			}
+		}
 	case configcommon.AuthSourceEnvVars:
-		if err := persistCredentials(kc, workspaceID, authToken); err != nil {
+		if err := persistCredentials(kc, storedCreds, workspaceID, authToken, username); err != nil {
 			logger.Warnf("Could not save credentials to the OS keychain (%v). Continuing with env values for this run only.", err)
 		} else {
 			logger.TInfof("Imported BITRISE_BUILD_CACHE_AUTH_TOKEN + WORKSPACE_ID from env into the OS keychain.")
+			if username != "" {
+				logger.Infof("Saved display name %q for local invocations.", username)
+			}
 			logger.Infof("You can now remove them from your shell rc files.")
 		}
-	case configcommon.AuthSourceJWT, configcommon.AuthSourceMultiplatform:
-		// JWT is per-build, multiplatform is already on disk — neither warrants persisting again.
+	case configcommon.AuthSourceJWT:
+		// Per-build, don't persist.
 		logger.TInfof("Using credentials resolved by the CLI.")
+	case configcommon.AuthSourceMultiplatform:
+		if err := persistCredentials(kc, storedCreds, workspaceID, authToken, username); err != nil {
+			logger.Warnf("Could not save credentials to the OS keychain (%v). Continuing with disk values for this run only.", err)
+		} else {
+			logger.TInfof("Migrated credentials from the multiplatform config to the OS keychain.")
+			if username != "" {
+				logger.Infof("Saved display name %q for local invocations.", username)
+			}
+		}
 	case configcommon.AuthSourceNone:
-		if err := persistCredentials(kc, workspaceID, authToken); err != nil {
+		if err := persistCredentials(kc, storedCreds, workspaceID, authToken, username); err != nil {
 			logger.Warnf("Could not save credentials to the OS keychain (%v). Continuing with values for this run only.", err)
 		} else {
 			logger.TInfof("Credentials saved to the OS keychain. Future runs will pick them up automatically.")
@@ -104,9 +144,9 @@ func (*huhWizard) Run(ctx context.Context) error {
 // keychain wins over env vars (so a populated keychain isn't silently overridden
 // by stale shell-rc env vars), then we fall back to ResolveAuthConfig for the
 // env / JWT / multiplatform sources, returning AuthSourceNone if none are set.
-func wizardStartingCreds(envs map[string]string) (configcommon.CacheAuthConfig, configcommon.AuthSource) {
-	if cfg, ok := configcommon.GetKeychainCredentials(); ok {
-		return cfg, configcommon.AuthSourceKeychain
+func wizardStartingCreds(envs map[string]string, storedCreds keychain.Credentials) (configcommon.CacheAuthConfig, configcommon.AuthSource) {
+	if storedCreds.AuthToken != "" && storedCreds.WorkspaceID != "" {
+		return configcommon.CacheAuthConfig{AuthToken: storedCreds.AuthToken, WorkspaceID: storedCreds.WorkspaceID}, configcommon.AuthSourceKeychain
 	}
 
 	cfg, src, err := configcommon.ResolveAuthConfig(envs)
@@ -117,8 +157,18 @@ func wizardStartingCreds(envs map[string]string) (configcommon.CacheAuthConfig, 
 	return cfg, src
 }
 
-func persistCredentials(kc keychainStore, workspaceID, authToken string) error {
-	if err := kc.Save(keychain.Credentials{AuthToken: authToken, WorkspaceID: workspaceID}); err != nil {
+func usernamePersistable(source configcommon.AuthSource) bool {
+	return source == configcommon.AuthSourceKeychain ||
+		source == configcommon.AuthSourceEnvVars ||
+		source == configcommon.AuthSourceMultiplatform ||
+		source == configcommon.AuthSourceNone
+}
+
+func persistCredentials(kc keychainStore, existing keychain.Credentials, workspaceID, authToken, username string) error {
+	existing.AuthToken = authToken
+	existing.WorkspaceID = workspaceID
+	existing.Username = username
+	if err := kc.Save(existing); err != nil {
 		return fmt.Errorf("save credentials to keychain: %w", err)
 	}
 

--- a/cmd/common/activate_interactive_test.go
+++ b/cmd/common/activate_interactive_test.go
@@ -7,10 +7,59 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 )
 
 func TestActivateCmd_HasInteractiveFlag(t *testing.T) {
 	flag := ActivateCmd.Flags().Lookup("interactive")
 	require.NotNil(t, flag, "--interactive flag should be registered on activate command")
 	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestPersistCredentials_writesUsernameField(t *testing.T) {
+	kc := &stubKeychain{}
+	require.NoError(t, persistCredentials(kc, keychain.Credentials{}, "ws-1", "tok-1", "alice"))
+	assert.Equal(t, "alice", kc.saved.Username)
+	assert.Equal(t, "ws-1", kc.saved.WorkspaceID)
+	assert.Equal(t, "tok-1", kc.saved.AuthToken)
+}
+
+type stubKeychain struct {
+	creds keychain.Credentials
+	saved keychain.Credentials
+}
+
+func (s *stubKeychain) Load() (keychain.Credentials, error) {
+	return s.creds, nil
+}
+
+func (s *stubKeychain) Save(c keychain.Credentials) error {
+	s.saved = c
+
+	return nil
+}
+
+func TestPersistCredentials_preservesOAuthFieldsOnUpdate(t *testing.T) {
+	existing := keychain.Credentials{
+		AuthToken:    "old-tok",
+		WorkspaceID:  "old-ws",
+		RefreshToken: "refresh-abc",
+		JWT:          "jwt-xyz",
+	}
+	kc := &stubKeychain{}
+
+	require.NoError(t, persistCredentials(kc, existing, "old-ws", "old-tok", "alice"))
+	assert.Equal(t, "alice", kc.saved.Username)
+	assert.Equal(t, "refresh-abc", kc.saved.RefreshToken, "OAuth refresh token must survive username edit")
+	assert.Equal(t, "jwt-xyz", kc.saved.JWT)
+}
+
+func TestUsernamePersistable(t *testing.T) {
+	assert.True(t, usernamePersistable(configcommon.AuthSourceKeychain))
+	assert.True(t, usernamePersistable(configcommon.AuthSourceEnvVars))
+	assert.True(t, usernamePersistable(configcommon.AuthSourceNone))
+	assert.True(t, usernamePersistable(configcommon.AuthSourceMultiplatform))
+	assert.False(t, usernamePersistable(configcommon.AuthSourceJWT))
 }

--- a/internal/auth/keychain/keychain.go
+++ b/internal/auth/keychain/keychain.go
@@ -23,6 +23,7 @@ var ErrNotFound = errors.New("no Bitrise Build Cache credentials in keychain")
 type Credentials struct {
 	AuthToken          string    `json:"auth_token"`
 	WorkspaceID        string    `json:"workspace_id"`
+	Username           string    `json:"username,omitempty"`
 	PATExpiry          time.Time `json:"pat_expiry,omitempty"`
 	JWT                string    `json:"jwt,omitempty"`
 	JWTExpiry          time.Time `json:"jwt_expiry,omitempty"`

--- a/internal/config/common/auth.go
+++ b/internal/config/common/auth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os/user"
 	"strings"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
@@ -14,6 +15,7 @@ const (
 	EnvAuthToken   = "BITRISE_BUILD_CACHE_AUTH_TOKEN"   //nolint:gosec // env-var key, not a credential
 	EnvWorkspaceID = "BITRISE_BUILD_CACHE_WORKSPACE_ID" //nolint:gosec // env-var key, not a credential
 	EnvJWT         = "BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN"
+	EnvUsername    = "BITRISE_BUILD_CACHE_USERNAME"
 )
 
 var (
@@ -69,6 +71,44 @@ func GetKeychainCredentialsWith(loader AuthLoader) (CacheAuthConfig, bool) {
 		AuthToken:   creds.AuthToken,
 		WorkspaceID: creds.WorkspaceID,
 	}, true
+}
+
+type UsernameSource int
+
+const (
+	UsernameSourceNone UsernameSource = iota
+	UsernameSourceEnv
+	UsernameSourceKeychain
+	UsernameSourceOS
+)
+
+func ResolveUsername(envs map[string]string) (string, UsernameSource) {
+	return resolveUsername(envs, keychain.New(), osUsername)
+}
+
+func resolveUsername(envs map[string]string, loader AuthLoader, osResolver func() string) (string, UsernameSource) {
+	if v := strings.TrimSpace(envs[EnvUsername]); v != "" {
+		return v, UsernameSourceEnv
+	}
+	if creds, err := loader.Load(); err == nil {
+		if v := strings.TrimSpace(creds.Username); v != "" {
+			return v, UsernameSourceKeychain
+		}
+	}
+	if v := strings.TrimSpace(osResolver()); v != "" {
+		return v, UsernameSourceOS
+	}
+
+	return "", UsernameSourceNone
+}
+
+func osUsername() string {
+	u, err := user.Current()
+	if err != nil {
+		return ""
+	}
+
+	return u.Username
 }
 
 // Wired via RegisterMultiplatformReader to avoid a multiplatform→common import cycle.

--- a/internal/config/common/auth_test.go
+++ b/internal/config/common/auth_test.go
@@ -456,3 +456,47 @@ func TestGetKeychainCredentials_loadErrorTreatedAsEmpty(t *testing.T) {
 	_, ok := GetKeychainCredentialsWith(loader)
 	assert.False(t, ok)
 }
+
+func osUserStub() string { return "os-user" }
+
+func TestResolveUsername_envWins(t *testing.T) {
+	loader := fakeAuthLoader{creds: keychain.Credentials{Username: "kc-user"}}
+	envs := map[string]string{EnvUsername: "env-user"}
+
+	got, src := resolveUsername(envs, loader, osUserStub)
+	assert.Equal(t, "env-user", got)
+	assert.Equal(t, UsernameSourceEnv, src)
+}
+
+func TestResolveUsername_keychainWinsOverOS(t *testing.T) {
+	loader := fakeAuthLoader{creds: keychain.Credentials{Username: "kc-user"}}
+
+	got, src := resolveUsername(map[string]string{}, loader, osUserStub)
+	assert.Equal(t, "kc-user", got)
+	assert.Equal(t, UsernameSourceKeychain, src)
+}
+
+func TestResolveUsername_osFallback(t *testing.T) {
+	loader := fakeAuthLoader{creds: keychain.Credentials{}}
+
+	got, src := resolveUsername(map[string]string{}, loader, osUserStub)
+	assert.Equal(t, "os-user", got)
+	assert.Equal(t, UsernameSourceOS, src)
+}
+
+func TestResolveUsername_envEmptyStringSkipped(t *testing.T) {
+	loader := fakeAuthLoader{creds: keychain.Credentials{Username: "kc-user"}}
+	envs := map[string]string{EnvUsername: "  "}
+
+	got, src := resolveUsername(envs, loader, osUserStub)
+	assert.Equal(t, "kc-user", got)
+	assert.Equal(t, UsernameSourceKeychain, src)
+}
+
+func TestResolveUsername_allEmpty(t *testing.T) {
+	loader := fakeAuthLoader{err: keychain.ErrNotFound}
+
+	got, src := resolveUsername(map[string]string{}, loader, func() string { return "" })
+	assert.Empty(t, got)
+	assert.Equal(t, UsernameSourceNone, src)
+}

--- a/internal/config/common/cache_config.go
+++ b/internal/config/common/cache_config.go
@@ -6,7 +6,6 @@ import (
 	"hash"
 	"maps"
 	"os"
-	"os/user"
 	"runtime"
 	"strconv"
 	"strings"
@@ -319,12 +318,11 @@ func generateHostMetadata(envs map[string]string, commandFunc CommandFunc, logge
 	}
 	metadata.Hostname = strings.TrimSpace(hostname)
 
-	// Username
-	u, err := user.Current()
-	if err != nil {
-		logger.Errorf("Error in get username: %v", err)
+	resolved, src := ResolveUsername(envs)
+	if src == UsernameSourceNone {
+		logger.Debugf("Could not resolve local invocation username from any source (env, keychain, os/user); leaving empty.")
 	}
-	metadata.Username = strings.TrimSpace(u.Username)
+	metadata.Username = strings.TrimSpace(resolved)
 
 	return metadata
 }

--- a/internal/config/common/cache_config_test.go
+++ b/internal/config/common/cache_config_test.go
@@ -352,3 +352,18 @@ func TestNewCacheConfigMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestNewMetadata_usernameFromEnvOverride(t *testing.T) {
+	envs := map[string]string{"BITRISE_BUILD_CACHE_USERNAME": "alice-dev"}
+
+	got := NewMetadata(envs, func(_ string, _ ...string) (string, error) { return "", nil }, log.NewLogger())
+	assert.Equal(t, "alice-dev", got.HostMetadata.Username)
+}
+
+func TestNewMetadata_usernameEnvWhitespaceFallsThrough(t *testing.T) {
+	envs := map[string]string{"BITRISE_BUILD_CACHE_USERNAME": "   "}
+
+	got := NewMetadata(envs, func(_ string, _ ...string) (string, error) { return "", nil }, log.NewLogger())
+	assert.NotEqual(t, "   ", got.HostMetadata.Username)
+	assert.NotEmpty(t, got.HostMetadata.Username, "should fall back to OS username")
+}


### PR DESCRIPTION
## Summary
- `keychain.Credentials.Username` — optional persisted display name.
- `configcommon.ResolveUsername(envs)` — precedence `BITRISEIO_CACHE_USERNAME` env → keychain → `os/user.Current().Username`.
- `bitrise-build-cache auth set --username <name>` — non-interactive persist.
- `activate --interactive` — new wizard prompt "Display name for this machine's local invocations". Defaults to OS username, empty allowed. Updates keychain when the user modifies the stored value.

## Out of scope
- Consumers that stamp invocations with the resolved username (tracked as ACI-5046).
- `invocations list` CLI filter + BE-side filter.

## Test plan
- [x] `make lint` clean.
- [x] `go test -tags unit -race ./internal/config/common/... ./internal/auth/keychain/... ./cmd/auth/... ./cmd/common/...` green.
- [x] Unit tests for `resolveUsername` cover env-wins / keychain-wins / OS fallback / whitespace-empty env skip / all-empty.
- [ ] Manual: run `bitrise-build-cache auth set --token X --workspace-id Y --username alice`, then `bitrise-build-cache auth status` shows the display name.
- [ ] Manual: `activate --interactive` → keychain-only path → change display name → confirm keychain updated.