### PR TITLE
fix: ACI-5179 ccache-helper unlinks its socket on SIGTERM

### DIFF
--- a/cmd/ccache/start_storage_helper.go
+++ b/cmd/ccache/start_storage_helper.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os/signal"
+	"syscall"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/google/uuid"
@@ -48,7 +50,12 @@ var (
 				return fmt.Errorf("create storage helper: %w", err)
 			}
 
-			if err := helper.Start(cmd.Context()); err != nil {
+			// Propagate SIGTERM / SIGINT so the helper's Run loop exits and the
+			// listener's deferred Close unlinks the Unix socket file.
+			signalCtx, stopSignals := signal.NotifyContext(cmd.Context(), syscall.SIGTERM, syscall.SIGINT)
+			defer stopSignals()
+
+			if err := helper.Start(signalCtx); err != nil {
 				return fmt.Errorf("run storage helper: %w", err)
 			}
 


### PR DESCRIPTION
## Summary

`ccache storage-helper start` passed `cmd.Context()` unaltered to `helper.Start`. Cobra doesn't wire SIGTERM into that context, so on `daemon down` / `launchctl bootout` the Go runtime's default signal handler killed the process before `IpcServer.Run`'s `<-ctx.Done()` fired. The deferred `listener.Close()` never ran, so the Unix socket file at `$TMPDIR/ccache-ipc.sock` stayed on disk with no listener behind it — and `daemon info` then reported the helper as `stuck` right after a clean shutdown.

## Changes

- `cmd/ccache/start_storage_helper.go`
  - Wrap `cmd.Context()` with `signal.NotifyContext(SIGTERM, SIGINT)` before passing to `helper.Start`. Same pattern the xcelerate proxy already uses.

Now `IpcServer.Run` exits cleanly on signal, `*net.UnixListener.Close` fires its unlink-on-close, and the socket file is gone by the time the process exits.

## Test plan

- [x] `go test -tags unit -race ./internal/ccache/` passes.
- [x] `make lint-fix` clean.
- [x] End-to-end: `ccache storage-helper start` + `kill -TERM` — exit 0, `$TMPDIR/ccache-ipc.sock` no longer present (was: still there, "Server shutting down" never logged).

Ticket: [ACI-5179](https://bitrise.atlassian.net/browse/ACI-5179)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5179]: https://bitrise.atlassian.net/browse/ACI-5179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ