### PR TITLE
chore: bump Go module path /v2 -> /v3 for v3.0.0 release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common.injectedVersion={{.Version}}
+      - -X github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common.injectedVersion={{.Version}}
     goos:
       - linux
       # - windows

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -13,14 +13,14 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
-	xceleratconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
+	xceleratconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // nolint:gochecknoglobals

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	keyring "github.com/zalando/go-keyring"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // 4096 < typical kernel pipe buffer (16-64KB); the Gradle init script reads stdout then stderr sequentially, a larger stderr could deadlock.

--- a/cmd/bazel/activate_bazel.go
+++ b/cmd/bazel/activate_bazel.go
@@ -10,11 +10,11 @@ import (
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/bazel"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/permhint"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/bazel"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/permhint"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // activateBazelCmd represents the activate bazel command

--- a/cmd/bazel/activate_bazel_test.go
+++ b/cmd/bazel/activate_bazel_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/bazel"
-	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/bazel"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/bazel"
+	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/bazel"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 func Test_activateBazelCmdFn(t *testing.T) {

--- a/cmd/bazel/enableForBazel.go
+++ b/cmd/bazel/enableForBazel.go
@@ -9,10 +9,10 @@ import (
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/bazel"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/bazel"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // enableForBazelCmd represents the bazel command

--- a/cmd/bazel/enableForBazel_test.go
+++ b/cmd/bazel/enableForBazel_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/bazel"
-	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/bazel"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/bazel"
+	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/bazel"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils/mocks"
 )
 
 func makeFakeJWT(orgID string) string {

--- a/cmd/browse/browse.go
+++ b/cmd/browse/browse.go
@@ -8,9 +8,9 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	browsepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/browse"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	browsepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/browse"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/ccache/activate_cpp.go
+++ b/cmd/ccache/activate_cpp.go
@@ -6,10 +6,10 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/permhint"
-	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/ccache"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/permhint"
+	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/ccache"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/ccache/collect_stats.go
+++ b/cmd/ccache/collect_stats.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/ccache"
+	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/ccache"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/ccache/health_check_storage_helper.go
+++ b/cmd/ccache/health_check_storage_helper.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/ccache"
+	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/ccache"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/ccache/set_invocation_id.go
+++ b/cmd/ccache/set_invocation_id.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/ccache"
+	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/ccache"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/ccache/start_storage_helper.go
+++ b/cmd/ccache/start_storage_helper.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/ccache"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/ccache"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/ccache/stop_storage_helper.go
+++ b/cmd/ccache/stop_storage_helper.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/ccache"
+	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/ccache"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/common/activate.go
+++ b/cmd/common/activate.go
@@ -4,8 +4,8 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/common/childstats"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/common/childstats"
 )
 
 var ActivateCmd = &cobra.Command{ //nolint:gochecknoglobals

--- a/cmd/common/activate_interactive.go
+++ b/cmd/common/activate_interactive.go
@@ -13,12 +13,12 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
-	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/bazel"
-	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/ccache"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/bazel"
+	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/ccache"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/common/activate_interactive_huh.go
+++ b/cmd/common/activate_interactive_huh.go
@@ -8,10 +8,10 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/charmbracelet/huh"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/authprompt"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/authprompt"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 type huhWizard struct{}

--- a/cmd/common/activate_interactive_test.go
+++ b/cmd/common/activate_interactive_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 func TestActivateCmd_HasInteractiveFlag(t *testing.T) {

--- a/cmd/common/auth_status_test.go
+++ b/cmd/common/auth_status_test.go
@@ -8,7 +8,7 @@ import (
 
 	keyring "github.com/zalando/go-keyring"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/oauth"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/oauth"
 )
 
 func TestCurrentAuthStatus(t *testing.T) {

--- a/cmd/common/client.go
+++ b/cmd/common/client.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/build/bazel/remote/execution/v2"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/kv_storage"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/build/bazel/remote/execution/v2"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/kv_storage"
 )
 
 const (

--- a/cmd/common/login.go
+++ b/cmd/common/login.go
@@ -8,10 +8,10 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/bitriseapi"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/oauth"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/bitriseapi"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/oauth"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 var loginWorkspace string //nolint:gochecknoglobals

--- a/cmd/common/register_child_invocation.go
+++ b/cmd/common/register_child_invocation.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	pkgcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/common"
+	pkgcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/common"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/common/register_invocation.go
+++ b/cmd/common/register_invocation.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	pkgcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/common"
+	pkgcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/common"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/common/root.go
+++ b/cmd/common/root.go
@@ -8,10 +8,10 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/refresh"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/versioncheck"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/refresh"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/versioncheck"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/common/status.go
+++ b/cmd/common/status.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/status"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/status"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/common/status_exit_integration_test.go
+++ b/cmd/common/status_exit_integration_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 )
 
 // helperEnvVar gates the helper-process branch of TestMain. When set, the

--- a/cmd/common/status_test.go
+++ b/cmd/common/status_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 	keyring "github.com/zalando/go-keyring"
 
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/reactnative"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/reactnative"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 )
 
 // runStatusCmd invokes the registered "status" cobra command with the given

--- a/cmd/common/version.go
+++ b/cmd/common/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 var VersionCmd = &cobra.Command{ //nolint:gochecknoglobals

--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -3,8 +3,8 @@ package daemon
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/daemon"
 )
 
 func resolveBackendAndPaths() (daemonpkg.Backend, daemonpkg.Paths, error) {

--- a/cmd/daemon/down.go
+++ b/cmd/daemon/down.go
@@ -6,9 +6,9 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/permhint"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/permhint"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/daemon/info.go
+++ b/cmd/daemon/info.go
@@ -13,11 +13,11 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache"
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	xcelerateconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	xcelerateconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/daemon/info_test.go
+++ b/cmd/daemon/info_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache/protocol"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache/protocol"
 )
 
 func TestProbeSocket_missingFile(t *testing.T) {

--- a/cmd/daemon/install.go
+++ b/cmd/daemon/install.go
@@ -9,9 +9,9 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/permhint"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/permhint"
 )
 
 // transientBinPrefixes mark filesystem locations whose contents the OS may prune between logins;

--- a/cmd/daemon/restart.go
+++ b/cmd/daemon/restart.go
@@ -7,9 +7,9 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/permhint"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/permhint"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/daemon/uninstall.go
+++ b/cmd/daemon/uninstall.go
@@ -7,9 +7,9 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/permhint"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/permhint"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/daemon/up.go
+++ b/cmd/daemon/up.go
@@ -7,9 +7,9 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/permhint"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/permhint"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	doctorpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/doctor"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	doctorpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/doctor"
 )
 
 const (

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	doctorpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/doctor"
+	doctorpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/doctor"
 )
 
 func okItem(name string) doctorpkg.ReportItem {

--- a/cmd/file/file.go
+++ b/cmd/file/file.go
@@ -6,8 +6,8 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	pkgfile "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/file"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	pkgfile "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/file"
 )
 
 // nolint:gochecknoglobals,dupl

--- a/cmd/gradle/activate_gradle.go
+++ b/cmd/gradle/activate_gradle.go
@@ -9,11 +9,11 @@ import (
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/permhint"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/permhint"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // ActivateGradleCmd represents the `gradle` subcommand under `activate`

--- a/cmd/gradle/activate_gradle_mirrors.go
+++ b/cmd/gradle/activate_gradle_mirrors.go
@@ -3,9 +3,9 @@ package gradle
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors"
-	mirrorspkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/gradle/mirrors"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle/mirrors"
+	mirrorspkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/gradle/mirrors"
 )
 
 var activateGradleMirrorsCmd = &cobra.Command{ //nolint:gochecknoglobals

--- a/cmd/gradle/activate_gradle_test.go
+++ b/cmd/gradle/activate_gradle_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/gradle"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/gradle"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils/mocks"
 )
 
 func Test_activateGradleCmdFn(t *testing.T) {

--- a/cmd/gradle/enable_for_gradle.go
+++ b/cmd/gradle/enable_for_gradle.go
@@ -8,11 +8,11 @@ import (
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 const (

--- a/cmd/gradle/enable_for_gradle_test.go
+++ b/cmd/gradle/enable_for_gradle_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/gradle"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/gradle"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
 )
 
 func Test_enableForGradleCmdFn(t *testing.T) {

--- a/cmd/gradle/gradleVerificationAddDeps.go
+++ b/cmd/gradle/gradleVerificationAddDeps.go
@@ -7,9 +7,9 @@ import (
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // addGradleVerificationReferenceDeps represents the gradle command

--- a/cmd/gradle/gradleVerificationWrite.go
+++ b/cmd/gradle/gradleVerificationWrite.go
@@ -12,8 +12,8 @@ import (
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 //go:embed "asset/verification-metadata.xml"

--- a/cmd/gradle/restoreGradleConfigurationCache.go
+++ b/cmd/gradle/restoreGradleConfigurationCache.go
@@ -13,12 +13,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/filegroup"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/gradle"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/filegroup"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/gradle"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 const (

--- a/cmd/gradle/restoreGradleOutputData.go
+++ b/cmd/gradle/restoreGradleOutputData.go
@@ -8,8 +8,8 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/diagnostics"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/diagnostics"
 )
 
 var restoreGradleOutputDataCmd = &cobra.Command{ //nolint:gochecknoglobals

--- a/cmd/gradle/saveGradleConfigurationCache.go
+++ b/cmd/gradle/saveGradleConfigurationCache.go
@@ -11,11 +11,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/gradle"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/hash"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/gradle"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/hash"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 const GradleConfigCacheMetadataPath = "gradle-config-cache-metadata.json"

--- a/cmd/gradle/saveGradleOutputData.go
+++ b/cmd/gradle/saveGradleOutputData.go
@@ -8,8 +8,8 @@ import (
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/diagnostics"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/diagnostics"
 )
 
 var saveGradleOutputDataCmd = &cobra.Command{ //nolint:gochecknoglobals

--- a/cmd/reactnative/activate_react_native.go
+++ b/cmd/reactnative/activate_react_native.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	rnpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/reactnative"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	rnpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/reactnative"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/reactnative/react_native.go
+++ b/cmd/reactnative/react_native.go
@@ -3,7 +3,7 @@ package reactnative
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/reactnative/run_cmd.go
+++ b/cmd/reactnative/run_cmd.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	rnpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/reactnative"
+	rnpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/reactnative"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -7,8 +7,8 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/updater"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/updater"
 )
 
 //nolint:gochecknoglobals

--- a/cmd/xcode/activate_xcode.go
+++ b/cmd/xcode/activate_xcode.go
@@ -6,11 +6,11 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/permhint"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/permhint"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 const (

--- a/cmd/xcode/activate_xcode_test.go
+++ b/cmd/xcode/activate_xcode_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/xcode"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils/mocks"
 )
 
 func TestActivateXcode_activateXcodeCmdFn(t *testing.T) {

--- a/cmd/xcode/deleteXcodeDerivedData.go
+++ b/cmd/xcode/deleteXcodeDerivedData.go
@@ -13,13 +13,13 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/filegroup"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/hash"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/deriveddata"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/filegroup"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/hash"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/deriveddata"
 )
 
 // nolint: gochecknoglobals

--- a/cmd/xcode/mocks/config_mock.go
+++ b/cmd/xcode/mocks/config_mock.go
@@ -4,8 +4,8 @@
 package mocks
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/xcode"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"sync"
 )

--- a/cmd/xcode/mocks/kv_storage.go
+++ b/cmd/xcode/mocks/kv_storage.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	context "context"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/kv_storage"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/kv_storage"
 	bytestream "google.golang.org/genproto/googleapis/bytestream"
 	grpc "google.golang.org/grpc"
 	sync "sync"

--- a/cmd/xcode/mocks/remote_execution.go
+++ b/cmd/xcode/mocks/remote_execution.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	context "context"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/build/bazel/remote/execution/v2"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/build/bazel/remote/execution/v2"
 	grpc "google.golang.org/grpc"
 	sync "sync"
 )

--- a/cmd/xcode/mocks/runner_mock.go
+++ b/cmd/xcode/mocks/runner_mock.go
@@ -5,8 +5,8 @@ package mocks
 
 import (
 	"context"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/xcodeargs"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/xcode"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/xcodeargs"
 	"sync"
 )
 

--- a/cmd/xcode/mocks/session_client.go
+++ b/cmd/xcode/mocks/session_client.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	context "context"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/llvm/session"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/session"
 	grpc "google.golang.org/grpc"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	sync "sync"

--- a/cmd/xcode/restoreXcodeDerivedDataFiles.go
+++ b/cmd/xcode/restoreXcodeDerivedDataFiles.go
@@ -11,13 +11,13 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	xa "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/analytics"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/deriveddata"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	xa "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/analytics"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/deriveddata"
 )
 
 // nolint: gochecknoglobals

--- a/cmd/xcode/saveXcodeDerivedDataFiles.go
+++ b/cmd/xcode/saveXcodeDerivedDataFiles.go
@@ -11,13 +11,13 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/hash"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	xa "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/analytics"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/deriveddata"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/hash"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	xa "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/analytics"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/deriveddata"
 )
 
 const XCodeCacheMetadataPath = "dd-metadata.json"

--- a/cmd/xcode/saveXcodeDerivedDataFiles_test.go
+++ b/cmd/xcode/saveXcodeDerivedDataFiles_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	xcodeMocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/deriveddata/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/xcode"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	xcodeMocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/deriveddata/mocks"
 )
 
 func Test_saveXcodeDerivedDataFilesCmdFn(t *testing.T) {

--- a/cmd/xcode/xcelerate.go
+++ b/cmd/xcode/xcelerate.go
@@ -3,7 +3,7 @@ package xcode
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 )
 
 var xcelerateCommand = &cobra.Command{ //nolint:gochecknoglobals

--- a/cmd/xcode/xcelerate_start_proxy.go
+++ b/cmd/xcode/xcelerate_start_proxy.go
@@ -15,13 +15,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/proxy"
-	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/build/bazel/remote/execution/v2"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/kv_storage"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/proxy"
+	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/build/bazel/remote/execution/v2"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/kv_storage"
 )
 
 const (

--- a/cmd/xcode/xcelerate_start_proxy_test.go
+++ b/cmd/xcode/xcelerate_start_proxy_test.go
@@ -18,13 +18,13 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode/mocks"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/build/bazel/remote/execution/v2"
-	llvmkv "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/llvm/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/llvm/session"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/xcode"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/xcode/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/build/bazel/remote/execution/v2"
+	llvmkv "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/session"
 )
 
 func Test_XcelerateProxy(t *testing.T) {

--- a/cmd/xcode/xcelerate_stop_proxy.go
+++ b/cmd/xcode/xcelerate_stop_proxy.go
@@ -10,9 +10,9 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // This command should go under an xcelerate subcommand together with stop-xcode-proxy IMO

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -22,17 +22,17 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/analytics/multiplatform"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/invocations"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/analytics"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/xcodeargs"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/common/childstats"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/llvm/session"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/analytics/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/invocations"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/analytics"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/xcodeargs"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/common/childstats"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/session"
 )
 
 const (

--- a/cmd/xcode/xcodebuild_local_log_mock_test.go
+++ b/cmd/xcode/xcodebuild_local_log_mock_test.go
@@ -4,7 +4,7 @@
 package xcode
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/invocations"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/invocations"
 	"sync"
 )
 

--- a/cmd/xcode/xcodebuild_local_log_test.go
+++ b/cmd/xcode/xcodebuild_local_log_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/invocations"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/xcodeargs"
-	xcodeargsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/xcodeargs/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/invocations"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/xcodeargs"
+	xcodeargsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/xcodeargs/mocks"
 )
 
 type fakeXcodeRunner struct {

--- a/cmd/xcode/xcodebuild_relation_mock_test.go
+++ b/cmd/xcode/xcodebuild_relation_mock_test.go
@@ -4,7 +4,7 @@
 package xcode
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/analytics/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/analytics/multiplatform"
 	"sync"
 )
 

--- a/cmd/xcode/xcodebuild_relation_test.go
+++ b/cmd/xcode/xcodebuild_relation_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/analytics/multiplatform"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/analytics"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/analytics/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/analytics"
 )
 
 var relationTestLogger = newRelationTestLogger() //nolint:gochecknoglobals

--- a/cmd/xcode/xcodebuild_test.go
+++ b/cmd/xcode/xcodebuild_test.go
@@ -12,13 +12,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode/mocks"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/xcodeargs"
-	xcodeargsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/xcodeargs/mocks"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/llvm/session"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/xcode"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/xcode/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/xcodeargs"
+	xcodeargsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/xcodeargs/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/session"
 )
 
 func Test_xcodebuildCmdFn(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bitrise-io/bitrise-build-cache-cli/v2
+module github.com/bitrise-io/bitrise-build-cache-cli/v3
 
 go 1.24.0
 

--- a/internal/analytics/multiplatform/invocations.go
+++ b/internal/analytics/multiplatform/invocations.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 // Invocation is the analytics payload for a run command, sent for every execution.

--- a/internal/authprompt/authprompt.go
+++ b/internal/authprompt/authprompt.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
 )
 
 func Group(workspaceID, authToken *string) *huh.Group {

--- a/internal/browse/url.go
+++ b/internal/browse/url.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
 )
 
 var ErrMissingWorkspace = errors.New("BuildURL: WorkspaceID is required")

--- a/internal/build_cache/kv/client.go
+++ b/internal/build_cache/kv/client.go
@@ -15,9 +15,9 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/build/bazel/remote/execution/v2"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/kv_storage"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/build/bazel/remote/execution/v2"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/kv_storage"
 )
 
 //go:generate moq -rm -stub -pkg mocks -out ./mocks/kv_storage.go ./../../../proto/kv_storage KVStorageClient

--- a/internal/build_cache/kv/download_multi.go
+++ b/internal/build_cache/kv/download_multi.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/retry"
 	"github.com/dustin/go-humanize"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/filegroup"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/filegroup"
 )
 
 type DownloadFilesStats struct {

--- a/internal/build_cache/kv/download_test.go
+++ b/internal/build_cache/kv/download_test.go
@@ -15,8 +15,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv/mocks"
 )
 
 var downloadTestData = []byte("test content") //nolint:gochecknoglobals

--- a/internal/build_cache/kv/methods.go
+++ b/internal/build_cache/kv/methods.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
-	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/build/bazel/remote/execution/v2"
+	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/build/bazel/remote/execution/v2"
 )
 
 type PutParams struct {

--- a/internal/build_cache/kv/mocks/kv_storage.go
+++ b/internal/build_cache/kv/mocks/kv_storage.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	context "context"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/kv_storage"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/kv_storage"
 	bytestream "google.golang.org/genproto/googleapis/bytestream"
 	grpc "google.golang.org/grpc"
 	sync "sync"

--- a/internal/build_cache/kv/upload.go
+++ b/internal/build_cache/kv/upload.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/hash"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/hash"
 )
 
 func (c *Client) UploadFileToBuildCache(ctx context.Context, filePath, key string) error {

--- a/internal/build_cache/kv/upload_multi.go
+++ b/internal/build_cache/kv/upload_multi.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/retry"
 	"github.com/dustin/go-humanize"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/filegroup"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/filegroup"
 )
 
 type UploadFilesStats struct {

--- a/internal/build_cache/kv/upload_test.go
+++ b/internal/build_cache/kv/upload_test.go
@@ -13,9 +13,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv/mocks"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/slicebuf"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/slicebuf"
 )
 
 var uploadTestData = []byte("test content") //nolint:gochecknoglobals

--- a/internal/ccache/analytics/client.go
+++ b/internal/ccache/analytics/client.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/analytics/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/analytics/multiplatform"
 )
 
 // Client sends ccache analytics to the Bitrise backend.

--- a/internal/ccache/analytics/invocations.go
+++ b/internal/ccache/analytics/invocations.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/analytics/multiplatform"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/analytics/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 //nolint:gochecknoglobals

--- a/internal/ccache/analytics/invocations_test.go
+++ b/internal/ccache/analytics/invocations_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 // sampleStatsOutput is representative `ccache -v -v -s` text output.

--- a/internal/ccache/analytics/types.go
+++ b/internal/ccache/analytics/types.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/analytics/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/analytics/multiplatform"
 )
 
 // CcacheStats holds statistics parsed from `ccache -v -v -s`.

--- a/internal/ccache/ipc_client.go
+++ b/internal/ccache/ipc_client.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache/protocol"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache/protocol"
 )
 
 const (

--- a/internal/ccache/ipc_client_test.go
+++ b/internal/ccache/ipc_client_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache/protocol"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache/protocol"
 )
 
 // shortTempSocket creates a Unix socket path short enough for macOS (< 104 chars).

--- a/internal/ccache/ipc_server.go
+++ b/internal/ccache/ipc_server.go
@@ -12,9 +12,9 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/gofrs/uuid/v5"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache/protocol"
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache/protocol"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 type IpcServer struct {

--- a/internal/ccache/ipc_server_integration_test.go
+++ b/internal/ccache/ipc_server_integration_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache/protocol"
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache/protocol"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 // integrationTempSocket creates a Unix socket path short enough for macOS (< 104 chars).

--- a/internal/ccache/ipc_server_test.go
+++ b/internal/ccache/ipc_server_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 func Test_NewServer_initializes_activeInvocationID(t *testing.T) {

--- a/internal/ccache/protocol/ccache_ipc_test.go
+++ b/internal/ccache/protocol/ccache_ipc_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache/protocol"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache/protocol"
 )
 
 func Test_WriteReadGreeting(t *testing.T) {

--- a/internal/ccache/request_processor.go
+++ b/internal/ccache/request_processor.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache/protocol"
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache/protocol"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 type requestProcessor struct {

--- a/internal/ccache/request_processor_test.go
+++ b/internal/ccache/request_processor_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache/protocol"
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache/protocol"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 // connStub implements io.ReadWriter using separate read/write buffers.

--- a/internal/config/bazel/activate_bazel_params.go
+++ b/internal/config/bazel/activate_bazel_params.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 type CacheParams struct {

--- a/internal/config/bazel/activate_bazel_params_test.go
+++ b/internal/config/bazel/activate_bazel_params_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 func Test_ActivateBazelParams(t *testing.T) {

--- a/internal/config/bazel/bazel_config.go
+++ b/internal/config/bazel/bazel_config.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/stringmerge"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/stringmerge"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 //go:embed bazelrc.gotemplate

--- a/internal/config/bazel/bazel_config_generate_test.go
+++ b/internal/config/bazel/bazel_config_generate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 func Test_Generate(t *testing.T) {

--- a/internal/config/bazel/bazel_config_write_test.go
+++ b/internal/config/bazel/bazel_config_write_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils/mocks"
 )
 
 func Test_WriteToBazelrc(t *testing.T) {

--- a/internal/config/bazel/migrator.go
+++ b/internal/config/bazel/migrator.go
@@ -3,7 +3,7 @@ package bazelconfig
 import (
 	"fmt"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
 )
 
 // SidecarMigrator implements toolconfig.Migrator for the bazel sidecar.

--- a/internal/config/bazel/sidecar.go
+++ b/internal/config/bazel/sidecar.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
 )
 
 // Sidecar is the bazel activation provenance file written next to ~/.bazelrc.

--- a/internal/config/ccache/config.go
+++ b/internal/config/ccache/config.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 const (

--- a/internal/config/ccache/migrator.go
+++ b/internal/config/ccache/migrator.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // ConfigMigrator implements toolconfig.Migrator for ~/.bitrise/cache/ccache/config.json.

--- a/internal/config/common/auth.go
+++ b/internal/config/common/auth.go
@@ -8,7 +8,7 @@ import (
 	"os/user"
 	"strings"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
 )
 
 const (

--- a/internal/config/common/auth_test.go
+++ b/internal/config/common/auth_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
 )
 
 type fakeAuthLoader struct {

--- a/internal/config/common/authsource.go
+++ b/internal/config/common/authsource.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
 )
 
 // AuthDescription is the shared description of a resolved credential, consumed

--- a/internal/config/common/authsource_test.go
+++ b/internal/config/common/authsource_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
 )
 
 func TestSourceLabel(t *testing.T) {

--- a/internal/config/common/cli_version.go
+++ b/internal/config/common/cli_version.go
@@ -12,7 +12,7 @@ import (
 
 // injectedVersion is the CLI version stamped at build time via:
 //
-//	-ldflags "-X github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common.injectedVersion=<ver>"
+//	-ldflags "-X github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common.injectedVersion=<ver>"
 //
 // Goreleaser sets this on every release build. Local `go build` leaves it
 // empty and we fall back to debug.ReadBuildInfo below.

--- a/internal/config/common/endpoint.go
+++ b/internal/config/common/endpoint.go
@@ -3,7 +3,7 @@ package common
 import (
 	"slices"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
 )
 
 const datacenterEnvKey = "BITRISE_DEN_VM_DATACENTER"

--- a/internal/config/common/mocks/benchmark_phase_provider.go
+++ b/internal/config/common/mocks/benchmark_phase_provider.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	"sync"
 )
 

--- a/internal/config/gradle/activate.go
+++ b/internal/config/gradle/activate.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
 )
 
 const (

--- a/internal/config/gradle/activate_for_gradle_params.go
+++ b/internal/config/gradle/activate_for_gradle_params.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/envexport"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/envexport"
 )
 
 const (

--- a/internal/config/gradle/activate_for_gradle_params_test.go
+++ b/internal/config/gradle/activate_for_gradle_params_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	commonmocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/mocks"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	commonmocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
 )
 
 func Test_activateGradleParams(t *testing.T) {

--- a/internal/config/gradle/benchmark.go
+++ b/internal/config/gradle/benchmark.go
@@ -3,7 +3,7 @@ package gradleconfig
 import (
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 // EnvExporter abstracts environment variable export for testability.

--- a/internal/config/gradle/benchmark_test.go
+++ b/internal/config/gradle/benchmark_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	commonmocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	commonmocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common/mocks"
 )
 
 type noopExporter struct{}

--- a/internal/config/gradle/gradle_properties_from_params.go
+++ b/internal/config/gradle/gradle_properties_from_params.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/stringmerge"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/stringmerge"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 const (

--- a/internal/config/gradle/gradle_properties_from_params_test.go
+++ b/internal/config/gradle/gradle_properties_from_params_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils/mocks"
 )
 
 func Test_gradlePropertiesFromParams(t *testing.T) {

--- a/internal/config/gradle/gradleconfig.go
+++ b/internal/config/gradle/gradleconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 //go:embed initd.gradle.kts.gotemplate

--- a/internal/config/gradle/gradleconfig_write_test.go
+++ b/internal/config/gradle/gradleconfig_write_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils/mocks"
 )
 
 func Test_writeGradleInitGradle(t *testing.T) {

--- a/internal/config/gradle/migrator.go
+++ b/internal/config/gradle/migrator.go
@@ -3,7 +3,7 @@ package gradleconfig
 import (
 	"fmt"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
 )
 
 // SidecarMigrator implements toolconfig.Migrator for the gradle sidecar.

--- a/internal/config/gradle/mirror_url.go
+++ b/internal/config/gradle/mirror_url.go
@@ -3,7 +3,7 @@ package gradleconfig
 import (
 	"fmt"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle/mirrors"
 )
 
 const (

--- a/internal/config/gradle/mirrors/activate.go
+++ b/internal/config/gradle/mirrors/activate.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // EnabledEnvKey is the env var that gates mirror activation.

--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle/mirrors"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 func TestActivate(t *testing.T) {

--- a/internal/config/gradle/mirrors/scope_gap.go
+++ b/internal/config/gradle/mirrors/scope_gap.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // gradleScriptCandidates are the script files scanned at activation time.

--- a/internal/config/gradle/mirrors/scope_gap_test.go
+++ b/internal/config/gradle/mirrors/scope_gap_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle/mirrors"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 func TestLogScopeGapWarnings(t *testing.T) {

--- a/internal/config/gradle/sidecar.go
+++ b/internal/config/gradle/sidecar.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
 )
 
 // Sidecar is the gradle activation provenance file written next to the

--- a/internal/config/multiplatform/config.go
+++ b/internal/config/multiplatform/config.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 const (

--- a/internal/config/multiplatform/register.go
+++ b/internal/config/multiplatform/register.go
@@ -1,8 +1,8 @@
 package multiplatform
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 func init() { //nolint:gochecknoinits

--- a/internal/config/reactnative/config.go
+++ b/internal/config/reactnative/config.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 const (

--- a/internal/config/reactnative/config_test.go
+++ b/internal/config/reactnative/config_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/reactnative"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/reactnative"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils/mocks"
 )
 
 func TestConfig_SaveAndRead_RoundTrip(t *testing.T) {

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -13,12 +13,12 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/shirou/gopsutil/v4/process"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/envexport"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/envexport"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 const (

--- a/internal/config/xcelerate/benchmark.go
+++ b/internal/config/xcelerate/benchmark.go
@@ -3,7 +3,7 @@ package xcelerate
 import (
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 // EnvExporter abstracts environment variable export for testability.

--- a/internal/config/xcelerate/benchmark_test.go
+++ b/internal/config/xcelerate/benchmark_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	commonmocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/mocks"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	commonmocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
 )
 
 type noopExporter struct{}

--- a/internal/config/xcelerate/config.go
+++ b/internal/config/xcelerate/config.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 const (

--- a/internal/config/xcelerate/config_test.go
+++ b/internal/config/xcelerate/config_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	commonmocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/mocks"
-	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	commonmocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common/mocks"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils/mocks"
 )
 
 func TestConfig_Save(t *testing.T) {

--- a/internal/config/xcelerate/migrator.go
+++ b/internal/config/xcelerate/migrator.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // ConfigMigrator implements toolconfig.Migrator for ~/.bitrise-xcelerate/config.json.

--- a/internal/config/xcelerate/paths.go
+++ b/internal/config/xcelerate/paths.go
@@ -3,8 +3,8 @@ package xcelerate
 import (
 	"path/filepath"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 const (

--- a/internal/daemon/backend.go
+++ b/internal/daemon/backend.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"runtime"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/exec"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/exec"
 )
 
 var ErrUnsupportedPlatform = errors.New("daemon install is only supported on macOS (launchd) and Linux (systemd)")

--- a/internal/daemon/binary.go
+++ b/internal/daemon/binary.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 )
 
 const stableBinName = "bitrise-build-cache"

--- a/internal/daemon/paths.go
+++ b/internal/daemon/paths.go
@@ -3,7 +3,7 @@ package daemon
 import (
 	"fmt"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 )
 
 // Paths is an alias of the shared internal/paths.Paths so external callers

--- a/internal/dependencies/cli.go
+++ b/internal/dependencies/cli.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	cliBinaryName = "bitrise-build-cache"
-	cliModulePath = "github.com/bitrise-io/bitrise-build-cache-cli/v2"
+	cliModulePath = "github.com/bitrise-io/bitrise-build-cache-cli/v3"
 	// InstallDir is the directory where dependency binaries (CLI, ccache) are installed.
 	InstallDir = "/usr/local/bin"
 )

--- a/internal/doctor/check_auth.go
+++ b/internal/doctor/check_auth.go
@@ -3,7 +3,7 @@ package doctor
 import (
 	"context"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 func (d *Doctor) authCheck() Check {

--- a/internal/doctor/check_auth_backend.go
+++ b/internal/doctor/check_auth_backend.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 const (

--- a/internal/doctor/check_ccache.go
+++ b/internal/doctor/check_ccache.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"time"
 
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 func (d *Doctor) ccacheHelperCheck() Check {

--- a/internal/doctor/check_xcelerate.go
+++ b/internal/doctor/check_xcelerate.go
@@ -12,9 +12,9 @@ import (
 	"syscall"
 	"time"
 
-	xceleratconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	xceleratconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 func (d *Doctor) xcelerateProxyCheck() Check {

--- a/internal/doctor/check_xcelerate_xcconfig.go
+++ b/internal/doctor/check_xcelerate_xcconfig.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	xceleratconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	xceleratconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 func (d *Doctor) xcelerateXcconfigCheck() Check {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -7,12 +7,12 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/refresh"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/refresh"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 type State string

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -18,10 +18,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
 )
 
 // ──────────────────────────── fakes ────────────────────────────

--- a/internal/doctor/fix_auth_prompt.go
+++ b/internal/doctor/fix_auth_prompt.go
@@ -3,7 +3,7 @@ package doctor
 import (
 	"fmt"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/authprompt"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/authprompt"
 )
 
 type AuthPromptFixer struct {

--- a/internal/doctor/fix_daemon_restart.go
+++ b/internal/doctor/fix_daemon_restart.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/daemon"
 )
 
 type DaemonRestartFixer struct {

--- a/internal/doctor/fix_daemon_up.go
+++ b/internal/doctor/fix_daemon_up.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/daemon"
 )
 
 type DaemonUpFixer struct {

--- a/internal/doctor/fix_update.go
+++ b/internal/doctor/fix_update.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/updater"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/updater"
 )
 
 type UpdateFixer struct {

--- a/internal/envexport/envexport.go
+++ b/internal/envexport/envexport.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/exec"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/stringmerge"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/exec"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/stringmerge"
 )
 
 // EnvExporter exports environment variables to the current process and CI-specific mechanisms.

--- a/internal/filegroup/file_group_info.go
+++ b/internal/filegroup/file_group_info.go
@@ -17,7 +17,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/pkg/xattr"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/hash"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/hash"
 )
 
 type Info struct {

--- a/internal/gradle/gradle.go
+++ b/internal/gradle/gradle.go
@@ -3,7 +3,7 @@ package gradle
 import (
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
 )
 
 type Cache struct {

--- a/internal/gradle/key.go
+++ b/internal/gradle/key.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 type CacheKeyParams struct {

--- a/internal/gradle/metadata.go
+++ b/internal/gradle/metadata.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/filegroup"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/filegroup"
 )
 
 const metadataVersion = 1

--- a/internal/hash/blob_hasher.go
+++ b/internal/hash/blob_hasher.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/zeebo/blake3"
 
-	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/build/bazel/remote/execution/v2"
+	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/build/bazel/remote/execution/v2"
 )
 
 func NewBlobHasher(hash remoteexecution.DigestFunction_Value) hash.Hash {

--- a/internal/invocations/invocations.go
+++ b/internal/invocations/invocations.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 )
 
 type Source string

--- a/internal/invocations/invocations_test.go
+++ b/internal/invocations/invocations_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 )
 
 const canonicalRecordPath = "../../docs/canonical-record.ndjson"

--- a/internal/logio/writer_test.go
+++ b/internal/logio/writer_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/logio"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/logio"
 )
 
 // captureLogger satisfies the subset of go-utils log.Logger that Writer

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
 )
 
 // Credentials is the OAuth login credential, persisted in the OS keychain as a

--- a/internal/refresh/migrate.go
+++ b/internal/refresh/migrate.go
@@ -4,11 +4,11 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"golang.org/x/mod/semver"
 
-	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/bazel"
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle"
-	xcelerateconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
+	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/bazel"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
+	xcelerateconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
 )
 
 // DefaultMigrators returns the per-tool migrators refresh dispatches on

--- a/internal/refresh/migrate_test.go
+++ b/internal/refresh/migrate_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
 )
 
 type recordingMigrator struct {

--- a/internal/refresh/notify.go
+++ b/internal/refresh/notify.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"golang.org/x/mod/semver"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
 )
 
 // CurrentConfigVersions returns the semver each tool's persisted config should

--- a/internal/refresh/notify_test.go
+++ b/internal/refresh/notify_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
 )
 
 func TestNeedsNudge_majorBump(t *testing.T) {

--- a/internal/refresh/scanner.go
+++ b/internal/refresh/scanner.go
@@ -4,12 +4,12 @@
 package refresh
 
 import (
-	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/bazel"
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle"
-	xcelerateconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/toolconfig"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/bazel"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
+	xcelerateconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // Scan returns one Sample per tool with a config present on disk.

--- a/internal/updater/manual.go
+++ b/internal/updater/manual.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/logio"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/logio"
 )
 
 const InstallerURL = "https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh"

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/daemon"
+	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/daemon"
 )
 
 type Options struct {

--- a/internal/utils/content.go
+++ b/internal/utils/content.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/stringmerge"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/stringmerge"
 )
 
 func AddContentOrCreateFile(

--- a/internal/utils/content_test.go
+++ b/internal/utils/content_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils/mocks"
 )
 
 func TestActivateXcode_AddContentOrCreateFile(t *testing.T) {

--- a/internal/utils/mocks/command_mock.go
+++ b/internal/utils/mocks/command_mock.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 	"os"
 	"sync"
 	"syscall"

--- a/internal/utils/mocks/decoder_factory_mock.go
+++ b/internal/utils/mocks/decoder_factory_mock.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 	"io"
 	"sync"
 )

--- a/internal/utils/mocks/decoder_mock.go
+++ b/internal/utils/mocks/decoder_mock.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 	"sync"
 )
 

--- a/internal/utils/mocks/encoder_factory_mock.go
+++ b/internal/utils/mocks/encoder_factory_mock.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 	"io"
 	"sync"
 )

--- a/internal/utils/mocks/encoder_mock.go
+++ b/internal/utils/mocks/encoder_mock.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 	"sync"
 )
 

--- a/internal/utils/mocks/os_proxy_mock.go
+++ b/internal/utils/mocks/os_proxy_mock.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 	"os"
 	"sync"
 )

--- a/internal/versioncheck/run_test.go
+++ b/internal/versioncheck/run_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"testing"
 	"time"
 

--- a/internal/versioncheck/state.go
+++ b/internal/versioncheck/state.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 )
 
 const StateFile = "version-state.json"

--- a/internal/versioncheck/state_test.go
+++ b/internal/versioncheck/state_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"testing"
 	"time"
 

--- a/internal/xcelerate/analytics/cache_operations.go
+++ b/internal/xcelerate/analytics/cache_operations.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-retryablehttp"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 func NewCacheOperation(startT time.Time, operationType string, metadata *common.CacheConfigMetadata) *CacheOperation {

--- a/internal/xcelerate/analytics/invocations.go
+++ b/internal/xcelerate/analytics/invocations.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 type InvocationRunStats struct {

--- a/internal/xcelerate/deriveddata/cache_key.go
+++ b/internal/xcelerate/deriveddata/cache_key.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 type CacheKeyParams struct {

--- a/internal/xcelerate/deriveddata/metadata.go
+++ b/internal/xcelerate/deriveddata/metadata.go
@@ -11,8 +11,8 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/dustin/go-humanize"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/filegroup"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/filegroup"
 )
 
 const metadataVersion = 1

--- a/internal/xcelerate/deriveddata/mocks/tracker_mock.go
+++ b/internal/xcelerate/deriveddata/mocks/tracker_mock.go
@@ -4,8 +4,8 @@
 package mocks
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/deriveddata"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/deriveddata"
 	"sync"
 	"time"
 )

--- a/internal/xcelerate/deriveddata/tracker.go
+++ b/internal/xcelerate/deriveddata/tracker.go
@@ -7,8 +7,8 @@ import (
 	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 //go:generate moq -out mocks/tracker_mock.go -pkg mocks . StepAnalyticsTracker

--- a/internal/xcelerate/proxy/blob.go
+++ b/internal/xcelerate/proxy/blob.go
@@ -3,8 +3,8 @@ package proxy
 import (
 	"encoding/hex"
 
-	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/build/bazel/remote/execution/v2"
-	llvmcas "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/llvm/cas"
+	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/build/bazel/remote/execution/v2"
+	llvmcas "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/cas"
 )
 
 const digestFunction = remoteexecution.DigestFunction_BLAKE3

--- a/internal/xcelerate/proxy/mocks/client.go
+++ b/internal/xcelerate/proxy/mocks/client.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	"context"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/proxy"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/proxy"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"io"
 	"sync"

--- a/internal/xcelerate/proxy/proxy.go
+++ b/internal/xcelerate/proxy/proxy.go
@@ -16,12 +16,12 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/hash"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/slicebuf"
-	llvmcas "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/llvm/cas"
-	llvmkv "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/llvm/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/llvm/session"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/hash"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/slicebuf"
+	llvmcas "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/cas"
+	llvmkv "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/session"
 )
 
 var (

--- a/internal/xcelerate/proxy/proxy_test.go
+++ b/internal/xcelerate/proxy/proxy_test.go
@@ -14,11 +14,11 @@ import (
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/test/bufconn"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/proxy"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/proxy/mocks"
-	llvmcas "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/llvm/cas"
-	llvmkv "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/llvm/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/proxy"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/proxy/mocks"
+	llvmcas "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/cas"
+	llvmkv "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/kv"
 )
 
 func Test_Proxy_PushDisabled(t *testing.T) {

--- a/internal/xcelerate/xcodeargs/args_test.go
+++ b/internal/xcelerate/xcodeargs/args_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/xcodeargs"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/xcodeargs"
 )
 
 func Test_DefaultXcodeArgs(t *testing.T) {

--- a/internal/xcelerate/xcodeargs/mocks/args_mock.go
+++ b/internal/xcelerate/xcodeargs/mocks/args_mock.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/xcodeargs"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcelerate/xcodeargs"
 	"sync"
 )
 

--- a/internal/xcelerate/xcodeargs/runner.go
+++ b/internal/xcelerate/xcodeargs/runner.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
 )
 
 type RunStats struct {

--- a/main.go
+++ b/main.go
@@ -1,18 +1,18 @@
 package main
 
 import (
-	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/auth"
-	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/bazel"
-	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/browse"
-	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/ccache"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
-	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/daemon"
-	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/doctor"
-	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/file"
-	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/gradle"
-	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/reactnative"
-	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/update"
-	_ "github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/xcode"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/auth"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/bazel"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/browse"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/ccache"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/daemon"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/doctor"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/file"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/gradle"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/reactnative"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/update"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/xcode"
 )
 
 func main() {

--- a/pkg/browse/browser.go
+++ b/pkg/browse/browser.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/browse"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/browse"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 )
 
 // ciProviderUnknown filters the dashboard's invocation list to local runs

--- a/pkg/browse/browser_test.go
+++ b/pkg/browse/browser_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/browse"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/browse"
 )
 
 // browse_ErrNoOpener returns the internal sentinel so the public-API

--- a/pkg/ccache/activator.go
+++ b/pkg/ccache/activator.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/auth/keychain"
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // ---------------------------------------------------------------------------

--- a/pkg/ccache/activator_test.go
+++ b/pkg/ccache/activator_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 	keyring "github.com/zalando/go-keyring"
 
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils/mocks"
-	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/ccache"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils/mocks"
+	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/ccache"
 )
 
 var mockLogger = newMockLogger() //nolint:gochecknoglobals

--- a/pkg/ccache/storage_helper.go
+++ b/pkg/ccache/storage_helper.go
@@ -16,16 +16,16 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/google/uuid"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	iccache "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache"
-	ccacheanalytics "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache/analytics"
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/exec"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	pkgcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/common/childstats"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	iccache "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache"
+	ccacheanalytics "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache/analytics"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/exec"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	pkgcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/common/childstats"
 )
 
 // ---------------------------------------------------------------------------

--- a/pkg/common/childstats/childstats.go
+++ b/pkg/common/childstats/childstats.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 )
 
 const (

--- a/pkg/common/invocation_registry.go
+++ b/pkg/common/invocation_registry.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/analytics/multiplatform"
-	ccacheanalytics "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache/analytics"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/analytics/multiplatform"
+	ccacheanalytics "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache/analytics"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // ---------------------------------------------------------------------------

--- a/pkg/common/invocation_registry_test.go
+++ b/pkg/common/invocation_registry_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/analytics/multiplatform"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/analytics/multiplatform"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
 )
 
 type stubInvocationsAPI struct {

--- a/pkg/file/helper.go
+++ b/pkg/file/helper.go
@@ -14,10 +14,10 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/google/uuid"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/build_cache/kv"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/exec"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/build_cache/kv"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/exec"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // ---------------------------------------------------------------------------

--- a/pkg/gradle/mirrors/activator.go
+++ b/pkg/gradle/mirrors/activator.go
@@ -10,10 +10,10 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/envexport"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle/mirrors"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/envexport"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // ---------------------------------------------------------------------------

--- a/pkg/gradle/mirrors/activator_test.go
+++ b/pkg/gradle/mirrors/activator_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/gradle/mirrors"
+	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle/mirrors"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/gradle/mirrors"
 )
 
 func boolPtr(b bool) *bool { return &b }

--- a/pkg/reactnative/activator.go
+++ b/pkg/reactnative/activator.go
@@ -12,16 +12,16 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle"
-	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
-	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/reactnative"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/dependencies"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/envexport"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/ccache"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
+	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/reactnative"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/dependencies"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/envexport"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/ccache"
 )
 
 // ---------------------------------------------------------------------------

--- a/pkg/reactnative/activator_test.go
+++ b/pkg/reactnative/activator_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/reactnative"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/reactnative"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 func TestActivator_saveReactNativeMarker_WritesEnabledTrue(t *testing.T) {

--- a/pkg/reactnative/post_run_deps.go
+++ b/pkg/reactnative/post_run_deps.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/analytics/multiplatform"
-	ccacheanalytics "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache/analytics"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/ccache"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/common/childstats"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/analytics/multiplatform"
+	ccacheanalytics "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache/analytics"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/ccache"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/common/childstats"
 )
 
 // ---------------------------------------------------------------------------

--- a/pkg/reactnative/runner.go
+++ b/pkg/reactnative/runner.go
@@ -9,13 +9,13 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/google/uuid"
 
-	ccacheipc "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/ccache"
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
-	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/multiplatform"
-	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/reactnative"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/exec"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	ccacheipc "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/ccache"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
+	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/reactnative"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/exec"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // MsgRNNotActivated is the warning emitted when `react-native run` is invoked

--- a/pkg/reactnative/wrap/detect.go
+++ b/pkg/reactnative/wrap/detect.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/status"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/status"
 )
 
 // OptOutEnv, when set to "0", skips detection entirely and returns a

--- a/pkg/status/checker.go
+++ b/pkg/status/checker.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/reactnative"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/reactnative"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 // Feature names accepted by IsEnabled and the `--feature` flag.

--- a/pkg/status/checker_test.go
+++ b/pkg/status/checker_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/ccache"
-	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/reactnative"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
-	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils/mocks"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/status"
+	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
+	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/reactnative"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	utilsMocks "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils/mocks"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/status"
 )
 
 type featureBits struct {

--- a/proto/kv_storage/kv_storage.pb.go
+++ b/proto/kv_storage/kv_storage.pb.go
@@ -78,7 +78,7 @@ const file_kv_storage_kv_storage_proto_rawDesc = "" +
 	"\x03Get\x12\x1e.google.bytestream.ReadRequest\x1a\x1f.google.bytestream.ReadResponse0\x01\x12J\n" +
 	"\x03Put\x12\x1f.google.bytestream.WriteRequest\x1a .google.bytestream.WriteResponse(\x01\x12D\n" +
 	"\x06Delete\x12\x1e.google.bytestream.ReadRequest\x1a\x1a.kv_storage.DeleteResponse\x12f\n" +
-	"\vWriteStatus\x12*.google.bytestream.QueryWriteStatusRequest\x1a+.google.bytestream.QueryWriteStatusResponseB=Z;github.com/bitrise-io/bitrise-build-cache-cli/v2/kv_storageb\x06proto3"
+	"\vWriteStatus\x12*.google.bytestream.QueryWriteStatusRequest\x1a+.google.bytestream.QueryWriteStatusResponseB=Z;github.com/bitrise-io/bitrise-build-cache-cli/v3/kv_storageb\x06proto3"
 
 var (
 	file_kv_storage_kv_storage_proto_rawDescOnce sync.Once

--- a/proto/kv_storage/kv_storage.proto
+++ b/proto/kv_storage/kv_storage.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "google/bytestream/bytestream.proto";
 
 package kv_storage;
-option go_package = "github.com/bitrise-io/bitrise-build-cache-cli/v2/kv_storage";
+option go_package = "github.com/bitrise-io/bitrise-build-cache-cli/v3/kv_storage";
 
 message DeleteResponse {
   uint32 ok =1;

--- a/proto/llvm/cas/compilation_caching_cas.pb.go
+++ b/proto/llvm/cas/compilation_caching_cas.pb.go
@@ -1020,7 +1020,7 @@ const file_llvm_cas_compilation_caching_cas_proto_rawDesc = "" +
 	"\x03Put\x12/.compilation_cache_service.cas.v1.CASPutRequest\x1a0.compilation_cache_service.cas.v1.CASPutResponse\"\x00\x12m\n" +
 	"\x04Load\x120.compilation_cache_service.cas.v1.CASLoadRequest\x1a1.compilation_cache_service.cas.v1.CASLoadResponse\"\x00\x12m\n" +
 	"\x04Save\x120.compilation_cache_service.cas.v1.CASSaveRequest\x1a1.compilation_cache_service.cas.v1.CASSaveResponse\"\x00B\x8c\x01\n" +
-	"&com.apple.dt.compilation_cache_serviceB\x17CompilationCachingProtoP\x01ZAgithub.com/bitrise-io/bitrise-build-cache-cli/v2/llvm/cas;llvmcas\xa2\x02\x03CCSb\x06proto3"
+	"&com.apple.dt.compilation_cache_serviceB\x17CompilationCachingProtoP\x01ZAgithub.com/bitrise-io/bitrise-build-cache-cli/v3/llvm/cas;llvmcas\xa2\x02\x03CCSb\x06proto3"
 
 var (
 	file_llvm_cas_compilation_caching_cas_proto_rawDescOnce sync.Once

--- a/proto/llvm/cas/compilation_caching_cas.proto
+++ b/proto/llvm/cas/compilation_caching_cas.proto
@@ -12,7 +12,7 @@ option java_multiple_files = true;
 option java_package = "com.apple.dt.compilation_cache_service";
 option java_outer_classname = "CompilationCachingProto";
 option objc_class_prefix = "CCS";
-option go_package = "github.com/bitrise-io/bitrise-build-cache-cli/v2/llvm/cas;llvmcas";
+option go_package = "github.com/bitrise-io/bitrise-build-cache-cli/v3/llvm/cas;llvmcas";
 
 package compilation_cache_service.cas.v1;
 

--- a/proto/llvm/kv/compilation_caching_kv.pb.go
+++ b/proto/llvm/kv/compilation_caching_kv.pb.go
@@ -430,7 +430,7 @@ const file_llvm_kv_compilation_caching_kv_proto_rawDesc = "" +
 	"KeyValueDB\x12}\n" +
 	"\bGetValue\x126.compilation_cache_service.keyvalue.v1.GetValueRequest\x1a7.compilation_cache_service.keyvalue.v1.GetValueResponse\"\x00\x12}\n" +
 	"\bPutValue\x126.compilation_cache_service.keyvalue.v1.PutValueRequest\x1a7.compilation_cache_service.keyvalue.v1.PutValueResponse\"\x00B\x8a\x01\n" +
-	"&com.apple.dt.compilation_cache_serviceB\x17CompilationCachingProtoP\x01Z?github.com/bitrise-io/bitrise-build-cache-cli/v2/llvm/kv;llvmkv\xa2\x02\x03CCSb\x06proto3"
+	"&com.apple.dt.compilation_cache_serviceB\x17CompilationCachingProtoP\x01Z?github.com/bitrise-io/bitrise-build-cache-cli/v3/llvm/kv;llvmkv\xa2\x02\x03CCSb\x06proto3"
 
 var (
 	file_llvm_kv_compilation_caching_kv_proto_rawDescOnce sync.Once

--- a/proto/llvm/kv/compilation_caching_kv.proto
+++ b/proto/llvm/kv/compilation_caching_kv.proto
@@ -12,7 +12,7 @@ option java_multiple_files = true;
 option java_package = "com.apple.dt.compilation_cache_service";
 option java_outer_classname = "CompilationCachingProto";
 option objc_class_prefix = "CCS";
-option go_package = "github.com/bitrise-io/bitrise-build-cache-cli/v2/llvm/kv;llvmkv";
+option go_package = "github.com/bitrise-io/bitrise-build-cache-cli/v3/llvm/kv;llvmkv";
 
 package compilation_cache_service.keyvalue.v1;
 

--- a/proto/llvm/session/session.pb.go
+++ b/proto/llvm/session/session.pb.go
@@ -213,7 +213,7 @@ const file_llvm_session_session_proto_rawDesc = "" +
 	"\aSession\x12B\n" +
 	"\n" +
 	"SetSession\x12\x1a.session.SetSessionRequest\x1a\x16.google.protobuf.Empty\"\x00\x12M\n" +
-	"\x0fGetSessionStats\x12\x16.google.protobuf.Empty\x1a .session.GetSessionStatsResponse\"\x00BGZEgithub.com/bitrise-io/bitrise-build-cache-cli/v2/llvm/session;sessionb\x06proto3"
+	"\x0fGetSessionStats\x12\x16.google.protobuf.Empty\x1a .session.GetSessionStatsResponse\"\x00BGZEgithub.com/bitrise-io/bitrise-build-cache-cli/v3/llvm/session;sessionb\x06proto3"
 
 var (
 	file_llvm_session_session_proto_rawDescOnce sync.Once

--- a/proto/llvm/session/session.proto
+++ b/proto/llvm/session/session.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/bitrise-io/bitrise-build-cache-cli/v2/llvm/session;session";
+option go_package = "github.com/bitrise-io/bitrise-build-cache-cli/v3/llvm/session;session";
 
 package session;
 

--- a/scripts/update_activate_gradle_features.sh
+++ b/scripts/update_activate_gradle_features.sh
@@ -2,6 +2,6 @@
 
 set -ex
 
-go get github.com/bitrise-io/bitrise-build-cache-cli/v2@${BITRISE_GIT_TAG}
+go get github.com/bitrise-io/bitrise-build-cache-cli/v3@${BITRISE_GIT_TAG}
 go mod tidy
 go mod vendor

--- a/scripts/update_activate_gradle_mirrors.sh
+++ b/scripts/update_activate_gradle_mirrors.sh
@@ -2,6 +2,6 @@
 
 set -ex
 
-go get github.com/bitrise-io/bitrise-build-cache-cli/v2@${BITRISE_GIT_TAG}
+go get github.com/bitrise-io/bitrise-build-cache-cli/v3@${BITRISE_GIT_TAG}
 go mod tidy
 go mod vendor


### PR DESCRIPTION
## Summary

Go modules require the module path suffix to match the major version. Releasing v3.0.0 with module path ending in `/v2` broke the auto-update PRs for the three step repos that consume the CLI as a Go module (gradle-features, gradle-mirrors, react-native-features):

\`\`\`
go: github.com/bitrise-io/bitrise-build-cache-cli/v2@v3.0.0: invalid version: module path includes a major version suffix, so major version must match
\`\`\`

Rename \`bitrise-build-cache-cli/v2\` -> \`.../v3\` across:
- \`go.mod\` module line
- 220 Go files' import statements
- \`.goreleaser.yaml\` ldflags path
- 4 proto files' \`go_package\` option (both \`.proto\` + generated \`.pb.go\`)
- \`scripts/update_activate_gradle_features.sh\` + \`update_activate_gradle_mirrors.sh\` (the \`go get ...@\${BITRISE_GIT_TAG}\` line)

Purely mechanical \`sed 's|bitrise-build-cache-cli/v2|bitrise-build-cache-cli/v3|g'\`. No behavior changes.

## Test plan

- [ ] \`go build ./...\` passes locally
- [ ] \`go test -tags unit -race ./...\` — pre-existing \`TestActivator_Activate/returns_error_when_auth_config_is_missing\` failure also fails on main; not caused by this change
- [ ] CI green
- [ ] Downstream v3.0.0 release re-cut with the new module path -> step auto-update PRs succeed for all 5 step repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)