### PR TITLE
fix: ACI-5182 daemon install warns when a different bitrise-build-cache is on $PATH

### DIFF
--- a/cmd/daemon/install.go
+++ b/cmd/daemon/install.go
@@ -117,7 +117,7 @@ func warnIfShadowedBinary(logger log.Logger, pinned string) {
 		return
 	}
 
-	logger.Warnf("Pinning %s into the supervisor config, but `bitrise-build-cache` on your $PATH resolves to %s.", pinned, onPath)
+	logger.Warnf("Pinning %s into the supervisor config, but `%s` on your $PATH resolves to %s.", pinned, paths.CLIBinaryName, onPath)
 	logger.Warnf("Interactive commands and the daemon would use different binaries — likely different CLI versions too.")
 	logger.Warnf("To pin the PATH binary instead, rerun via its full path: %s daemon install", onPath)
 }

--- a/cmd/daemon/install.go
+++ b/cmd/daemon/install.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -67,6 +69,8 @@ var installCmd = &cobra.Command{
 			exe = stable
 		}
 
+		warnIfShadowedBinary(logger, exe)
+
 		result, err := daemonpkg.Install(cmd.Context(), backend, paths, daemonpkg.DefaultServices(), exe)
 		if err != nil {
 			if errors.Is(err, daemonpkg.ErrUnsupportedPlatform) {
@@ -101,6 +105,33 @@ var installCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func warnIfShadowedBinary(logger log.Logger, pinned string) {
+	onPath, err := exec.LookPath("bitrise-build-cache")
+	if err != nil {
+		return
+	}
+	if resolvePath(pinned) == resolvePath(onPath) {
+		return
+	}
+
+	logger.Warnf("Pinning %s into the supervisor config, but `bitrise-build-cache` on your $PATH resolves to %s.", pinned, onPath)
+	logger.Warnf("Interactive commands and the daemon would use different binaries — likely different CLI versions too.")
+	logger.Warnf("To pin the PATH binary instead, rerun via its full path: %s daemon install", onPath)
+}
+
+func resolvePath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return p
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return abs
+	}
+
+	return resolved
 }
 
 func init() {

--- a/cmd/daemon/install.go
+++ b/cmd/daemon/install.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 	daemonpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/daemon"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/permhint"
 )
 
@@ -108,7 +109,7 @@ var installCmd = &cobra.Command{
 }
 
 func warnIfShadowedBinary(logger log.Logger, pinned string) {
-	onPath, err := exec.LookPath("bitrise-build-cache")
+	onPath, err := exec.LookPath(paths.CLIBinaryName)
 	if err != nil {
 		return
 	}

--- a/internal/daemon/binary.go
+++ b/internal/daemon/binary.go
@@ -9,8 +9,6 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 )
 
-const stableBinName = "bitrise-build-cache"
-
 // StableBinPath returns ~/.bitrise/bin/bitrise-build-cache.
 func StableBinPath() (string, error) {
 	p, err := paths.Default()
@@ -18,7 +16,7 @@ func StableBinPath() (string, error) {
 		return "", fmt.Errorf("resolve stable bin path: %w", err)
 	}
 
-	return p.BitriseBinFile(stableBinName), nil
+	return p.BitriseBinFile(paths.CLIBinaryName), nil
 }
 
 // CopyCLIToStableBin copies src to StableBinPath() with 0o755 perms,

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -64,6 +64,9 @@ const (
 	gradleInitScriptRelative = ".gradle/init.d/bitrise-build-cache.init.gradle.kts"
 )
 
+// CLIBinaryName is the on-disk name of the CLI executable (daemon plist entry, PATH lookup).
+const CLIBinaryName = "bitrise-build-cache"
+
 // Paths resolves on-disk locations rooted at a single home directory.
 type Paths struct {
 	Home string


### PR DESCRIPTION
## Summary

`daemon install` embeds `os.Executable()` into the LaunchAgent plist / systemd unit. When the shell has a different `bitrise-build-cache` first on `$PATH` (common when both `brew install` and `installer.sh` are used), interactive commands and the daemon silently run different binaries — often different CLI versions.

## Changes

- `cmd/daemon/install.go`
  - New `warnIfShadowedBinary`: after resolving the pinned path via `os.Executable`, compare against `exec.LookPath("bitrise-build-cache")` (both `EvalSymlinks`'d). If they differ, print a 3-line warning that names both paths and shows the exact command to pin the PATH binary instead.
  - Non-fatal: install proceeds. Users can rerun via the intended full path if they want the other binary.

## Test plan

- [x] `go test -tags unit -race ./cmd/daemon/` passes.
- [x] `make lint-fix` clean.
- [x] End-to-end: with homebrew binary first on PATH, `~/.bitrise/bin/bitrise-build-cache daemon install` prints the shadow warning. With PATH updated so both resolve to the same binary, no warning.

Ticket: [ACI-5182](https://bitrise.atlassian.net/browse/ACI-5182)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5182]: https://bitrise.atlassian.net/browse/ACI-5182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ