### PR TITLE
feat: ACI-5044 slim invocation emit on proxy session close

### DIFF
--- a/cmd/xcode/xcelerate_start_proxy.go
+++ b/cmd/xcode/xcelerate_start_proxy.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/google/uuid"
@@ -18,7 +19,9 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/cmd/common"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/analytics"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/proxy"
 	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/build/bazel/remote/execution/v2"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/kv_storage"
@@ -165,10 +168,68 @@ func StartXcodeCacheProxy(
 		return fmt.Errorf("create kv client: %w", err)
 	}
 
+	emitter := newSlimInvocationEmitter(config, envProvider, commandFunc, initialLogger)
+
+	p := proxy.NewProxy(client, config.PushEnabled, initialLogger, loggerFactory, emitter)
+
+	serveErr := p.Serve(listener)
+
+	p.FlushCurrentSession(context.WithoutCancel(ctx))
+
 	//nolint:wrapcheck
-	return proxy.
-		NewProxy(client, config.PushEnabled, initialLogger, loggerFactory).
-		Serve(listener)
+	return serveErr
+}
+
+// slimInvocationEmitter PUTs a Slim analytics.Invocation on proxy session close.
+// F2 (xcodebuild wrapper) overwrites the same InvocationID with the enriched row.
+type slimInvocationEmitter struct {
+	client   *analytics.Client
+	auth     configcommon.CacheAuthConfig
+	metadata configcommon.CacheConfigMetadata
+	logger   log.Logger
+}
+
+func newSlimInvocationEmitter(
+	config xcelerate.Config,
+	envProvider map[string]string,
+	commandFunc configcommon.CommandFunc,
+	logger log.Logger,
+) proxy.InvocationEmitter {
+	client, err := analytics.NewClient(consts.XcodeAnalyticsServiceEndpoint, config.AuthConfig.TokenInGradleFormat(), logger)
+	if err != nil {
+		logger.Warnf("Slim invocation emit disabled — analytics client init failed: %s", err)
+
+		return nil
+	}
+
+	return &slimInvocationEmitter{
+		client:   client,
+		auth:     config.AuthConfig,
+		metadata: configcommon.NewMetadata(envProvider, commandFunc, logger),
+		logger:   logger,
+	}
+}
+
+func (e *slimInvocationEmitter) EmitSlim(ctx context.Context, meta proxy.SessionMeta, stats proxy.SessionStats) {
+	// Fire-and-forget: proxy's shutdown/setSession critical path must not block on network I/O.
+	go func() {
+		inv := analytics.NewInvocation(analytics.InvocationRunStats{
+			InvocationDate: meta.StartTime,
+			InvocationID:   meta.InvocationID,
+			Duration:       time.Since(meta.StartTime).Milliseconds(),
+			HitRate:        stats.HitRate(),
+		}, e.auth, e.metadata)
+
+		if err := e.client.PutInvocation(*inv); err != nil {
+			e.logger.Warnf("Failed to emit slim invocation %s: %s", meta.InvocationID, err)
+
+			return
+		}
+
+		e.logger.Debugf("Slim invocation emitted: %s (hit-rate %.02f%%)", meta.InvocationID, stats.HitRate()*100)
+	}()
+
+	_ = ctx
 }
 
 func getProxyLogFile(osProxy utils.OsProxy, invocationID string) (string, error) {

--- a/internal/xcelerate/proxy/invocation_emit.go
+++ b/internal/xcelerate/proxy/invocation_emit.go
@@ -1,0 +1,59 @@
+package proxy
+
+import (
+	"context"
+	"time"
+)
+
+// SessionMeta is the identity of the session being emitted.
+type SessionMeta struct {
+	InvocationID string
+	AppSlug      string
+	BuildSlug    string
+	StepSlug     string
+	StartTime    time.Time
+}
+
+// SessionStats is the counters snapshot at emit time.
+type SessionStats struct {
+	Hits          int64
+	Misses        int64
+	KVHits        int64
+	KVMisses      int64
+	Uploads       int64
+	UploadBytes   int64
+	DownloadBytes int64
+	KVUploadBytes int64
+}
+
+// InvocationEmitter emits a slim analytics invocation for a closed proxy session.
+// F2 (enrichment from xcodebuild) PUTs to the same InvocationID and overwrites this row.
+type InvocationEmitter interface {
+	EmitSlim(ctx context.Context, meta SessionMeta, stats SessionStats)
+}
+
+// HitRate mirrors cmd/xcode/xcodebuild.go — KV counters take priority over blob when both exist.
+func (s SessionStats) HitRate() float32 {
+	if s.KVHits+s.KVMisses > 0 {
+		return float32(s.KVHits) / float32(s.KVHits+s.KVMisses)
+	}
+
+	if s.Hits+s.Misses > 0 {
+		return float32(s.Hits) / float32(s.Hits+s.Misses)
+	}
+
+	return 0
+}
+
+func (s stats) toPublic() SessionStats {
+	return SessionStats{
+		Hits:          s.hits,
+		Misses:        s.misses,
+		KVHits:        s.kvHits,
+		KVMisses:      s.kvMisses,
+		Uploads:       s.uploads,
+		UploadBytes:   s.uploadBytes,
+		DownloadBytes: s.downloadBytes,
+		KVUploadBytes: s.kvUploadBytes,
+	}
+}

--- a/internal/xcelerate/proxy/invocation_emit_test.go
+++ b/internal/xcelerate/proxy/invocation_emit_test.go
@@ -1,0 +1,156 @@
+package proxy_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/proxy"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/xcelerate/proxy/mocks"
+	sessionproto "github.com/bitrise-io/bitrise-build-cache-cli/v2/proto/llvm/session"
+)
+
+type capturingEmitter struct {
+	mu    sync.Mutex
+	calls []capturedEmit
+}
+
+type capturedEmit struct {
+	meta  proxy.SessionMeta
+	stats proxy.SessionStats
+}
+
+func (e *capturingEmitter) EmitSlim(_ context.Context, meta proxy.SessionMeta, stats proxy.SessionStats) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.calls = append(e.calls, capturedEmit{meta: meta, stats: stats})
+}
+
+func (e *capturingEmitter) captured() []capturedEmit {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	out := make([]capturedEmit, len(e.calls))
+	copy(out, e.calls)
+
+	return out
+}
+
+func newProxyForEmit(t *testing.T, emitter proxy.InvocationEmitter) *proxy.Proxy {
+	t.Helper()
+
+	kvClient := &mocks.ClientMock{}
+	loggerFactory := func(string) (log.Logger, error) { return mockLogger, nil }
+
+	return proxy.NewProxy(kvClient, false, mockLogger, loggerFactory, emitter)
+}
+
+func TestSetSession_replacingSessionEmitsPrior(t *testing.T) {
+	emitter := &capturingEmitter{}
+	p := newProxyForEmit(t, emitter)
+
+	_, err := p.SetSession(context.Background(), &sessionproto.SetSessionRequest{
+		InvocationId: "inv-1", AppSlug: "app", BuildSlug: "b1", StepSlug: "s1",
+	})
+	require.NoError(t, err)
+
+	_, err = p.SetSession(context.Background(), &sessionproto.SetSessionRequest{
+		InvocationId: "inv-2", AppSlug: "app", BuildSlug: "b2", StepSlug: "s2",
+	})
+	require.NoError(t, err)
+
+	calls := emitter.captured()
+	require.Len(t, calls, 1, "second SetSession should emit the first session")
+	assert.Equal(t, "inv-1", calls[0].meta.InvocationID)
+	assert.Equal(t, "b1", calls[0].meta.BuildSlug)
+	assert.False(t, calls[0].meta.StartTime.IsZero(), "start time captured on SetSession")
+}
+
+func TestFlushCurrentSession_emitsOpenSession(t *testing.T) {
+	emitter := &capturingEmitter{}
+	p := newProxyForEmit(t, emitter)
+
+	_, err := p.SetSession(context.Background(), &sessionproto.SetSessionRequest{
+		InvocationId: "inv-3", AppSlug: "app", BuildSlug: "b3", StepSlug: "s3",
+	})
+	require.NoError(t, err)
+
+	p.FlushCurrentSession(context.Background())
+
+	calls := emitter.captured()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "inv-3", calls[0].meta.InvocationID)
+}
+
+func TestFlushCurrentSession_noOpWhenNoSession(t *testing.T) {
+	emitter := &capturingEmitter{}
+	p := newProxyForEmit(t, emitter)
+
+	p.FlushCurrentSession(context.Background())
+
+	assert.Empty(t, emitter.captured())
+}
+
+func TestFlushCurrentSession_noOpWhenEmitterNil(t *testing.T) {
+	p := newProxyForEmit(t, nil)
+
+	_, err := p.SetSession(context.Background(), &sessionproto.SetSessionRequest{
+		InvocationId: "inv-4",
+	})
+	require.NoError(t, err)
+
+	assert.NotPanics(t, func() { p.FlushCurrentSession(context.Background()) })
+}
+
+func TestFlushCurrentSession_secondCallIsNoOp(t *testing.T) {
+	emitter := &capturingEmitter{}
+	p := newProxyForEmit(t, emitter)
+
+	_, err := p.SetSession(context.Background(), &sessionproto.SetSessionRequest{InvocationId: "inv-5"})
+	require.NoError(t, err)
+
+	p.FlushCurrentSession(context.Background())
+	p.FlushCurrentSession(context.Background())
+
+	assert.Len(t, emitter.captured(), 1)
+}
+
+func TestSessionStats_HitRate_prefersKVWhenBothPresent(t *testing.T) {
+	s := proxy.SessionStats{Hits: 1, Misses: 9, KVHits: 4, KVMisses: 1}
+	assert.InDelta(t, 0.8, s.HitRate(), 0.0001)
+}
+
+func TestSessionStats_HitRate_fallsBackToBlob(t *testing.T) {
+	s := proxy.SessionStats{Hits: 3, Misses: 1}
+	assert.InDelta(t, 0.75, s.HitRate(), 0.0001)
+}
+
+func TestSessionStats_HitRate_zeroWhenNoOps(t *testing.T) {
+	assert.InDelta(t, 0, proxy.SessionStats{}.HitRate(), 0.0001)
+}
+
+func TestSetSession_startTimeMonotonicish(t *testing.T) {
+	emitter := &capturingEmitter{}
+	p := newProxyForEmit(t, emitter)
+
+	before := time.Now()
+	_, err := p.SetSession(context.Background(), &sessionproto.SetSessionRequest{InvocationId: "inv-6"})
+	require.NoError(t, err)
+	after := time.Now()
+
+	p.FlushCurrentSession(context.Background())
+
+	calls := emitter.captured()
+	require.Len(t, calls, 1)
+	assert.False(t, calls[0].meta.StartTime.Before(before))
+	assert.False(t, calls[0].meta.StartTime.After(after))
+}
+
+var _ = emptypb.Empty{}

--- a/internal/xcelerate/proxy/proxy.go
+++ b/internal/xcelerate/proxy/proxy.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"runtime"
 	"sync"
@@ -55,9 +56,13 @@ type Proxy struct {
 	skipGetCapabilitiesCall []grpc.ServiceDesc
 	logger                  log.Logger
 	loggerFactory           LoggerFactory
+
+	emitter        InvocationEmitter
+	currentSession *SessionMeta
+	grpcServer     *grpc.Server
 }
 
-func NewProxy(kvClient Client, pushEnabled bool, logger log.Logger, loggerFactory LoggerFactory) *grpc.Server {
+func NewProxy(kvClient Client, pushEnabled bool, logger log.Logger, loggerFactory LoggerFactory, emitter InvocationEmitter) *Proxy {
 	// Note: Gradle plugin uses a client balancer, with multiple channels (min 2), each with multiple connections.
 	// For a simple implementation, we only have one channel with multiple connections.
 	numChan := max(2, runtime.NumCPU()/6)
@@ -71,6 +76,7 @@ func NewProxy(kvClient Client, pushEnabled bool, logger log.Logger, loggerFactor
 		sessionState:  newSessionState(),
 		logger:        logger,
 		loggerFactory: loggerFactory,
+		emitter:       emitter,
 		ccSemaphore:   make(chan struct{}, ccLimit),
 		skipGetCapabilitiesCall: []grpc.ServiceDesc{
 			session.Session_ServiceDesc, // skip GetCapabilities call for session service methods
@@ -98,18 +104,64 @@ func NewProxy(kvClient Client, pushEnabled bool, logger log.Logger, loggerFactor
 	llvmkv.RegisterKeyValueDBServer(grpcServer, proxy)
 	session.RegisterSessionServer(grpcServer, proxy)
 
-	return grpcServer
+	proxy.grpcServer = grpcServer
+
+	return proxy
 }
 
-func (p *Proxy) SetSession(_ context.Context, request *session.SetSessionRequest) (*emptypb.Empty, error) {
+// Serve delegates to the underlying gRPC server.
+func (p *Proxy) Serve(l net.Listener) error {
+	//nolint:wrapcheck
+	return p.grpcServer.Serve(l)
+}
+
+// GracefulStop stops the underlying gRPC server after in-flight RPCs finish.
+func (p *Proxy) GracefulStop() {
+	p.grpcServer.GracefulStop()
+}
+
+// FlushCurrentSession emits the currently-open session (if any) via the configured emitter.
+// Caller is responsible for invoking this on shutdown — SetSession() already emits the
+// previous session before starting a new one.
+func (p *Proxy) FlushCurrentSession(ctx context.Context) {
 	p.sessionMutex.Lock()
 	defer p.sessionMutex.Unlock()
+
+	p.emitCurrentSessionLocked(ctx)
+}
+
+// emitCurrentSessionLocked snapshots + emits under the caller-held sessionMutex.
+func (p *Proxy) emitCurrentSessionLocked(ctx context.Context) {
+	if p.emitter == nil || p.currentSession == nil {
+		return
+	}
+
+	meta := *p.currentSession
+	stats := p.sessionState.getStats().toPublic()
+
+	p.emitter.EmitSlim(ctx, meta, stats)
+
+	p.currentSession = nil
+}
+
+func (p *Proxy) SetSession(ctx context.Context, request *session.SetSessionRequest) (*emptypb.Empty, error) {
+	p.sessionMutex.Lock()
+	defer p.sessionMutex.Unlock()
+
+	p.emitCurrentSessionLocked(ctx)
 
 	p.capabilitiesCalled = false
 
 	p.kvClient.ChangeSession(request.GetInvocationId(), request.GetAppSlug(), request.GetBuildSlug(), request.GetStepSlug())
 
 	p.sessionState = newSessionState()
+	p.currentSession = &SessionMeta{
+		InvocationID: request.GetInvocationId(),
+		AppSlug:      request.GetAppSlug(),
+		BuildSlug:    request.GetBuildSlug(),
+		StepSlug:     request.GetStepSlug(),
+		StartTime:    time.Now(),
+	}
 
 	logger, err := p.loggerFactory(request.GetInvocationId())
 	if err != nil {

--- a/internal/xcelerate/proxy/proxy_test.go
+++ b/internal/xcelerate/proxy/proxy_test.go
@@ -42,7 +42,7 @@ func Test_Proxy_PushDisabled(t *testing.T) {
 	go func() {
 		p := proxy.NewProxy(kvClient, false, mockLogger, func(invocationID string) (log.Logger, error) {
 			return mockLogger, nil
-		})
+		}, nil)
 
 		_ = p.Serve(listener)
 	}()

--- a/internal/xcelerate/proxy/setup_test.go
+++ b/internal/xcelerate/proxy/setup_test.go
@@ -15,4 +15,9 @@ func init() {
 	mockLogger.On("TDebugf", mock.Anything, mock.Anything).Return()
 	mockLogger.On("TDebugf", mock.Anything).Return()
 	mockLogger.On("TErrorf", mock.Anything, mock.Anything).Return()
+	mockLogger.On("TInfof", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockLogger.On("TInfof", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockLogger.On("TInfof", mock.Anything, mock.Anything, mock.Anything).Return()
+	mockLogger.On("TInfof", mock.Anything, mock.Anything).Return()
+	mockLogger.On("TInfof", mock.Anything).Return()
 }


### PR DESCRIPTION
## Summary
- Xcelerate-proxy PUTs `analytics.Invocation` on session close (both replacing SetSession and graceful shutdown flush).
- Slim payload: `InvocationID`, `InvocationDate`, `Duration`, `HitRate`. `Command`/`Scheme`/`XcodeVersion` left empty for F2 to overwrite under the same `InvocationID`.
- Emit is fire-and-forget on a goroutine — SetSession handshake never blocks on the network.
- Refactors `NewProxy()` to return `*Proxy` (with `Serve`/`GracefulStop`) so callers can invoke `FlushCurrentSession()` after `Serve()` returns.

## Test plan
- [ ] `go test -tags unit -race ./internal/xcelerate/proxy/...` green (new `invocation_emit_test.go` covers replace-emits-prior, flush-open-session, no-op nil emitter, no-op empty session, HitRate KV-priority)
- [ ] `make lint` clean
- [ ] Manual: run `bitrise-build-cache xcelerate start-proxy`, trigger a build, observe slim invocation appears in xcode-analytics before F2 overwrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)