### PR TITLE
feat: ACI-5159 honor custom GRADLE_USER_HOME for Gradle activation

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -434,6 +434,8 @@ workflows:
     envs:
     - TEST_APP_URL: git@github.com:duckduckgo/Android.git
     - BRANCH: develop
+    # activate must write the init script here, not $HOME/.gradle
+    - GRADLE_USER_HOME: $HOME/custom-gradle-home
     steps:
     - bundle::feature-e2e-setup: {}
     - script@1:
@@ -460,10 +462,17 @@ workflows:
             set -exo pipefail
             ../bitrise-build-cache-cli activate gradle -d --cache --cache-push
     - script:
-        title: Print ~/.init.d/bitrise-build-cache.init.gradle.kts
+        title: Assert init script honors GRADLE_USER_HOME
         inputs:
           - content: |-
-              cat ~/.gradle/init.d/bitrise-build-cache.init.gradle.kts
+              set -exo pipefail
+              test -f "$GRADLE_USER_HOME/init.d/bitrise-build-cache.init.gradle.kts"
+              # activate writes build-cache to GRADLE_USER_HOME and migrates the preboot mirror out of ~/.gradle
+              if [ -f "$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts" ] || [ -f "$HOME/.gradle/init.d/bitrise-gradle-mirrors.init.gradle.kts" ]; then
+                echo "ERROR: bitrise init scripts left in ~/.gradle instead of GRADLE_USER_HOME ($GRADLE_USER_HOME)"
+                exit 1
+              fi
+              cat "$GRADLE_USER_HOME/init.d/bitrise-build-cache.init.gradle.kts"
     - script:
         title: Build and capture logs
         inputs:
@@ -1298,6 +1307,8 @@ workflows:
     envs:
     - TEST_APP_URL: git@github.com:duckduckgo/Android.git
     - BRANCH: develop
+    # both init scripts must land here, not $HOME/.gradle
+    - GRADLE_USER_HOME: $HOME/custom-gradle-home
     steps:
     - bundle::feature-e2e-setup: {}
     - script@1:
@@ -1323,14 +1334,22 @@ workflows:
             export BITRISE_MAVENCENTRAL_PROXY_ENABLED=true
             ../bitrise-build-cache-cli activate gradle-mirrors -d
     - script:
-        title: Print init scripts
+        title: Assert init scripts honor GRADLE_USER_HOME
         inputs:
           - content: |-
+              set -exo pipefail
+              test -f "$GRADLE_USER_HOME/init.d/bitrise-build-cache.init.gradle.kts"
+              test -f "$GRADLE_USER_HOME/init.d/bitrise-gradle-mirrors.init.gradle.kts"
+              # activate migrates the preboot mirror out of ~/.gradle, and everything else lands in GRADLE_USER_HOME
+              if [ -f "$HOME/.gradle/init.d/bitrise-build-cache.init.gradle.kts" ] || [ -f "$HOME/.gradle/init.d/bitrise-gradle-mirrors.init.gradle.kts" ]; then
+                echo "ERROR: init scripts written to ~/.gradle instead of GRADLE_USER_HOME ($GRADLE_USER_HOME)"
+                exit 1
+              fi
               echo "=== bitrise-build-cache.init.gradle.kts ==="
-              cat ~/.gradle/init.d/bitrise-build-cache.init.gradle.kts
+              cat "$GRADLE_USER_HOME/init.d/bitrise-build-cache.init.gradle.kts"
               echo ""
               echo "=== bitrise-gradle-mirrors.init.gradle.kts ==="
-              cat ~/.gradle/init.d/bitrise-gradle-mirrors.init.gradle.kts
+              cat "$GRADLE_USER_HOME/init.d/bitrise-gradle-mirrors.init.gradle.kts"
     - script:
         title: Guard - init script compiles clean under allWarningsAsErrors
         inputs:
@@ -1344,7 +1363,7 @@ workflows:
             GUARD_HOME=$(mktemp -d)
             GUARD_PROJ=$(mktemp -d)
             mkdir -p "$GUARD_HOME/init.d"
-            cp ~/.gradle/init.d/bitrise-gradle-mirrors.init.gradle.kts "$GUARD_HOME/init.d/"
+            cp "$GRADLE_USER_HOME/init.d/bitrise-gradle-mirrors.init.gradle.kts" "$GUARD_HOME/init.d/"
             printf 'org.gradle.kotlin.dsl.allWarningsAsErrors=true\n' > "$GUARD_HOME/gradle.properties"
             printf 'rootProject.name = "init-compile-guard"\n' > "$GUARD_PROJ/settings.gradle.kts"
             GRADLE_USER_HOME="$GUARD_HOME" ./gradlew --project-dir "$GUARD_PROJ" help --stacktrace

--- a/cmd/gradle/activate_gradle.go
+++ b/cmd/gradle/activate_gradle.go
@@ -6,12 +6,13 @@ import (
 	"path/filepath"
 
 	"github.com/bitrise-io/go-utils/v2/log"
-	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/spf13/cobra"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
+	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle/mirrors"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/permhint"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
@@ -36,12 +37,18 @@ If the "# [start/end] generated-by-bitrise-build-cache" block is already present
 		logger.EnableDebugLog(common.IsDebugLogMode)
 		logger.TInfof("Activate Bitrise plugins for Gradle")
 
-		gradleHome, err := pathutil.NewPathModifier().AbsPath(gradleHomeNonExpanded)
+		allEnvs := utils.AllEnvs()
+
+		p, err := paths.Default()
 		if err != nil {
-			return fmt.Errorf("expand Gradle home path (%s), error: %w", gradleHome, err)
+			return fmt.Errorf("resolve home dir: %w", err)
 		}
 
-		allEnvs := utils.AllEnvs()
+		gradleHome := p.GradleHome(allEnvs[paths.GradleUserHomeEnvKey])
+
+		if merr := mirrorsconfig.MigratePrebootInitScript(logger, utils.DefaultOsProxy{}, p.GradleHome(""), gradleHome); merr != nil {
+			logger.Warnf("Could not relocate preboot Gradle mirrors init script: %s", merr)
+		}
 
 		if cliPath, exeErr := os.Executable(); exeErr == nil {
 			activateGradleParams.CLIPath = cliPath

--- a/cmd/gradle/activate_gradle_mirrors.go
+++ b/cmd/gradle/activate_gradle_mirrors.go
@@ -28,7 +28,6 @@ disables the mirrors per workflow / per workspace without removing the file.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		activator := mirrorspkg.NewActivator(mirrorspkg.ActivatorParams{
-			GradleHome:    gradleHomeNonExpanded,
 			SelectedFlags: selectedMirrorFlags(cmd),
 			DebugLogging:  common.IsDebugLogMode,
 		})

--- a/cmd/gradle/enable_for_gradle.go
+++ b/cmd/gradle/enable_for_gradle.go
@@ -5,18 +5,17 @@ import (
 	"os"
 
 	"github.com/bitrise-io/go-utils/v2/log"
-	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/spf13/cobra"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 const (
-	gradleHomeNonExpanded   = "~/.gradle"
 	FmtErrorEnableForGradle = "adding Gradle plugins failed: %w"
 )
 
@@ -49,12 +48,14 @@ If the "# [start/end] generated-by-bitrise-build-cache" block is already present
 		logger.EnableDebugLog(common.IsDebugLogMode)
 		logger.TInfof("Enable Bitrise Build Cache for Gradle")
 		//
-		gradleHome, err := pathutil.NewPathModifier().AbsPath(gradleHomeNonExpanded)
+		allEnvs := utils.AllEnvs()
+
+		p, err := paths.Default()
 		if err != nil {
-			return fmt.Errorf("expand Gradle home path (%s), error: %w", gradleHome, err)
+			return fmt.Errorf("resolve home dir: %w", err)
 		}
 
-		allEnvs := utils.AllEnvs()
+		gradleHome := p.GradleHome(allEnvs[paths.GradleUserHomeEnvKey])
 
 		//
 		if err := EnableForGradleCmdFn(logger, gradleHome, allEnvs); err != nil {

--- a/cmd/gradle/gradleVerificationAddDeps.go
+++ b/cmd/gradle/gradleVerificationAddDeps.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 
 	"github.com/bitrise-io/go-utils/v2/log"
-	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/spf13/cobra"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
@@ -28,13 +28,15 @@ This command will:
 		logger.EnableDebugLog(common.IsDebugLogMode)
 		logger.TInfof("Add Bitrise Build Cache for Gradle plugins")
 		//
-		gradleHome, err := pathutil.NewPathModifier().AbsPath(gradleHomeNonExpanded)
-		if err != nil {
-			return fmt.Errorf("expand Gradle home path (%s), error: %w", gradleHome, err)
-		}
-
 		//
 		allEnvs := utils.AllEnvs()
+
+		p, err := paths.Default()
+		if err != nil {
+			return fmt.Errorf("resolve home dir: %w", err)
+		}
+
+		gradleHome := p.GradleHome(allEnvs[paths.GradleUserHomeEnvKey])
 		if err := addGradlePluginsFn(logger, gradleHome, allEnvs); err != nil {
 			return fmt.Errorf("enable Gradle Build Cache: %w", err)
 		}

--- a/internal/config/gradle/gradle_properties_from_params.go
+++ b/internal/config/gradle/gradle_properties_from_params.go
@@ -30,9 +30,9 @@ func (updater GradlePropertiesUpdater) UpdateGradleProps(
 	logger log.Logger,
 	gradleHomePath string,
 ) error {
-	logger.Infof("(i) Write ~/.gradle/gradle.properties")
-
 	gradlePropertiesPath := filepath.Join(gradleHomePath, "gradle.properties")
+	logger.Infof("(i) Write %s", gradlePropertiesPath)
+
 	currentGradlePropsFileContent, isGradlePropsExists, err := updater.OsProxy.ReadFileIfExists(gradlePropertiesPath)
 	if err != nil {
 		return fmt.Errorf(ErrFmtGradlePropertiesCheck, gradlePropertiesPath, err)

--- a/internal/config/gradle/gradleconfig.go
+++ b/internal/config/gradle/gradleconfig.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"path/filepath"
 	"text/template"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
@@ -20,13 +20,10 @@ var (
 	errFmtParseTemplate             = "generate init.gradle: parse template: %w"
 	errFmtExecuteTemplate           = "generate init.gradle: execute template: %w"
 	errFmtGradleGeneration          = "couldn't generate gradle init content: %w"
-	errFmtEnsureGradleInitDirExists = "ensure ~/.gradle/init.d exists: %w"
+	errFmtEnsureGradleInitDirExists = "ensure Gradle init.d exists: %w"
 	errFmtWritingGradleInitFile     = "write bitrise-build-cache.init.gradle.kts to %s, error: %w"
 )
 
-// Generate init.gradle content.
-// Recommended to save the content into $HOME/.gradle/init.d/ instead of
-// overwriting the $HOME/.gradle/init.gradle file.
 func (inventory TemplateInventory) GenerateInitGradle(templateProxy utils.TemplateProxy) (string, error) {
 	tmpl, err := templateProxy.Parse("init.gradle", gradleTemplateText)
 	if err != nil {
@@ -47,22 +44,22 @@ func (inventory TemplateInventory) WriteToGradleInit(
 	osProxy utils.OsProxy,
 	templateProxy utils.TemplateProxy,
 ) error {
-	logger.Infof("(i) Ensure ~/.gradle and ~/.gradle/init.d directories exist")
-	gradleInitDPath := filepath.Join(gradleHomePath, "init.d")
+	gradleInitDPath := paths.GradleInitDir(gradleHomePath)
+	logger.Infof("(i) Ensure Gradle home (%s) and its init.d directory exist", gradleHomePath)
 	err := osProxy.MkdirAll(gradleInitDPath, 0o755) //nolint:mnd
 	if err != nil {
 		return fmt.Errorf(errFmtEnsureGradleInitDirExists, err)
 	}
 
-	logger.Infof("(i) Generate ~/.gradle/init.d/bitrise-build-cache.init.gradle.kts")
+	initGradlePath := paths.GradleInitScript(gradleHomePath)
+	logger.Infof("(i) Generate %s", initGradlePath)
 	initGradleContent, err := inventory.GenerateInitGradle(templateProxy)
 	if err != nil {
 		return fmt.Errorf(errFmtGradleGeneration, err)
 	}
 
-	logger.Infof("(i) Write ~/.gradle/init.d/bitrise-build-cache.init.gradle.kts")
+	logger.Infof("(i) Write %s", initGradlePath)
 	{
-		initGradlePath := filepath.Join(gradleInitDPath, "bitrise-build-cache.init.gradle.kts")
 		err = osProxy.WriteFile(initGradlePath, []byte(initGradleContent), 0o755) //nolint:gosec,mnd
 		if err != nil {
 			return fmt.Errorf(errFmtWritingGradleInitFile, initGradlePath, err)

--- a/internal/config/gradle/mirrors/activate.go
+++ b/internal/config/gradle/mirrors/activate.go
@@ -113,7 +113,7 @@ func Activate(logger log.Logger, osProxy utils.OsProxy, params Params) error {
 
 	initDPath := filepath.Join(params.GradleHome, "init.d")
 	if err := osProxy.MkdirAll(initDPath, 0o755); err != nil { //nolint:mnd
-		return fmt.Errorf("ensure ~/.gradle/init.d exists: %w", err)
+		return fmt.Errorf("ensure Gradle init.d exists: %w", err)
 	}
 
 	initFilePath := filepath.Join(initDPath, InitFileName)

--- a/internal/config/gradle/mirrors/migrate.go
+++ b/internal/config/gradle/mirrors/migrate.go
@@ -1,0 +1,52 @@
+package mirrors
+
+import (
+	"fmt"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+)
+
+// MigratePrebootInitScript moves the preboot mirror init script from the default
+// Gradle home into gradleHome. Preboot has no GRADLE_USER_HOME so it writes to
+// ~/.gradle, which custom-GRADLE_USER_HOME builds never read. No-op when the homes
+// match, no source exists, or gradleHome already has one.
+func MigratePrebootInitScript(logger log.Logger, osProxy utils.OsProxy, defaultGradleHome, gradleHome string) error {
+	if defaultGradleHome == gradleHome {
+		return nil
+	}
+
+	src := paths.GradleMirrorsInitScript(defaultGradleHome)
+	content, exists, err := osProxy.ReadFileIfExists(src)
+	if err != nil {
+		return fmt.Errorf("read preboot mirror init script (%s): %w", src, err)
+	}
+	if !exists {
+		return nil
+	}
+
+	dst := paths.GradleMirrorsInitScript(gradleHome)
+	if _, dstExists, err := osProxy.ReadFileIfExists(dst); err != nil {
+		return fmt.Errorf("check mirror init script (%s): %w", dst, err)
+	} else if dstExists {
+		return nil
+	}
+
+	if err := osProxy.MkdirAll(paths.GradleInitDir(gradleHome), 0o755); err != nil {
+		return fmt.Errorf("ensure Gradle init.d exists: %w", err)
+	}
+
+	if err := osProxy.WriteFile(dst, []byte(content), 0o644); err != nil { //nolint:gosec,mnd
+		return fmt.Errorf("write mirror init script (%s): %w", dst, err)
+	}
+
+	if err := osProxy.Remove(src); err != nil {
+		return fmt.Errorf("remove preboot mirror init script (%s): %w", src, err)
+	}
+
+	logger.Infof("(i) Relocated preboot Gradle mirrors init script to %s (honoring GRADLE_USER_HOME)", dst)
+
+	return nil
+}

--- a/internal/config/gradle/mirrors/migrate_test.go
+++ b/internal/config/gradle/mirrors/migrate_test.go
@@ -1,0 +1,92 @@
+//go:build unit
+
+package mirrors_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	utilsMocks "github.com/bitrise-io/go-utils/v2/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle/mirrors"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+)
+
+func migrateTestLogger() *utilsMocks.Logger {
+	l := &utilsMocks.Logger{}
+	l.On("Infof", mock.Anything).Return()
+	l.On("Infof", mock.Anything, mock.Anything).Return()
+
+	return l
+}
+
+func writePrebootMirror(t *testing.T, gradleHome string) string {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(paths.GradleInitDir(gradleHome), 0o755))
+	src := paths.GradleMirrorsInitScript(gradleHome)
+	require.NoError(t, os.WriteFile(src, []byte("// preboot mirror"), 0o644))
+
+	return src
+}
+
+func TestMigratePrebootInitScript_movesToCustomHome(t *testing.T) {
+	defaultHome := filepath.Join(t.TempDir(), ".gradle")
+	customHome := t.TempDir()
+	src := writePrebootMirror(t, defaultHome)
+
+	err := mirrorsconfig.MigratePrebootInitScript(migrateTestLogger(), utils.DefaultOsProxy{}, defaultHome, customHome)
+	require.NoError(t, err)
+
+	movedContent, err := os.ReadFile(paths.GradleMirrorsInitScript(customHome))
+	require.NoError(t, err)
+	require.Equal(t, "// preboot mirror", string(movedContent))
+
+	_, statErr := os.Stat(src)
+	require.True(t, os.IsNotExist(statErr), "preboot script should be removed after move")
+}
+
+func TestMigratePrebootInitScript_noopWhenHomesEqual(t *testing.T) {
+	home := filepath.Join(t.TempDir(), ".gradle")
+	src := writePrebootMirror(t, home)
+
+	err := mirrorsconfig.MigratePrebootInitScript(migrateTestLogger(), utils.DefaultOsProxy{}, home, home)
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(src)
+	require.NoError(t, statErr, "script must be left untouched when homes are equal")
+}
+
+func TestMigratePrebootInitScript_noopWhenNoPrebootScript(t *testing.T) {
+	defaultHome := filepath.Join(t.TempDir(), ".gradle")
+	customHome := t.TempDir()
+
+	err := mirrorsconfig.MigratePrebootInitScript(migrateTestLogger(), utils.DefaultOsProxy{}, defaultHome, customHome)
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(paths.GradleMirrorsInitScript(customHome))
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestMigratePrebootInitScript_doesNotClobberExistingTarget(t *testing.T) {
+	defaultHome := filepath.Join(t.TempDir(), ".gradle")
+	customHome := t.TempDir()
+	src := writePrebootMirror(t, defaultHome)
+
+	require.NoError(t, os.MkdirAll(paths.GradleInitDir(customHome), 0o755))
+	dst := paths.GradleMirrorsInitScript(customHome)
+	require.NoError(t, os.WriteFile(dst, []byte("// fresh mirror"), 0o644))
+
+	err := mirrorsconfig.MigratePrebootInitScript(migrateTestLogger(), utils.DefaultOsProxy{}, defaultHome, customHome)
+	require.NoError(t, err)
+
+	dstContent, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	require.Equal(t, "// fresh mirror", string(dstContent), "existing target must not be overwritten")
+
+	_, statErr := os.Stat(src)
+	require.NoError(t, statErr, "preboot script must be left in place when target already exists")
+}

--- a/internal/config/gradle/mirrors/mirror.go
+++ b/internal/config/gradle/mirrors/mirror.go
@@ -6,6 +6,8 @@ import (
 	_ "embed"
 	"strings"
 	"unicode"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 )
 
 // RepoMirror describes a single repository that can be mirrored.
@@ -36,8 +38,7 @@ func InitTemplate() string {
 	return initTemplate
 }
 
-// InitFileName is the filename written under ~/.gradle/init.d.
-const InitFileName = "bitrise-gradle-mirrors.init.gradle.kts"
+const InitFileName = paths.GradleMirrorsInitScriptName
 
 // URLPattern is the format string for mirror URLs: URL segment.
 // The canonical un-suffixed hostname is redirected to DC-internal proxy IPs

--- a/internal/paths/gradle.go
+++ b/internal/paths/gradle.go
@@ -1,0 +1,36 @@
+package paths
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const (
+	GradleUserHomeEnvKey        = "GRADLE_USER_HOME"
+	GradleHomeRelative          = ".gradle"
+	GradleInitScriptName        = "bitrise-build-cache.init.gradle.kts"
+	GradleMirrorsInitScriptName = "bitrise-gradle-mirrors.init.gradle.kts"
+	gradleInitDir               = "init.d"
+)
+
+// GradleHome honors GRADLE_USER_HOME (verbatim), else <home>/.gradle. Gradle only
+// auto-applies init scripts from $GRADLE_USER_HOME/init.d.
+func (p Paths) GradleHome(gradleUserHomeEnv string) string {
+	if v := strings.TrimSpace(gradleUserHomeEnv); v != "" {
+		return v
+	}
+
+	return filepath.Join(p.Home, GradleHomeRelative)
+}
+
+func GradleInitDir(gradleHome string) string {
+	return filepath.Join(gradleHome, gradleInitDir)
+}
+
+func GradleInitScript(gradleHome string) string {
+	return filepath.Join(GradleInitDir(gradleHome), GradleInitScriptName)
+}
+
+func GradleMirrorsInitScript(gradleHome string) string {
+	return filepath.Join(GradleInitDir(gradleHome), GradleMirrorsInitScriptName)
+}

--- a/internal/paths/gradle_test.go
+++ b/internal/paths/gradle_test.go
@@ -1,0 +1,23 @@
+//go:build unit
+
+package paths
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPaths_GradleHome(t *testing.T) {
+	p := FromHome("/Users/alice")
+
+	assert.Equal(t, filepath.Join("/Users/alice", ".gradle"), p.GradleHome(""))
+	assert.Equal(t, filepath.Join("/Users/alice", ".gradle"), p.GradleHome("  "))
+	assert.Equal(t, "/g", p.GradleHome("/g"))
+}
+
+func TestGradleInitScriptPaths(t *testing.T) {
+	assert.Equal(t, filepath.Join("/g", "init.d"), GradleInitDir("/g"))
+	assert.Equal(t, filepath.Join("/g", "init.d", GradleInitScriptName), GradleInitScript("/g"))
+}

--- a/pkg/gradle/mirrors/activator.go
+++ b/pkg/gradle/mirrors/activator.go
@@ -13,20 +13,13 @@ import (
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle/mirrors"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/envexport"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
-// DefaultGradleHome is used when ActivatorParams.GradleHome is empty.
-const DefaultGradleHome = "~/.gradle"
-
 // ActivatorParams configures the Gradle mirrors activation.
 type ActivatorParams struct {
-	// GradleHome is the Gradle home directory. Tilde-prefixed paths are expanded.
-	// Empty means DefaultGradleHome.
+	// GradleHome is expanded as-is; empty resolves GRADLE_USER_HOME, else ~/.gradle.
 	GradleHome string
 
 	// ProjectRoot is the directory scanned for scope-gap warnings (Gradle
@@ -101,17 +94,12 @@ func NewActivator(params ActivatorParams) *Activator {
 		envs = utils.AllEnvs()
 	}
 
-	gradleHome := params.GradleHome
-	if gradleHome == "" {
-		gradleHome = DefaultGradleHome
-	}
-
 	return &Activator{
 		logger:       logger,
 		osProxy:      osProxy,
 		pathModifier: pathModifier,
 
-		gradleHome:    gradleHome,
+		gradleHome:    params.GradleHome,
 		projectRoot:   params.ProjectRoot,
 		selectedFlags: params.SelectedFlags,
 		datacenter:    params.Datacenter,
@@ -133,9 +121,18 @@ func (a *Activator) Activate(_ context.Context) error {
 	configcommon.LogCLIVersion(a.logger)
 	a.logger.TInfof("Activate Bitrise mirrors for Gradle")
 
-	gradleHome, err := a.pathModifier.AbsPath(a.gradleHome)
+	gradleHome, err := a.resolveGradleHome()
 	if err != nil {
-		return fmt.Errorf("expand Gradle home path (%s): %w", a.gradleHome, err)
+		return err
+	}
+
+	// Skip the migration for an explicit GradleHome override; only heal env-resolved homes.
+	if a.gradleHome == "" {
+		if home, herr := a.osProxy.UserHomeDir(); herr == nil {
+			if merr := mirrorsconfig.MigratePrebootInitScript(a.logger, a.osProxy, paths.FromHome(home).GradleHome(""), gradleHome); merr != nil {
+				a.logger.Warnf("Could not relocate preboot Gradle mirrors init script: %s", merr)
+			}
+		}
 	}
 
 	enabled := a.resolveEnabled()
@@ -160,6 +157,24 @@ func (a *Activator) Activate(_ context.Context) error {
 // ---------------------------------------------------------------------------
 // Private — env fallback
 // ---------------------------------------------------------------------------
+
+func (a *Activator) resolveGradleHome() (string, error) {
+	if a.gradleHome != "" {
+		abs, err := a.pathModifier.AbsPath(a.gradleHome)
+		if err != nil {
+			return "", fmt.Errorf("expand Gradle home path (%s): %w", a.gradleHome, err)
+		}
+
+		return abs, nil
+	}
+
+	home, err := a.osProxy.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+
+	return paths.FromHome(home).GradleHome(a.envs[paths.GradleUserHomeEnvKey]), nil
+}
 
 func (a *Activator) resolveEnabled() bool {
 	if a.enabled != nil {

--- a/pkg/reactnative/activator.go
+++ b/pkg/reactnative/activator.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/bitrise-io/go-utils/v2/log"
-	"github.com/bitrise-io/go-utils/v2/pathutil"
 
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
@@ -20,6 +19,7 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/dependencies"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/envexport"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/ccache"
 )
@@ -266,10 +266,14 @@ type gradleActivator struct {
 }
 
 func (g *gradleActivator) activate() error {
-	gradleHome, err := pathutil.NewPathModifier().AbsPath("~/.gradle")
+	allEnvs := utils.AllEnvs()
+
+	p, err := paths.Default()
 	if err != nil {
-		return fmt.Errorf("expand Gradle home path: %w", err)
+		return fmt.Errorf("resolve home dir: %w", err)
 	}
+
+	gradleHome := p.GradleHome(allEnvs[paths.GradleUserHomeEnvKey])
 
 	gradleParams := gradleconfig.DefaultActivateGradleParams()
 	gradleParams.Cache.Enabled = true
@@ -278,7 +282,7 @@ func (g *gradleActivator) activate() error {
 	if err := gradleconfig.Activate(
 		g.logger,
 		gradleHome,
-		utils.AllEnvs(),
+		allEnvs,
 		g.debugLogging,
 		gradleParams.TemplateInventory,
 		func(inventory gradleconfig.TemplateInventory, path string) error {

--- a/pkg/status/checker.go
+++ b/pkg/status/checker.go
@@ -7,13 +7,13 @@ package status
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
 	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/reactnative"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
@@ -46,6 +46,8 @@ type CheckerParams struct {
 	Logger         log.Logger
 	OsProxy        utils.OsProxy
 	DecoderFactory utils.DecoderFactory
+	// Envs honors GRADLE_USER_HOME when locating the init script; nil means utils.AllEnvs().
+	Envs map[string]string
 }
 
 // Checker inspects the filesystem for cache-feature activation signals.
@@ -53,6 +55,7 @@ type Checker struct {
 	logger         log.Logger
 	osProxy        utils.OsProxy
 	decoderFactory utils.DecoderFactory
+	envs           map[string]string
 }
 
 // NewChecker creates a Checker, filling in production defaults for any nil
@@ -73,10 +76,16 @@ func NewChecker(p CheckerParams) *Checker {
 		decoderFactory = utils.DefaultDecoderFactory{}
 	}
 
+	envs := p.Envs
+	if envs == nil {
+		envs = utils.AllEnvs()
+	}
+
 	return &Checker{
 		logger:         logger,
 		osProxy:        osProxy,
 		decoderFactory: decoderFactory,
+		envs:           envs,
 	}
 }
 
@@ -119,8 +128,8 @@ func (c *Checker) gradleEnabled() bool {
 		return false
 	}
 
-	initFile := filepath.Join(home, ".gradle", "init.d", "bitrise-build-cache.init.gradle.kts")
-	if _, err := c.osProxy.Stat(initFile); err != nil {
+	gradleHome := paths.FromHome(home).GradleHome(c.envs[paths.GradleUserHomeEnvKey])
+	if _, err := c.osProxy.Stat(paths.GradleInitScript(gradleHome)); err != nil {
 		return false
 	}
 

--- a/pkg/status/checker_test.go
+++ b/pkg/status/checker_test.go
@@ -73,6 +73,8 @@ func newCheckerForHome(home string) *status.Checker {
 		Logger:         mockLogger,
 		OsProxy:        osProxy,
 		DecoderFactory: decoderFactory,
+		// Empty (not nil) so an ambient GRADLE_USER_HOME can't redirect the lookup.
+		Envs: map[string]string{},
 	})
 }
 
@@ -123,6 +125,35 @@ func TestChecker_Status_Matrix(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestChecker_Gradle_HonorsCustomGradleUserHome(t *testing.T) {
+	home := t.TempDir()
+	gradleUserHome := t.TempDir()
+
+	initDir := filepath.Join(gradleUserHome, "init.d")
+	require.NoError(t, os.MkdirAll(initDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(initDir, "bitrise-build-cache.init.gradle.kts"), []byte("// stub"), 0o600))
+
+	osProxy := &utilsMocks.OsProxyMock{
+		UserHomeDirFunc: func() (string, error) { return home, nil },
+		OpenFileFunc:    os.OpenFile,
+		StatFunc:        os.Stat,
+	}
+	decoderFactory := &utilsMocks.DecoderFactoryMock{
+		DecoderFunc: func(r io.Reader) utils.Decoder { return json.NewDecoder(r) },
+	}
+
+	c := status.NewChecker(status.CheckerParams{
+		Logger:         mockLogger,
+		OsProxy:        osProxy,
+		DecoderFactory: decoderFactory,
+		Envs:           map[string]string{"GRADLE_USER_HOME": gradleUserHome},
+	})
+
+	gradle, err := c.IsEnabled(status.FeatureGradle)
+	require.NoError(t, err)
+	assert.True(t, gradle)
 }
 
 func TestChecker_XcodeDisabled_WhenBuildCacheFlagFalse(t *testing.T) {


### PR DESCRIPTION
## ACI-5159

Fixes: [ACI-5159](https://bitrise.atlassian.net/browse/ACI-5159) — Build Cache for Gradle should honor a custom `GRADLE_USER_HOME`.

### Problem
Gradle only auto-applies init scripts from `$GRADLE_USER_HOME/init.d`, but the CLI hardcoded `$HOME/.gradle`. With a custom `GRADLE_USER_HOME` (e.g. `/g`), `activate gradle` wrote its init script + `gradle.properties` where Gradle never looks → the remote Build Cache never engaged (no `🤖 Bitrise remote cache enabled` banner).

### Fix
Centralized Gradle-home resolution in `internal/paths`:
- `ResolveGradleHome(envs, modifier)` — for callers holding a `PathModifier`.
- `Paths.GradleHome(env)` — for callers with an already-resolved home (status checker).
- `GradleInitDir` / `GradleInitScript` + `GradleInitScriptName` — shared so writer and detector can't drift.

All resolve `GRADLE_USER_HOME` (verbatim when set) with a `~/.gradle` fallback — matching the gradle-plugins analytics plugin's own logic.

Routed every call site through it: `activate gradle`, `enable-for gradle`, `gradle-verification add-reference-deps`, `activate gradle-mirrors`, the React Native activator, the status checker, and the init-script writer. Removed the stale `gradleHomeNonExpanded` / `mirrors.DefaultGradleHome` fallbacks.

### gradle-plugins
No changes needed — the plugins already resolve Gradle home correctly (cache plugin via Gradle's API at runtime; analytics plugin via `GRADLE_USER_HOME` env). The bug was purely CLI-side placement.

### e2e
`feature-e2e-gradle-duckduck` and `e2e-mavencentral-mirror-duckduck` now set a custom `GRADLE_USER_HOME` and assert the init scripts land there (and **not** in `~/.gradle`). The existing remote-cache-banner check then proves the script engaged from the custom home.

### Follow-up
Restore/Save Gradle Cache steps still use `~/.gradle` — separate follow-up.

### Testing
- `make test-unit` — green (added env-aware resolver tests + a status-checker test for custom `GRADLE_USER_HOME`).
- `make lint` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5159]: https://bitrise.atlassian.net/browse/ACI-5159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ