### PR TITLE
fix: ACI-5177 kickstart daemon services after bootstrap

### DIFF
--- a/internal/daemon/control_test.go
+++ b/internal/daemon/control_test.go
@@ -28,9 +28,14 @@ func TestUp_launchd_startsAllInstalledServices(t *testing.T) {
 	require.Len(t, result.Statuses, 2)
 	assert.Equal(t, "launchd", result.BackendName)
 
-	assert.Len(t, upRunner.calls, 4)
+	// Up runs bootout-then-bootstrap-then-kickstart per service on launchd (ACI-5177).
+	assert.Len(t, upRunner.calls, 6)
 	assert.Equal(t, "bootout", upRunner.calls[0][1])
 	assert.Equal(t, "bootstrap", upRunner.calls[1][1])
+	assert.Equal(t, "kickstart", upRunner.calls[2][1])
+	assert.Equal(t, "bootout", upRunner.calls[3][1])
+	assert.Equal(t, "bootstrap", upRunner.calls[4][1])
+	assert.Equal(t, "kickstart", upRunner.calls[5][1])
 }
 
 func TestUp_launchd_errorsWhenNotInstalled(t *testing.T) {
@@ -96,13 +101,16 @@ func TestRestart_launchd_callsDownThenUp(t *testing.T) {
 	_, err = Restart(context.Background(), LaunchdBackend{Runner: restartRunner}, paths, DefaultServices())
 	require.NoError(t, err)
 
-	require.Len(t, restartRunner.calls, 6)
+	// Restart is Down (2 boots-out) + Up (2 * bootout+bootstrap+kickstart) = 8 calls.
+	require.Len(t, restartRunner.calls, 8)
 	assert.Equal(t, "bootout", restartRunner.calls[0][1])
 	assert.Equal(t, "bootout", restartRunner.calls[1][1])
 	assert.Equal(t, "bootout", restartRunner.calls[2][1])
 	assert.Equal(t, "bootstrap", restartRunner.calls[3][1])
-	assert.Equal(t, "bootout", restartRunner.calls[4][1])
-	assert.Equal(t, "bootstrap", restartRunner.calls[5][1])
+	assert.Equal(t, "kickstart", restartRunner.calls[4][1])
+	assert.Equal(t, "bootout", restartRunner.calls[5][1])
+	assert.Equal(t, "bootstrap", restartRunner.calls[6][1])
+	assert.Equal(t, "kickstart", restartRunner.calls[7][1])
 }
 
 func TestUp_systemd_startsAllInstalledServices(t *testing.T) {

--- a/internal/daemon/install_test.go
+++ b/internal/daemon/install_test.go
@@ -54,13 +54,19 @@ func TestInstall_launchd_writesPlistsAndBootstraps(t *testing.T) {
 		assert.True(t, filepath.IsAbs(st.ConfigPath))
 	}
 
-	// Every install does bootout-then-bootstrap per service: 2 services * 2 calls.
-	assert.Len(t, runner.calls, 4)
+	// Every install does bootout-then-bootstrap-then-kickstart per service: 2 services * 3 calls.
+	// kickstart -k is required to actually start the process on macOS Sequoia; bootstrap alone
+	// doesn't reliably honour RunAtLoad. See ACI-5177.
+	assert.Len(t, runner.calls, 6)
 	// calls[*][0] = launchctl bin, calls[*][1] = subcommand.
 	assert.Equal(t, "bootout", runner.calls[0][1])
 	assert.Equal(t, "bootstrap", runner.calls[1][1])
-	assert.Equal(t, "bootout", runner.calls[2][1])
-	assert.Equal(t, "bootstrap", runner.calls[3][1])
+	assert.Equal(t, "kickstart", runner.calls[2][1])
+	assert.Equal(t, "-k", runner.calls[2][2])
+	assert.Equal(t, "bootout", runner.calls[3][1])
+	assert.Equal(t, "bootstrap", runner.calls[4][1])
+	assert.Equal(t, "kickstart", runner.calls[5][1])
+	assert.Equal(t, "-k", runner.calls[5][2])
 }
 
 func TestInstall_launchd_idempotent_secondRunOverwritesPlist(t *testing.T) {

--- a/internal/daemon/launchd.go
+++ b/internal/daemon/launchd.go
@@ -35,7 +35,7 @@ func (b LaunchdBackend) Install(ctx context.Context, paths Paths, svc Service, e
 		return path, fmt.Errorf("write plist %s: %w", path, err)
 	}
 
-	if err := b.bootstrap(ctx, path); err != nil {
+	if err := b.bootstrap(ctx, path, svc.Label()); err != nil {
 		return path, err
 	}
 
@@ -45,7 +45,7 @@ func (b LaunchdBackend) Install(ctx context.Context, paths Paths, svc Service, e
 func (b LaunchdBackend) Start(ctx context.Context, paths Paths, svc Service) error {
 	path := paths.PlistPath(svc.Label())
 
-	return b.bootstrap(ctx, path)
+	return b.bootstrap(ctx, path, svc.Label())
 }
 
 func (b LaunchdBackend) Stop(ctx context.Context, paths Paths, svc Service) error {
@@ -78,8 +78,12 @@ func guiTarget() string {
 
 const launchctlBootoutNotLoaded = 5
 
-// bootstrap pre-boots out so a rerun picks up the new executable path on CLI upgrades.
-func (b LaunchdBackend) bootstrap(ctx context.Context, plistPath string) error {
+// bootstrap pre-boots out so a rerun picks up the new executable path on CLI upgrades,
+// then bootstraps + explicitly kickstarts the service. `bootstrap` alone is
+// unreliable on macOS Sequoia (25.x): plists with `RunAtLoad = true` land in
+// `state = not running` after `launchctl bootstrap` and never fire, so a
+// follow-up `kickstart -k` is what actually gets the process running.
+func (b LaunchdBackend) bootstrap(ctx context.Context, plistPath, label string) error {
 	_, stderr, code, runErr := b.Runner.Run(ctx, launchctlBin, "bootout", guiTarget(), plistPath)
 	if runErr != nil {
 		return fmt.Errorf("launchctl bootout (pre-bootstrap): %w", runErr)
@@ -96,6 +100,16 @@ func (b LaunchdBackend) bootstrap(ctx context.Context, plistPath string) error {
 
 	if code != 0 {
 		return fmt.Errorf("launchctl bootstrap %s exited %d: %s", plistPath, code, strings.TrimSpace(stderr))
+	}
+
+	target := guiTarget() + "/" + label
+	_, stderr, code, err = b.Runner.Run(ctx, launchctlBin, "kickstart", "-k", target)
+	if err != nil {
+		return fmt.Errorf("launchctl kickstart %s: %w", target, err)
+	}
+
+	if code != 0 {
+		return fmt.Errorf("launchctl kickstart %s exited %d: %s", target, code, strings.TrimSpace(stderr))
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

`launchctl bootstrap` alone doesn't reliably auto-start `RunAtLoad=true` LaunchAgents on macOS Sequoia (25.x). Services landed in `state = not running` with `last exit code = (never exited)` while the CLI happily reported "Services are now running." Follow up with `launchctl kickstart -k` to actually launch the process.

## Changes

- `internal/daemon/launchd.go`
  - `bootstrap` now takes a `label` argument and calls `launchctl kickstart -k gui/<uid>/<label>` after the successful bootstrap. Both `Install` and `Start` route through it, so `daemon install` / `daemon up` / `daemon restart` all get the fix.
- `internal/daemon/install_test.go` + `internal/daemon/control_test.go`
  - Bump the per-service launchctl call count from 2 (bootout + bootstrap) to 3 (bootout + bootstrap + kickstart). Lock the ordering.

## Test plan

- [x] `go test -tags unit -race ./internal/daemon/ ./cmd/daemon/` passes.
- [x] `make lint-fix` clean.
- [x] End-to-end: `daemon uninstall && daemon install && daemon info` — both services now report `running` immediately after install (was: `stopped` + `stuck`). Log dir populates.
- [x] `daemon down && daemon up` — services actually restart.

## Not covered (follow-up)

- ccache-helper starts under launchd but exits with `unauthenticated` because `BITRISE_BUILD_CACHE_AUTH_TOKEN` isn't in the launchd inherited env and the keychain-hydration `PersistentPreRun` hook isn't reached from `ccache start-helper`. Separate ticket to file — this PR is scoped to the launch-mechanism fix only.

Ticket: [ACI-5177](https://bitrise.atlassian.net/browse/ACI-5177)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5177]: https://bitrise.atlassian.net/browse/ACI-5177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ