### PR TITLE
fix: ACI-5178 clean shutdown for xcelerate proxy on SIGTERM

### DIFF
--- a/cmd/xcode/xcelerate_start_proxy.go
+++ b/cmd/xcode/xcelerate_start_proxy.go
@@ -162,9 +162,6 @@ func StartXcodeCacheProxy(
 
 	srv := proxy.NewProxy(client, config.PushEnabled, initialLogger, loggerFactory)
 
-	// grpc.Server.Stop closes the listener and returns Serve cleanly (nil).
-	// Doing this instead of raw listener.Close avoids the "accept … use of
-	// closed network connection" error path that a bare Close would trigger.
 	go func() {
 		<-ctx.Done()
 		srv.Stop()

--- a/cmd/xcode/xcelerate_start_proxy.go
+++ b/cmd/xcode/xcelerate_start_proxy.go
@@ -103,11 +103,6 @@ var (
 			}
 			defer listener.Close()
 
-			go func() {
-				<-signalCtx.Done()
-				_ = listener.Close()
-			}()
-
 			return StartXcodeCacheProxy(
 				signalCtx,
 				config,
@@ -165,10 +160,18 @@ func StartXcodeCacheProxy(
 		return fmt.Errorf("create kv client: %w", err)
 	}
 
+	srv := proxy.NewProxy(client, config.PushEnabled, initialLogger, loggerFactory)
+
+	// grpc.Server.Stop closes the listener and returns Serve cleanly (nil).
+	// Doing this instead of raw listener.Close avoids the "accept … use of
+	// closed network connection" error path that a bare Close would trigger.
+	go func() {
+		<-ctx.Done()
+		srv.Stop()
+	}()
+
 	//nolint:wrapcheck
-	return proxy.
-		NewProxy(client, config.PushEnabled, initialLogger, loggerFactory).
-		Serve(listener)
+	return srv.Serve(listener)
 }
 
 func getProxyLogFile(osProxy utils.OsProxy, invocationID string) (string, error) {


### PR DESCRIPTION
## Summary

The proxy's SIGTERM handler closed the listener directly, which made `grpc.Server.Serve` return `accept … use of closed network connection` and the process exited with code 1. That trips launchd's `KeepAlive.SuccessfulExit=false` respawn loop and looks like a crash to any exit-code monitor (systemd, k8s liveness probes on the Linux port).

Route shutdown through `grpc.Server.Stop` instead: it closes the listener AND cancels in-flight RPCs, and `Serve` then returns nil.

## Changes

- `cmd/xcode/xcelerate_start_proxy.go`
  - Drop the RunE-level `listener.Close()` goroutine.
  - Inside `StartXcodeCacheProxy`: create the gRPC server, spawn a goroutine that calls `srv.Stop()` on `ctx.Done`. `srv.Serve(listener)` then returns nil.
  - `defer listener.Close()` stays as a safety net for pre-serve failures.

## Test plan

- [x] `go test -tags unit -race ./cmd/xcode/` passes.
- [x] `make lint-fix` clean.
- [x] End-to-end: `xcelerate start-proxy` + `kill -TERM` → exit 0, no error text (was: exit 1 + scary error).

Ticket: [ACI-5178](https://bitrise.atlassian.net/browse/ACI-5178)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5178]: https://bitrise.atlassian.net/browse/ACI-5178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ