### PR TITLE
docs: ACI-5043 + ACI-5036 Xcode.app + scheme self-check docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Authentication is via two env vars (PAT + workspace ID) — see the [post-instal
 
 > The CLI configures the environment it's running in. If you're running commands in Docker containers, run the CLI inside the same container as Gradle/Bazel/Xcode/ccache.
 
+### Xcode.app (GUI builds)
+
+Pressing ▶ in Xcode.app bypasses the `xcodebuild` wrapper. Use `bitrise-build-cache xcode-app enable` to install an `XCODE_XCCONFIG_FILE` override so the GUI build pipeline also picks up the cache. See [`docs/xcode-app.md`](docs/xcode-app.md) for the full flow + a repo-controlled helper script pattern for team-wide rollout. For a scheme-level pre-build health check that catches a broken setup before ⌘B burns minutes on a no-cache build, see [`docs/xcode-scheme-self-check.md`](docs/xcode-scheme-self-check.md). macOS only.
+
 
 ## What does the CLI do on a high level?
 

--- a/docs/xcode-app.md
+++ b/docs/xcode-app.md
@@ -12,20 +12,24 @@ For the underlying CLI install + auth, see
 ## TL;DR
 
 ```sh
-# 1) one-time CLI + auth setup (see docs/install.md)
+# 1) one-time CLI install (see docs/install.md)
 brew install bitrise-io/bitrise-build-cache/bitrise-build-cache
-export BITRISE_BUILD_CACHE_AUTH_TOKEN="<PAT>"
-export BITRISE_BUILD_CACHE_WORKSPACE_ID="<workspace-slug>"
 
-# 2) configure the Xcode compile cache (writes ~/.bitrise-xcelerate/config.json)
+# 2) interactive sign-in — browser SSO, workspace picker, token stored
+#    in the OS keychain (auto-refreshed on subsequent CLI calls)
+bitrise-build-cache auth login
+
+# 3) configure the Xcode compile cache (writes ~/.bitrise-xcelerate/config.json)
 bitrise-build-cache activate xcode
 
-# 3) enable the override for Xcode.app GUI builds
+# 4) enable the override for Xcode.app GUI builds
 #    (also installs + starts the xcelerate-proxy daemon for you)
 bitrise-build-cache xcode-app enable
 
-# 4) relaunch Xcode, then build any target
+# 5) relaunch Xcode, then build any target
 ```
+
+Prefer env vars over the browser flow? Set `BITRISE_BUILD_CACHE_AUTH_TOKEN` + `BITRISE_BUILD_CACHE_WORKSPACE_ID` in your shell rc instead of step 2 — see [post-install](install.md#post-install). Env vars always take precedence over the keychain-stored token.
 
 macOS only. Linux + Windows don't ship Xcode.
 
@@ -61,7 +65,7 @@ socket to dial.
 | Step                                             | Why                                                                                                        |
 | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
 | `bitrise-build-cache --version` works            | Confirms the CLI is on `$PATH`. See [`docs/install.md`](install.md).                                       |
-| Auth env vars exported                           | `BITRISE_BUILD_CACHE_AUTH_TOKEN` + `BITRISE_BUILD_CACHE_WORKSPACE_ID`. See [post-install](install.md#post-install). |
+| Authenticated                                    | Either run `bitrise-build-cache auth login` (browser SSO + OS-keychain-stored token, auto-refreshed) **or** export `BITRISE_BUILD_CACHE_AUTH_TOKEN` + `BITRISE_BUILD_CACHE_WORKSPACE_ID`. Env vars take precedence when both are set. See [post-install](install.md#post-install). |
 | `bitrise-build-cache activate xcode` has run     | Writes `~/.bitrise-xcelerate/config.json` containing the proxy socket path that `xcode-app enable` reads.  |
 
 `xcode-app enable` installs + starts the xcelerate-proxy service itself (filtered subset of `daemon install + up`), so you don't need to run those separately. If you've already registered the daemon for other tools (ccache etc.), the proxy install is a no-op. `xcode-app enable` errors with a clear hint if the CLI / auth / `activate xcode` prerequisite is missing.
@@ -192,8 +196,11 @@ if ! command -v bitrise-build-cache >/dev/null; then
   exit 1
 fi
 
-# Auth env vars must already be set by the developer's shell rc.
-# Workspace credentials are personal — never commit them.
+# Trigger interactive sign-in when no creds are resolvable (env vars → keychain → analytics config).
+# `auth token` exits non-zero when nothing resolves; `auth login` is a no-op if the keychain already has a valid token.
+if ! bitrise-build-cache auth token >/dev/null 2>&1; then
+  bitrise-build-cache auth login
+fi
 
 bitrise-build-cache activate xcode
 bitrise-build-cache daemon install
@@ -205,9 +212,10 @@ Document in your repo's `README.md` that running
 `./scripts/enable-bitrise-build-cache.sh` after the first `git clone` is
 all that's needed.
 
-> **Auth credentials stay personal.** Each developer's PAT is tied to their
-> Bitrise account; never commit it to the repo. The helper script assumes
-> the env vars are already exported by the developer's shell rc.
+> **Auth credentials stay personal.** Each developer either runs
+> `bitrise-build-cache auth login` once (browser SSO, token in OS
+> keychain, auto-refreshed) or exports their own PAT via
+> `BITRISE_BUILD_CACHE_AUTH_TOKEN` — never commit either to the repo.
 
 ---
 

--- a/docs/xcode-app.md
+++ b/docs/xcode-app.md
@@ -1,0 +1,240 @@
+# Use the Bitrise Build Cache from Xcode.app (GUI builds)
+
+A one-page guide for enabling the compile cache when you press ▶ in
+Xcode.app. The default `xcodebuild` wrapper only kicks in for command-line
+builds — this page covers the GUI case.
+
+For the underlying CLI install + auth, see
+[`docs/install.md`](install.md) first.
+
+---
+
+## TL;DR
+
+```sh
+# 1) one-time CLI + auth setup (see docs/install.md)
+brew install bitrise-io/bitrise-build-cache/bitrise-build-cache
+export BITRISE_BUILD_CACHE_AUTH_TOKEN="<PAT>"
+export BITRISE_BUILD_CACHE_WORKSPACE_ID="<workspace-slug>"
+
+# 2) configure the Xcode compile cache (writes ~/.bitrise-xcelerate/config.json)
+bitrise-build-cache activate xcode
+
+# 3) enable the override for Xcode.app GUI builds
+#    (also installs + starts the xcelerate-proxy daemon for you)
+bitrise-build-cache xcode-app enable
+
+# 4) relaunch Xcode, then build any target
+```
+
+macOS only. Linux + Windows don't ship Xcode.
+
+---
+
+## How it works
+
+Xcode.app drives its build planner through `XCBBuildService` — the
+`xcodebuild` wrapper is bypassed for GUI builds. Apple exposes a single
+override slot, `XCODE_XCCONFIG_FILE`, that sits above per-target / per-base
+xcconfig but below `xcodebuild` CLI args.
+
+`xcode-app enable` does three things:
+
+1. Writes an override `xcconfig` to
+   `~/.bitrise-xcelerate/xcode-app.xcconfig` containing
+   `COMPILATION_CACHE_REMOTE_SERVICE_PATH` plus the
+   `COMPILATION_CACHE_ENABLE_*` / `SWIFT_*` / `CLANG_*` keys.
+2. Runs `launchctl setenv XCODE_XCCONFIG_FILE <path>` so processes spawned
+   from the current GUI session inherit the override.
+3. Installs a one-shot LaunchAgent
+   (`~/Library/LaunchAgents/io.bitrise.build-cache.xcode-app-setenv.plist`)
+   that re-applies the `setenv` on every login, so the override survives
+   logout.
+
+The xcelerate-proxy daemon is also installed + started so Xcode.app has a
+socket to dial.
+
+---
+
+## Prerequisites
+
+| Step                                             | Why                                                                                                        |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `bitrise-build-cache --version` works            | Confirms the CLI is on `$PATH`. See [`docs/install.md`](install.md).                                       |
+| Auth env vars exported                           | `BITRISE_BUILD_CACHE_AUTH_TOKEN` + `BITRISE_BUILD_CACHE_WORKSPACE_ID`. See [post-install](install.md#post-install). |
+| `bitrise-build-cache activate xcode` has run     | Writes `~/.bitrise-xcelerate/config.json` containing the proxy socket path that `xcode-app enable` reads.  |
+
+`xcode-app enable` installs + starts the xcelerate-proxy service itself (filtered subset of `daemon install + up`), so you don't need to run those separately. If you've already registered the daemon for other tools (ccache etc.), the proxy install is a no-op. `xcode-app enable` errors with a clear hint if the CLI / auth / `activate xcode` prerequisite is missing.
+
+---
+
+## Enable
+
+```sh
+bitrise-build-cache xcode-app enable
+```
+
+Output looks like:
+
+```
+✓ Wrote override xcconfig: /Users/<you>/.bitrise-xcelerate/xcode-app.xcconfig
+✓ Set XCODE_XCCONFIG_FILE via launchctl (LaunchAgent: …/io.bitrise.build-cache.xcode-app-setenv.plist)
+✓ Proxy socket: /var/folders/.../xcelerate-proxy.sock
+! Xcode is currently running (pid [1234]). Quit and relaunch Xcode to pick up the cache override.
+```
+
+If you already had `XCODE_XCCONFIG_FILE` pointing at a project xcconfig, you'll see an extra line above the LaunchAgent confirmation:
+
+```
+Chained previous XCODE_XCCONFIG_FILE: /Users/<you>/path/to/your/Base.xcconfig
+```
+
+See [Chaining an existing `XCODE_XCCONFIG_FILE`](#chaining-an-existing-xcode_xcconfig_file) for what that means.
+
+Re-running `enable` after a successful `enable` is safe — the activator detects the self-loop (`launchctl getenv XCODE_XCCONFIG_FILE` now points at our own override) and preserves the original prior-path state on disk, so `disable` later still restores the right xcconfig.
+
+> **Relaunch Xcode after enable.** `launchctl setenv` only reaches processes
+> launched *after* it ran. Already-open Xcode windows pick up the override
+> only on the next launch. Use ⌘Q (not just close the window).
+
+---
+
+## Verify the override is in effect
+
+After relaunching Xcode, three quick checks:
+
+```sh
+# 1. The env is set in the current GUI session:
+launchctl getenv XCODE_XCCONFIG_FILE
+#  → should print ~/.bitrise-xcelerate/xcode-app.xcconfig
+
+# 2. The setenv LaunchAgent is loaded (re-applies the env on every login):
+launchctl list | grep io.bitrise.build-cache
+#  → should list io.bitrise.build-cache.xcode-app-setenv (and the proxy)
+
+# 3. The proxy socket exists and is listening:
+socket_path=$(jq -r .proxySocketPath ~/.bitrise-xcelerate/config.json)
+test -S "$socket_path" && echo "proxy socket present at $socket_path"
+
+# 4. Build any target in Xcode. New entries should appear under
+#    ~/.local/state/xcelerate/logs/ — that's the proxy log directory.
+ls -lt ~/.local/state/xcelerate/logs/ | head
+```
+
+If `launchctl getenv` prints nothing, either the initial `launchctl setenv`
+or the LaunchAgent bootstrap failed during `enable` — re-run
+`bitrise-build-cache xcode-app enable` and read the error in its output.
+
+If the socket isn't there, the xcelerate-proxy service didn't start. Re-run
+`enable` (which calls daemon install + up internally) or, equivalently,
+`bitrise-build-cache daemon up`. The override expects the proxy to be
+listening — Xcode silently skips the cache if the socket isn't there.
+
+---
+
+## Chaining an existing `XCODE_XCCONFIG_FILE`
+
+If you (or your tooling) already set `XCODE_XCCONFIG_FILE` to a custom
+xcconfig, `enable` captures the existing value and **chains it** into our
+override via `#include` at the top of the file:
+
+```text
+// Bitrise Build Cache — Xcode.app override
+// Written by `bitrise-build-cache xcode-app enable`.
+
+#include "/Users/<you>/path/to/your/Base.xcconfig"
+
+COMPILATION_CACHE_ENABLE_DETACHED_KEY_QUERIES = YES
+...
+```
+
+Your settings keep winning where they don't collide with the
+`COMPILATION_CACHE_*` keys. `disable` restores the prior value into
+`launchctl` so re-enabling later picks up the same chain.
+
+> **List settings** (`OTHER_CFLAGS`, `OTHER_LDFLAGS` etc.) — none today, but
+> if a future override ever appends to one, use `$(inherited)` in the chained
+> xcconfig so your values aren't dropped.
+
+---
+
+## Disable
+
+```sh
+bitrise-build-cache xcode-app disable
+```
+
+Reverses every step:
+
+- `launchctl bootout` + remove the LaunchAgent plist.
+- `launchctl unsetenv XCODE_XCCONFIG_FILE` — or, if a prior path was chained
+  in at enable time, `launchctl setenv` back to it.
+- Remove our override xcconfig from `~/.bitrise-xcelerate/`.
+
+Idempotent — safe to run when nothing is enabled. Does **not** stop the
+xcelerate-proxy daemon; use `bitrise-build-cache daemon down` for that.
+
+---
+
+## Team-wide rollout (repo-controlled helper script)
+
+Most iOS teams want the override applied for every developer on the team
+without each person memorising the exact command. Ship a small script in
+the repo:
+
+```sh
+# scripts/enable-bitrise-build-cache.sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v bitrise-build-cache >/dev/null; then
+  echo "Install the CLI first: see docs/install.md" >&2
+  exit 1
+fi
+
+# Auth env vars must already be set by the developer's shell rc.
+# Workspace credentials are personal — never commit them.
+
+bitrise-build-cache activate xcode
+bitrise-build-cache daemon install
+bitrise-build-cache daemon up
+bitrise-build-cache xcode-app enable
+```
+
+Document in your repo's `README.md` that running
+`./scripts/enable-bitrise-build-cache.sh` after the first `git clone` is
+all that's needed.
+
+> **Auth credentials stay personal.** Each developer's PAT is tied to their
+> Bitrise account; never commit it to the repo. The helper script assumes
+> the env vars are already exported by the developer's shell rc.
+
+---
+
+## Pre-build self-check (catch a broken setup at ⌘B)
+
+The override survives logout, but the daemon can be killed, the PAT can
+rotate, and `activate xcode` can be overwritten by a teammate. To catch
+these before `swiftc` starts and burns minutes producing a no-cache build,
+wire `bitrise-build-cache doctor` into the scheme's **Build → Pre-actions**
+as a Run Script action. Full recipe (paste-in script + hard-block variant
++ team rollout via shared `.xcscheme`) in
+[`xcode-scheme-self-check.md`](xcode-scheme-self-check.md).
+
+---
+
+## Troubleshooting
+
+| Symptom                                                            | First thing to try                                                                                  |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `enable` errors with `xcelerate config not found`                  | Run `bitrise-build-cache activate xcode` first — that writes the proxy socket path enable depends on. |
+| `enable` succeeds but builds aren't using the cache                | Relaunched Xcode? `launchctl setenv` only reaches processes launched after `enable` ran.            |
+| `launchctl getenv XCODE_XCCONFIG_FILE` prints nothing              | Either the initial `launchctl setenv` failed or the LaunchAgent bootstrap did. Re-run `enable` and read the error in its output. |
+| Proxy socket missing (`test -S` fails on the path in `config.json`) | Re-run `bitrise-build-cache xcode-app enable` (it ensures the daemon service is installed + up), or `bitrise-build-cache daemon up`. Override expects the proxy listening. |
+| Your project's existing `XCODE_XCCONFIG_FILE` was overwritten      | `disable` restores it. If state got out of sync, manually `launchctl setenv` to the prior path.     |
+| Want to skip the cache for a single CLI build                      | Pass `XCODE_XCCONFIG_FILE=""` to a one-off `xcodebuild` invocation (CLI args win over the override slot). For GUI builds, edit the scheme → Build → Pre-actions and add `unset XCODE_XCCONFIG_FILE` in a "New Run Script Action" — ⌥-clicking Run only opens the scheme editor, it does not bypass the env. |
+| Multiple Xcode installs (Xcode-beta etc.)                          | The override applies to every Xcode launched after `setenv`. Only the GA `Xcode` process gets the relaunch nudge — beta users should quit-and-relaunch manually. |
+
+For deeper logging, prepend `-d`
+(`bitrise-build-cache -d xcode-app enable`). Open issues at
+[github.com/bitrise-io/bitrise-build-cache-cli](https://github.com/bitrise-io/bitrise-build-cache-cli/issues).

--- a/docs/xcode-scheme-self-check.md
+++ b/docs/xcode-scheme-self-check.md
@@ -1,0 +1,148 @@
+# Xcode Scheme Self-Check (Pre-Build `doctor`)
+
+Run `bitrise-build-cache doctor` from your Xcode scheme's **Build → Pre-actions**, so every ⌘B / Run / Test verifies the local Build Cache setup *before* `swiftc` starts. Catches missing proxy, stale auth, downed daemon, or misconfigured `xcconfig` before a full uncached build burns minutes.
+
+For CLI + auth setup and the compile-cache override, read [`install.md`](install.md) and [`xcode-app.md`](xcode-app.md) first — this page assumes both are done.
+
+---
+
+## When to add this
+
+You are:
+
+- Building in **Xcode.app** (⌘B / Run / Test) rather than `xcodebuild` CLI.
+- Have already run `bitrise-build-cache activate xcode` and `bitrise-build-cache xcode-app enable`.
+- Want a fast fail at build start when the cache setup drifts (daemon not running, PAT rotated, config wiped).
+
+Skip on Bitrise CI — the `xcodebuild` wrapper step already probes health there.
+
+---
+
+## Add the pre-action
+
+1. In Xcode: **Product → Scheme → Edit Scheme…** (⌘<)
+2. Left sidebar → **Build** → expand the arrow → **Pre-actions**.
+3. **+** → **New Run Script Action**.
+4. **Provide build settings from:** pick the primary target of the scheme (needed to inherit the target's environment).
+5. **Shell:** `/bin/sh` (default).
+6. Paste the body below.
+7. **Close** to save. The `.xcscheme` XML now contains the action — commit it if the scheme is shared across the team.
+
+### Run Script body
+
+```sh
+# Bitrise Build Cache — scheme pre-build self-check
+set -eu
+
+LOG="${TMPDIR:-/tmp}/bitrise-build-cache-doctor.log"
+
+# Xcode strips PATH down to a minimal set. Extend to common CLI install dirs.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+if ! command -v bitrise-build-cache >/dev/null 2>&1; then
+    # CLI not installed — nothing to check. Silent no-op.
+    exit 0
+fi
+
+if bitrise-build-cache doctor --no-update-check --no-backend-probe >"$LOG" 2>&1; then
+    exit 0
+fi
+
+# doctor exited non-zero → at least one check reported an error.
+# Surface the failure via a modal so the developer can't miss it.
+osascript <<APPLESCRIPT
+display alert "Bitrise Build Cache: setup check failed" \
+    message "The pre-build health check reported errors. Your build will run without the remote cache.
+
+Fix and retry:
+
+    bitrise-build-cache doctor --fix
+
+Full log: $LOG" \
+    as critical
+APPLESCRIPT
+
+exit 1
+```
+
+**Copy tip:** the alert message is a literal `osascript` string — keep the blank lines between `errors.`, `Fix and retry:`, `    bitrise-build-cache …`, and `Full log:`; they render as paragraph breaks in the dialog.
+
+---
+
+## What each flag does
+
+- `--no-update-check` — skips the GitHub release lookup. Pre-actions run on every build; you don't want a network call added to every ⌘B just to check for a new CLI version.
+- `--no-backend-probe` — skips the Build Cache backend auth probe (sentinel KV `PUT`). Same reason: keep the check local + fast.
+
+`doctor` still verifies: auth token presence, keychain access, `xcelerate` config, daemon socket, ccache helper, log dirs.
+
+---
+
+## Behaviour notes (read before shipping to a team)
+
+- **Xcode pre-actions do not hard-abort the build on non-zero exit.** The `osascript` modal is the reliable way to surface the failure to the developer — they read it, click OK, and the build then proceeds *without* the cache. If your team wants a hard block, add a Build Phase Run Script at the top of each target that fails on a marker file written by the pre-action. See [Hard block](#hard-block-optional) below.
+- **Output is not streamed to Xcode's Report navigator.** That's why the script tees output to `$LOG` and points the modal at the file — the developer opens it in Console/Terminal to see the exact `doctor` lines.
+- **PATH.** Xcode pre-actions inherit a stripped PATH. The script extends it to the three common CLI install roots — `$HOME/.local/bin` (`installer.sh` default), `/opt/homebrew/bin` (Homebrew Apple Silicon), `/usr/local/bin` (Homebrew Intel).
+- **Silent no-op when CLI missing.** If a teammate hasn't installed the CLI yet, the pre-action exits `0` rather than yelling at them mid-build. The absence is a setup issue, not a build issue — `docs/install.md` covers onboarding.
+
+---
+
+## Hard block (optional)
+
+If a soft warning isn't enough — for example, you have a strict policy that no build may proceed without the cache — combine the pre-action with a per-target Build Phase Run Script that reads a marker file.
+
+**Pre-action** (replace the `exit 1` at the bottom):
+
+```sh
+touch "${TMPDIR:-/tmp}/bitrise-build-cache-doctor.failed"
+exit 1
+```
+
+Also add, at the top of the script, a clean-up when doctor succeeds:
+
+```sh
+rm -f "${TMPDIR:-/tmp}/bitrise-build-cache-doctor.failed"
+```
+
+**Build Phase Run Script** (add as the *first* Run Script phase in each target's Build Phases):
+
+```sh
+if [ -f "${TMPDIR:-/tmp}/bitrise-build-cache-doctor.failed" ]; then
+    echo "error: Bitrise Build Cache doctor failed; run 'bitrise-build-cache doctor --fix'."
+    exit 1
+fi
+```
+
+Now Xcode aborts compilation at the first target that sees the marker.
+
+---
+
+## Verify
+
+1. Break the setup on purpose (e.g. `bitrise-build-cache daemon down`).
+2. ⌘B a target that uses the scheme.
+3. The modal should appear within a second. Dismiss it.
+4. `cat "${TMPDIR:-/tmp}/bitrise-build-cache-doctor.log"` shows the exact `doctor` output including the `↳ rerun with --fix to repair` hint on fixable items.
+5. `bitrise-build-cache doctor --fix` restores the setup; next ⌘B should pass silently.
+
+---
+
+## Team-wide rollout
+
+The pre-action lives inside the `.xcscheme` file at
+`YourProject.xcodeproj/xcshareddata/xcschemes/<Scheme>.xcscheme`. Commit that file to the repo and every teammate inherits the check on their next `git pull`.
+
+Only shared schemes work for this — per-user schemes (`xcuserdata/…`) aren't checked in. If your team runs on per-user schemes, either promote them to shared or ship the snippet in your project README as copy-paste.
+
+---
+
+## Troubleshooting
+
+| Symptom | First thing to try |
+| --- | --- |
+| Modal never appears; build runs without cache regardless | `command -v bitrise-build-cache` returns empty inside the pre-action's PATH. Confirm the install path is in the extended `PATH` line (`$HOME/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin`). |
+| Modal appears on every build even after `doctor --fix` | Doctor may report a WARN, not just ERROR — but the current snippet only escalates on non-zero exit (`doctor` exits `0` on WARN). Re-run `bitrise-build-cache doctor` in Terminal to read the exact state. |
+| `$LOG` file grows large over time | Rotate: replace `>"$LOG"` with `>"$LOG.tmp" && mv "$LOG.tmp" "$LOG"` (single overwrite per run — this is already the effective behaviour of `>` in `sh`). |
+| Pre-action runs but `osascript` blocks headlessly on CI VMs | The pre-action is intentionally scoped to Xcode.app GUI. For `xcodebuild` CLI builds, the CLI wrapper step handles health checks — remove or guard the alert behind `[ -t 0 ]` if a scheme runs in both contexts. |
+
+Open issues at [github.com/bitrise-io/bitrise-build-cache-cli](https://github.com/bitrise-io/bitrise-build-cache-cli/issues).


### PR DESCRIPTION
## Summary

Two docs pages for M2 Xcode.app support, squashed into one commit on top of `aci-4337-cli-xcode`:

- **`docs/xcode-app.md`** (ACI-5043) — one-page guide for enabling the compile cache when developers press ▶ in Xcode.app. Prerequisites (CLI + auth + `activate xcode` + `daemon up`), enable flow, Xcode-relaunch step, verification via `launchctl getenv`, `#include` chain for pre-existing `XCODE_XCCONFIG_FILE`, disable, repo-controlled helper script for team-wide rollout, troubleshooting.
- **`docs/xcode-scheme-self-check.md`** (ACI-5036) — paste-in Run Script for Xcode Build → Pre-actions that runs `bitrise-build-cache doctor --no-update-check --no-backend-probe` and surfaces failure via `osascript` modal. Covers PATH extension, silent no-op when CLI missing, optional hard-block via marker file + per-target Build Phase, shared-scheme rollout, verify + troubleshooting.
- **`README.md`** — new Xcode.app subsection cross-linking both docs.

Re-land of [PR #367](https://github.com/bitrise-io/bitrise-build-cache-cli/pull/367) (CLOSED) + this PR's original ACI-5036 content, squashed into a single doc commit.

Doc-only. No CLI code changes here — ACI-5041 + ACI-5042 code (which `xcode-app.md` documents) lands via [PR #399](https://github.com/bitrise-io/bitrise-build-cache-cli/pull/399). Both sibling PRs target `aci-4337-cli-xcode`; coordinate at merge time so docs don't precede code onto main.

## Test plan

- [ ] Render `docs/xcode-app.md` — link checks (README → xcode-app.md → xcode-scheme-self-check.md).
- [ ] Render `docs/xcode-scheme-self-check.md` — verify paste-in Run Script snippet formats correctly.
- [ ] Confirm the `docs/xcode-app.md` "Pre-build self-check" section cross-links `xcode-scheme-self-check.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)