### PR TITLE
fix: ACI-5175 redact BITRISE_API_TOKEN + bitpat_/bitwat_ values

### DIFF
--- a/internal/config/common/cache_config.go
+++ b/internal/config/common/cache_config.go
@@ -157,23 +157,59 @@ func hashKeyValue(hasher hash.Hash, key, value string) []byte {
 	return hasher.Sum(nil)
 }
 
+// alwaysRedactKeys are env vars that carry a Bitrise credential regardless of
+// whether BITRISE_SECRET_ENV_KEY_LIST names them. Keep in sync with any new
+// token-bearing env var the CLI or step layer introduces.
+var alwaysRedactKeys = []string{ //nolint:gochecknoglobals
+	EnvAuthToken, // BITRISE_BUILD_CACHE_AUTH_TOKEN
+	EnvJWT,       // BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN
+	"BITRISE_API_TOKEN",
+	"BUILD_TRIGGER_TOKEN",
+}
+
+// tokenValuePrefixes are value prefixes that identify a Bitrise credential —
+// used as a safety net so a value never surfaces cleartext even if its env-var
+// key isn't in the explicit lists above.
+var tokenValuePrefixes = []string{"bitpat_", "bitwat_"} //nolint:gochecknoglobals
+
 func redactBitriseEnvs(envs map[string]string) {
-	secretKeys := envs["BITRISE_SECRET_ENV_KEY_LIST"]
-	secretKeyList := strings.Split(secretKeys, ",")
 	hasher := sha256.New()
-	for _, key := range secretKeyList {
+	redact := func(key, value string) {
+		envs[key] = fmt.Sprintf("<sha256@%x>", hashKeyValue(hasher, key, value)[:4])
+	}
+
+	secretKeys := envs["BITRISE_SECRET_ENV_KEY_LIST"]
+	for key := range strings.SplitSeq(secretKeys, ",") {
 		if key == "" {
 			continue
 		}
 		if envValue, ok := envs[key]; ok {
-			envs[key] = fmt.Sprintf("<sha256@%x>", hashKeyValue(hasher, key, envValue)[:4])
+			redact(key, envValue)
 		}
 	}
 
-	key := EnvAuthToken
-	if envValue, ok := envs[key]; ok {
-		envs[key] = fmt.Sprintf("<sha256@%x>", hashKeyValue(hasher, key, envValue)[:4])
+	for _, key := range alwaysRedactKeys {
+		if envValue, ok := envs[key]; ok {
+			redact(key, envValue)
+		}
 	}
+
+	for key, value := range envs {
+		if !hasTokenPrefix(value) {
+			continue
+		}
+		redact(key, value)
+	}
+}
+
+func hasTokenPrefix(value string) bool {
+	for _, p := range tokenValuePrefixes {
+		if strings.HasPrefix(value, p) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func generateGitMetadata(logger log.Logger, commandFunc CommandFunc, envs map[string]string) GitMetadata {

--- a/internal/config/common/cache_config_test.go
+++ b/internal/config/common/cache_config_test.go
@@ -367,3 +367,63 @@ func TestNewMetadata_usernameEnvWhitespaceFallsThrough(t *testing.T) {
 	assert.NotEqual(t, "   ", got.HostMetadata.Username)
 	assert.NotEmpty(t, got.HostMetadata.Username, "should fall back to OS username")
 }
+
+func TestRedactBitriseEnvs_alwaysRedactedKeys(t *testing.T) {
+	t.Parallel()
+
+	envs := map[string]string{
+		"BITRISE_BUILD_CACHE_AUTH_TOKEN":          "raw-token-1",
+		"BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN": "raw-token-2",
+		"BITRISE_API_TOKEN":                       "raw-token-3",
+		"BUILD_TRIGGER_TOKEN":                     "raw-token-4",
+		"PATH":                                    "/usr/bin",
+	}
+
+	redactBitriseEnvs(envs)
+
+	for _, key := range []string{
+		"BITRISE_BUILD_CACHE_AUTH_TOKEN",
+		"BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN",
+		"BITRISE_API_TOKEN",
+		"BUILD_TRIGGER_TOKEN",
+	} {
+		assert.NotEqual(t, "raw-token", envs[key][:9], "%s must be redacted", key)
+		assert.Contains(t, envs[key], "<sha256@", "%s must be redacted with sha256 marker", key)
+	}
+	assert.Equal(t, "/usr/bin", envs["PATH"], "non-sensitive envs must be passed through")
+}
+
+func TestRedactBitriseEnvs_tokenValuePrefixSafetyNet(t *testing.T) {
+	t.Parallel()
+
+	envs := map[string]string{
+		"SOME_UNKNOWN_TOKEN_KEY": "bitpat_ABCDEF",
+		"ANOTHER_UNKNOWN_KEY":    "bitwat_XYZ123",
+		"UNRELATED":              "plain-value",
+	}
+
+	redactBitriseEnvs(envs)
+
+	assert.Contains(t, envs["SOME_UNKNOWN_TOKEN_KEY"], "<sha256@",
+		"bitpat_ values must be redacted even when the key is unknown")
+	assert.Contains(t, envs["ANOTHER_UNKNOWN_KEY"], "<sha256@",
+		"bitwat_ values must be redacted even when the key is unknown")
+	assert.Equal(t, "plain-value", envs["UNRELATED"], "non-token values must be passed through")
+}
+
+func TestRedactBitriseEnvs_secretKeyListStillHonoured(t *testing.T) {
+	t.Parallel()
+
+	envs := map[string]string{
+		"BITRISE_SECRET_ENV_KEY_LIST": "MY_SECRET,OTHER",
+		"MY_SECRET":                   "s1",
+		"OTHER":                       "s2",
+		"NOT_SECRET":                  "kept",
+	}
+
+	redactBitriseEnvs(envs)
+
+	assert.Contains(t, envs["MY_SECRET"], "<sha256@")
+	assert.Contains(t, envs["OTHER"], "<sha256@")
+	assert.Equal(t, "kept", envs["NOT_SECRET"])
+}


### PR DESCRIPTION
## Summary

The `Cache Config: {…}` INFO log during `activate` dumped `BITRISE_API_TOKEN` (`bitpat_…`) in cleartext. Redaction now covers a wider set of Bitrise-owned token env vars plus a value-prefix safety net.

## Changes

- `internal/config/common/cache_config.go`
  - New `alwaysRedactKeys` list: `BITRISE_BUILD_CACHE_AUTH_TOKEN`, `BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN`, `BITRISE_API_TOKEN`, `BUILD_TRIGGER_TOKEN`.
  - New `tokenValuePrefixes` scan (`bitpat_`, `bitwat_`) — redacts any env whose value starts with a Bitrise token prefix, regardless of key name (safety net for future token env vars).
  - Existing `BITRISE_SECRET_ENV_KEY_LIST` behaviour preserved.
- `internal/config/common/cache_config_test.go`
  - 3 new tests: explicit-key redaction, value-prefix redaction, secret-key-list regression.

Follow-up (out of scope, tracked separately in the ticket): gating the `Cache Config: %+v` log behind `--debug` to trim the env-dump noise.

## Test plan

- [x] `go test -tags unit -race ./internal/config/common/` passes.
- [x] `make lint-fix` clean.
- [x] Real repro: `BITRISE_API_TOKEN=bitpat_TESTLEAK123 bitrise-build-cache activate gradle` now prints `BITRISE_API_TOKEN:<sha256@…>` instead of the raw token.

Ticket: [ACI-5175](https://bitrise.atlassian.net/browse/ACI-5175)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5175]: https://bitrise.atlassian.net/browse/ACI-5175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ