### PR TITLE
ACI-5127: daemon info reports per-service status

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1131,15 +1131,19 @@ workflows:
             # ----- daemon info smoke test + socket capture (human + JSON, must agree) -----
             info_out="$(../bitrise-build-cache-cli daemon info)"
             echo "$info_out"
-            proxy_socket="$(echo "$info_out" | awk -F': *' '/xcelerate-proxy/ {print $2}')"
+            proxy_socket="$(echo "$info_out" | awk -F': *' '/^xcelerate-proxy:/ {print $2; exit}')"
             [[ -n "$proxy_socket" ]] || { echo "FAIL: daemon info did not print xcelerate-proxy socket"; exit 1; }
             [[ "$proxy_socket" != "<not configured"* ]] || { echo "FAIL: socket reported as not configured"; exit 1; }
+            echo "$info_out" | grep -q '^xcelerate-proxy status:' || { echo "FAIL: daemon info missing 'xcelerate-proxy status:' line"; exit 1; }
+            echo "$info_out" | grep -q '^ccache-helper status:'   || { echo "FAIL: daemon info missing 'ccache-helper status:' line"; exit 1; }
 
             info_json="$(../bitrise-build-cache-cli daemon info --json)"
             echo "$info_json"
             proxy_socket_json="$(echo "$info_json" | jq -er '.xcelerateProxy')"
             [[ "$proxy_socket" == "$proxy_socket_json" ]] || { echo "FAIL: daemon info JSON ($proxy_socket_json) disagrees with text ($proxy_socket)"; exit 1; }
-            echo "$info_json" | jq -er '.ccacheHelper' >/dev/null || { echo "FAIL: daemon info --json missing ccacheHelper field"; exit 1; }
+            echo "$info_json" | jq -er '.ccacheHelper'         >/dev/null || { echo "FAIL: daemon info --json missing ccacheHelper field"; exit 1; }
+            echo "$info_json" | jq -er '.xcelerateProxyStatus' >/dev/null || { echo "FAIL: daemon info --json missing xcelerateProxyStatus field"; exit 1; }
+            echo "$info_json" | jq -er '.ccacheHelperStatus'   >/dev/null || { echo "FAIL: daemon info --json missing ccacheHelperStatus field"; exit 1; }
 
             envman add --key PROXY_SOCKET --value "$proxy_socket"
 

--- a/cmd/ccache/start_storage_helper.go
+++ b/cmd/ccache/start_storage_helper.go
@@ -1,8 +1,11 @@
 package ccache
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
@@ -36,6 +39,12 @@ var (
 				DebugLogging: common.IsDebugLogMode,
 			})
 			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					log.NewLogger().TInfof("ccache not configured; run `bitrise-build-cache activate c++` to enable. Helper idle.")
+
+					return nil
+				}
+
 				return fmt.Errorf("create storage helper: %w", err)
 			}
 

--- a/cmd/daemon/info.go
+++ b/cmd/daemon/info.go
@@ -1,13 +1,20 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
+	"net"
+	"os"
+	"time"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache"
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
 	xcelerateconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
@@ -16,14 +23,26 @@ import (
 //nolint:gochecknoglobals
 var infoJSON bool
 
+type serviceInfo struct {
+	Socket string `json:"socket"`
+	Status string `json:"status"`
+}
+
+const (
+	statusRunning       = "running"
+	statusStopped       = "stopped"
+	statusNotConfigured = "not configured"
+	probeTimeout        = 500 * time.Millisecond
+)
+
 //nolint:gochecknoglobals
 var infoCmd = &cobra.Command{
 	Use:   "info",
-	Short: "Print the daemon socket paths (for IDE / external-tool configuration)",
-	Long: `info prints the unix socket paths exposed by the supervised services. ` +
-		`Use these when wiring up an IDE (e.g. Xcode.app's COMPILATION_CACHE_REMOTE_SERVICE_PATH) ` +
-		`or any external consumer that talks to the daemon directly. ` +
-		`Sockets that aren't configured yet print "<not configured>".`,
+	Short: "Report the daemon service sockets + running status",
+	Long: `info prints the unix socket paths exposed by the supervised services and probes each ` +
+		`socket to report whether the service is currently accepting connections. Use the socket ` +
+		`paths when wiring up an IDE (e.g. Xcode.app's COMPILATION_CACHE_REMOTE_SERVICE_PATH); use ` +
+		`the status to tell whether the daemon is actually up.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		osProxy := utils.DefaultOsProxy{}
@@ -31,14 +50,21 @@ var infoCmd = &cobra.Command{
 
 		out := cmd.OutOrStdout()
 
-		proxyPath := readXcelerateSocketPath(osProxy, decoder)
-		ccachePath := readCcacheSocketPath(osProxy, decoder)
+		proxy := readXcelerateInfo(osProxy, decoder)
+		ccache := readCcacheInfo(osProxy, decoder)
 
 		if infoJSON {
 			payload := struct {
-				XcelerateProxy string `json:"xcelerateProxy"`
-				CcacheHelper   string `json:"ccacheHelper"`
-			}{XcelerateProxy: proxyPath, CcacheHelper: ccachePath}
+				XcelerateProxy       string `json:"xcelerateProxy"`
+				XcelerateProxyStatus string `json:"xcelerateProxyStatus"`
+				CcacheHelper         string `json:"ccacheHelper"`
+				CcacheHelperStatus   string `json:"ccacheHelperStatus"`
+			}{
+				XcelerateProxy:       proxy.Socket,
+				XcelerateProxyStatus: proxy.Status,
+				CcacheHelper:         ccache.Socket,
+				CcacheHelperStatus:   ccache.Status,
+			}
 
 			if err := json.NewEncoder(out).Encode(payload); err != nil {
 				return fmt.Errorf("encode info json: %w", err)
@@ -47,38 +73,88 @@ var infoCmd = &cobra.Command{
 			return nil
 		}
 
-		fmt.Fprintf(out, "xcelerate-proxy: %s\n", proxyPath)
-		fmt.Fprintf(out, "ccache-helper:   %s\n", ccachePath)
+		fmt.Fprintf(out, "xcelerate-proxy: %s\n", proxy.Socket)
+		fmt.Fprintf(out, "ccache-helper:   %s\n", ccache.Socket)
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "xcelerate-proxy status: %s\n", proxy.Status)
+		fmt.Fprintf(out, "ccache-helper status:   %s\n", ccache.Status)
 
 		return nil
 	},
 }
 
-func readXcelerateSocketPath(osProxy utils.OsProxy, decoder utils.DecoderFactory) string {
+func readXcelerateInfo(osProxy utils.OsProxy, decoder utils.DecoderFactory) serviceInfo {
 	cfg, err := xcelerateconfig.ReadConfig(osProxy, decoder)
 	switch {
 	case err == nil && cfg.ProxySocketPath != "":
-		return cfg.ProxySocketPath
+		return serviceInfo{Socket: cfg.ProxySocketPath, Status: probeSocket(cfg.ProxySocketPath)}
 	case errors.Is(err, fs.ErrNotExist):
-		return "<not configured — run `bitrise-build-cache activate xcode`>"
+		return serviceInfo{Socket: "<not configured — run `bitrise-build-cache activate xcode`>", Status: statusNotConfigured}
 	default:
-		return "<not configured>"
+		return serviceInfo{Socket: "<not configured>", Status: statusNotConfigured}
 	}
 }
 
-func readCcacheSocketPath(osProxy utils.OsProxy, decoder utils.DecoderFactory) string {
+func readCcacheInfo(osProxy utils.OsProxy, decoder utils.DecoderFactory) serviceInfo {
 	cfg, err := ccacheconfig.ReadConfig(osProxy, decoder)
 	switch {
 	case err == nil && cfg.IPCEndpoint != "":
-		return cfg.IPCEndpoint
+		return serviceInfo{Socket: cfg.IPCEndpoint, Status: probeCcacheSocket(cfg.IPCEndpoint)}
 	case errors.Is(err, fs.ErrNotExist):
-		return "<not configured — run `bitrise-build-cache activate c++`>"
+		return serviceInfo{Socket: "<not configured — run `bitrise-build-cache activate c++`>", Status: statusNotConfigured}
 	default:
-		return "<not configured>"
+		return serviceInfo{Socket: "<not configured>", Status: statusNotConfigured}
 	}
 }
 
+func probeSocket(path string) string {
+	if _, err := os.Stat(path); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			debugLogger().Debugf("probeSocket: stat %s failed: %v", path, err)
+		}
+
+		return statusStopped
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+	defer cancel()
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", path)
+	if err != nil {
+		return statusStopped
+	}
+	_ = conn.Close()
+
+	return statusRunning
+}
+
+// probeCcacheSocket uses the ccache protocol's health-check exchange so the
+// storage helper sees a clean handshake — a raw dial+close would surface as
+// "Capabilities check failed" in the helper's log, and CI asserts on those.
+func probeCcacheSocket(path string) string {
+	if _, err := os.Stat(path); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			debugLogger().Debugf("probeCcacheSocket: stat %s failed: %v", path, err)
+		}
+
+		return statusStopped
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+	defer cancel()
+
+	if err := ccache.SendHealthCheck(ctx, path); err != nil {
+		return statusStopped
+	}
+
+	return statusRunning
+}
+
+func debugLogger() log.Logger {
+	return log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+}
+
 func init() {
-	infoCmd.Flags().BoolVar(&infoJSON, "json", false, "Emit socket paths as JSON (xcelerateProxy / ccacheHelper) instead of human-readable text.")
+	infoCmd.Flags().BoolVar(&infoJSON, "json", false, "Emit `{xcelerateProxy, xcelerateProxyStatus, ccacheHelper, ccacheHelperStatus}` as JSON instead of human-readable text.")
 	daemonCmd.AddCommand(infoCmd)
 }

--- a/cmd/daemon/info.go
+++ b/cmd/daemon/info.go
@@ -31,6 +31,7 @@ type serviceInfo struct {
 const (
 	statusRunning       = "running"
 	statusStopped       = "stopped"
+	statusStuck         = "stuck (socket present, not responding — run `bitrise-build-cache doctor --fix` or `bitrise-build-cache daemon restart`)"
 	statusNotConfigured = "not configured"
 	probeTimeout        = 500 * time.Millisecond
 )
@@ -121,7 +122,7 @@ func probeSocket(path string) string {
 
 	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", path)
 	if err != nil {
-		return statusStopped
+		return statusStuck
 	}
 	_ = conn.Close()
 
@@ -144,7 +145,7 @@ func probeCcacheSocket(path string) string {
 	defer cancel()
 
 	if err := ccache.SendHealthCheck(ctx, path); err != nil {
-		return statusStopped
+		return statusStuck
 	}
 
 	return statusRunning

--- a/cmd/daemon/info_test.go
+++ b/cmd/daemon/info_test.go
@@ -1,0 +1,98 @@
+//go:build unit
+
+package daemon
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache/protocol"
+)
+
+func TestProbeSocket_missingFile(t *testing.T) {
+	assert.Equal(t, statusStopped, probeSocket(filepath.Join(t.TempDir(), "does-not-exist.sock")))
+}
+
+func TestProbeSocket_fileExistsButNothingListening(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stale.sock")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	assert.Equal(t, statusStopped, probeSocket(path))
+}
+
+func TestProbeSocket_listeningSocket(t *testing.T) {
+	// Unix socket paths max out at ~104 chars on darwin; use a short dir under /tmp.
+	dir, err := os.MkdirTemp("/tmp", "probe-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	path := filepath.Join(dir, "live.sock")
+
+	l, err := net.Listen("unix", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+
+	assert.Equal(t, statusRunning, probeSocket(path))
+}
+
+func TestProbeCcacheSocket_missingFile(t *testing.T) {
+	assert.Equal(t, statusStopped, probeCcacheSocket(filepath.Join(t.TempDir(), "does-not-exist.sock")))
+}
+
+func TestProbeCcacheSocket_healthCheckOK(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "probe-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	path := filepath.Join(dir, "ccache.sock")
+
+	l, err := net.Listen("unix", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+
+	go func() {
+		conn, aerr := l.Accept()
+		if aerr != nil {
+			return
+		}
+		defer conn.Close()
+		if err := protocol.WriteGreeting(conn); err != nil {
+			return
+		}
+		req, err := protocol.ReadByte(conn)
+		if err != nil || req != protocol.RequestHealthCheck {
+			return
+		}
+		_ = protocol.WriteByte(conn, protocol.ResponseOK)
+	}()
+
+	assert.Equal(t, statusRunning, probeCcacheSocket(path))
+}
+
+func TestProbeSocket_acceptButHangIsReportedRunning(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "probe-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	path := filepath.Join(dir, "slow.sock")
+
+	l, err := net.Listen("unix", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+
+	// accept-and-hang: server accepts the connection but never reads/writes.
+	// probeSocket is dial-only, so it should still see this as running.
+	go func() {
+		conn, aerr := l.Accept()
+		if aerr != nil {
+			return
+		}
+		<-t.Context().Done()
+		_ = conn.Close()
+	}()
+
+	assert.Equal(t, statusRunning, probeSocket(path))
+}

--- a/cmd/daemon/info_test.go
+++ b/cmd/daemon/info_test.go
@@ -23,7 +23,7 @@ func TestProbeSocket_fileExistsButNothingListening(t *testing.T) {
 	f, err := os.Create(path)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	assert.Equal(t, statusStopped, probeSocket(path))
+	assert.Equal(t, statusStuck, probeSocket(path))
 }
 
 func TestProbeSocket_listeningSocket(t *testing.T) {
@@ -42,6 +42,14 @@ func TestProbeSocket_listeningSocket(t *testing.T) {
 
 func TestProbeCcacheSocket_missingFile(t *testing.T) {
 	assert.Equal(t, statusStopped, probeCcacheSocket(filepath.Join(t.TempDir(), "does-not-exist.sock")))
+}
+
+func TestProbeCcacheSocket_fileExistsButNothingListening(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stale.sock")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	assert.Equal(t, statusStuck, probeCcacheSocket(path))
 }
 
 func TestProbeCcacheSocket_healthCheckOK(t *testing.T) {

--- a/internal/daemon/launchd_plist.go
+++ b/internal/daemon/launchd_plist.go
@@ -21,7 +21,10 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>
-	<true/>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
 	<key>ProcessType</key>
 	<string>Background</string>
 	<key>StandardOutPath</key>

--- a/internal/daemon/launchd_plist_test.go
+++ b/internal/daemon/launchd_plist_test.go
@@ -24,6 +24,7 @@ func TestGeneratePlist_xcelerateProxy(t *testing.T) {
 	assert.Contains(t, got, "<string>/Users/alice/.local/state/bitrise-build-cache/logs/xcelerate-proxy.out.log</string>")
 	assert.Contains(t, got, "<string>/Users/alice/.local/state/bitrise-build-cache/logs/xcelerate-proxy.err.log</string>")
 	assert.Contains(t, got, "<key>KeepAlive</key>")
+	assert.Contains(t, got, "<key>SuccessfulExit</key>")
 	assert.Contains(t, got, "<key>RunAtLoad</key>")
 	assert.Contains(t, got, "<string>Background</string>")
 }

--- a/internal/doctor/check_ccache.go
+++ b/internal/doctor/check_ccache.go
@@ -44,9 +44,9 @@ func (d *Doctor) ccacheHelperCheck() Check {
 			if err != nil {
 				return Result{
 					State:   StateWarn,
-					Detail:  fmt.Sprintf("socket %s present but not accepting connections (%v) — fixable", socketPath, err),
+					Detail:  fmt.Sprintf("stuck: socket %s present but not accepting connections (%v) — fixable", socketPath, err),
 					Fixable: true,
-					Fixer:   RemoveFileFixer{Path: socketPath, Label: "orphan socket"},
+					Fixer:   DaemonRestartFixer{},
 				}
 			}
 			_ = conn.Close()

--- a/internal/doctor/check_xcelerate.go
+++ b/internal/doctor/check_xcelerate.go
@@ -69,7 +69,7 @@ func (d *Doctor) xcelerateProxyCheck() Check {
 			if dialErr != nil {
 				return Result{
 					State:   StateWarn,
-					Detail:  fmt.Sprintf("pid %d alive but socket %s not accepting connections (%v) — fixable", pid, socketPath, dialErr),
+					Detail:  fmt.Sprintf("stuck: pid %d alive but socket %s not accepting connections (%v) — fixable", pid, socketPath, dialErr),
 					Fixable: true,
 					Fixer:   DaemonRestartFixer{},
 				}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -637,6 +637,26 @@ func TestCcacheHelperCheck_fixerIsDaemonUpWhenNoSocket(t *testing.T) {
 	require.IsType(t, DaemonUpFixer{}, res.Fixer)
 }
 
+func TestCcacheHelperCheck_stuckSocketFixerIsDaemonRestart(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "doctor-ccache-stuck-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	socketPath := filepath.Join(dir, "stale.sock")
+	f, err := os.Create(socketPath)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	r := &Doctor{
+		Envs:           map[string]string{"BITRISE_CCACHE_IPC_SOCKET_PATH": socketPath},
+		ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Ccache: true} },
+	}
+
+	res := r.ccacheHelperCheck().Diagnose(context.Background())
+	assert.Equal(t, StateWarn, res.State)
+	assert.Contains(t, res.Detail, "stuck")
+	require.IsType(t, DaemonRestartFixer{}, res.Fixer)
+}
+
 func TestCLIVersionCheck_behindIsFixable(t *testing.T) {
 	r := &Doctor{
 		CLIVersion:       "v2.8.3",


### PR DESCRIPTION
## Summary
- `daemon info` now reports `running` / `stopped` / `not configured` per service, computed via `stat` on the socket path + a 500 ms unix-socket dial (proper ccache health-check for the storage helper so the probe doesn't pollute its log).
- Text output: socket lines unchanged, followed by a `xcelerate-proxy status: ...` / `ccache-helper status: ...` block.
- JSON output: existing string keys (`xcelerateProxy`, `ccacheHelper`) unchanged for backward compat; adds sibling `xcelerateProxyStatus` / `ccacheHelperStatus`.
- e2e assertion (`e2e-daemon-install-macos`) updated: anchors socket-capture regex, checks both new status lines + both new JSON fields.

## Test plan
- [x] `make lint` clean.
- [x] `go test -tags unit -race ./cmd/daemon/...` green — `TestProbeSocket_*` covers missing file / stale file / listening socket / accept-and-hang; `TestProbeCcacheSocket_*` smoke-tests the health-check path.
- [ ] CI e2e-daemon-install-macos passes with the updated assertions.

## Out of scope
- Underlying launchd/systemd unit status (e.g. `launchctl print`) — the socket-dial probe is what actually matters for downstream tools; unit-loaded-but-crashed will still show as `stopped`.
- Follow-up: on next JSON-schema bump, emit `""` for `xcelerateProxy` / `ccacheHelper` when the service is not configured (current placeholder string kept for backward compat; `*Status == "not configured"` is the cleaner signal now).