### PR TITLE
chore: untrack accidentally-committed CLI binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 .DS_Store
+bitrise-build-cache
 bitrise-build-cache-cli
 .bitrise.secrets.yml
 dist/


### PR DESCRIPTION
27MB `bitrise-build-cache` binary was committed with the ACI-4337 epic merge (c86d152). `.gitignore` already excluded the old `bitrise-build-cache-cli` name — add `bitrise-build-cache` so `go build ./...` output stays untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)