### PR TITLE
fix: ACI-5174 wizard writes gradle + bazel sidecars

### DIFF
--- a/cmd/common/activate_interactive.go
+++ b/cmd/common/activate_interactive.go
@@ -17,6 +17,7 @@ import (
 	bazelconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/bazel"
 	gradleconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/gradle"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 	ccachepkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/ccache"
 )
@@ -115,9 +116,8 @@ func runInteractiveGradle(logger log.Logger, envs map[string]string, pushEnabled
 	}
 
 	if home, homeErr := os.UserHomeDir(); homeErr == nil {
-		initFile := filepath.Join(gradleHome, "init.d", "bitrise-build-cache.init.gradle.kts")
 		if err := gradleconfig.WriteSidecar(home, gradleconfig.Sidecar{
-			InitScriptPath:   initFile,
+			InitScriptPath:   paths.FromHome(home).GradleInitScriptFile(),
 			CacheEnabled:     params.Cache.Enabled,
 			CachePushEnabled: params.Cache.PushEnabled,
 			AnalyticsEnabled: params.Analytics.Enabled,

--- a/cmd/common/activate_interactive.go
+++ b/cmd/common/activate_interactive.go
@@ -114,6 +114,18 @@ func runInteractiveGradle(logger log.Logger, envs map[string]string, pushEnabled
 		return fmt.Errorf("activate plugins for Gradle: %w", err)
 	}
 
+	if home, homeErr := os.UserHomeDir(); homeErr == nil {
+		initFile := filepath.Join(gradleHome, "init.d", "bitrise-build-cache.init.gradle.kts")
+		if err := gradleconfig.WriteSidecar(home, gradleconfig.Sidecar{
+			InitScriptPath:   initFile,
+			CacheEnabled:     params.Cache.Enabled,
+			CachePushEnabled: params.Cache.PushEnabled,
+			AnalyticsEnabled: params.Analytics.Enabled,
+		}); err != nil {
+			logger.Debugf("gradle sidecar write failed (non-fatal): %s", err)
+		}
+	}
+
 	logger.TInfof("✅ Bitrise Build Cache activated for Gradle")
 
 	return nil
@@ -145,6 +157,19 @@ func runInteractiveBazel(logger log.Logger, envs map[string]string, pushEnabled 
 
 	if err := inventory.WriteToBazelrc(logger, bazelrcPath, utils.DefaultOsProxy{}, utils.DefaultTemplateProxy()); err != nil {
 		return fmt.Errorf("write .bazelrc: %w", err)
+	}
+
+	if home, homeErr := os.UserHomeDir(); homeErr == nil {
+		if mErr := bazelconfig.WriteSidecar(home, bazelconfig.Sidecar{
+			BazelrcPath:       bazelrcPath,
+			CacheEnabled:      params.Cache.Enabled,
+			CachePushEnabled:  params.Cache.PushEnabled,
+			BESEnabled:        params.BES.Enabled,
+			RBEEnabled:        params.RBE.Enabled,
+			TimestampsEnabled: params.Timestamps,
+		}); mErr != nil {
+			logger.Debugf("bazel sidecar write failed (non-fatal): %s", mErr)
+		}
 	}
 
 	logger.TInfof("✅ Bitrise Build Cache activated for Bazel")


### PR DESCRIPTION
## Summary

`activate --interactive` was leaving `~/.bitrise/cache/gradle/config.json` and `~/.bitrise/cache/bazel/config.json` unwritten. `refresh.Notify`'s drift-nudge never fires for those tools because the file it inspects didn't exist for wizard-only users.

## Changes

- `cmd/common/activate_interactive.go`
  - `runInteractiveGradle` now writes the gradle sidecar after activation succeeds — same params + best-effort semantics as `cmd/gradle/activate_gradle.go:80`.
  - `runInteractiveBazel` now writes the bazel sidecar after `.bazelrc` is written — mirrors `cmd/bazel/activate_bazel.go:94`.

## Follow-up (not in scope)

Two callers per tool now use an identical WriteSidecar block. Worth extracting `WriteActivatedSidecar` helpers on `gradleconfig` / `bazelconfig` so the shape can't drift when a new field is added. Small refactor, separate PR.

## Test plan

- [x] `go test -tags unit -race ./cmd/common/` passes.
- [x] `make lint-fix` clean.
- [x] End-to-end proxied via direct-activate path — identical `WriteSidecar` call is already exercised by the existing golden gradle/bazel unit tests. Wizard-specific integration tests would need HOME injection infrastructure that doesn't exist yet (out of scope).

Ticket: [ACI-5174](https://bitrise.atlassian.net/browse/ACI-5174)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5174]: https://bitrise.atlassian.net/browse/ACI-5174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ