### PR TITLE
Route CI auth writes to config file (keychain-swap safe)

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -352,6 +352,8 @@ func renderUsername(logger log.Logger, envs map[string]string) {
 		logger.Infof("Local invocation display name: %s (source: %s env)", name, configcommon.EnvUsername)
 	case configcommon.UsernameSourceKeychain:
 		logger.Infof("Local invocation display name: %s (source: keychain)", name)
+	case configcommon.UsernameSourceFile:
+		logger.Infof("Local invocation display name: %s (source: config file)", name)
 	case configcommon.UsernameSourceOS:
 		logger.Infof("Local invocation display name: %s (source: OS username fallback)", name)
 	case configcommon.UsernameSourceNone:

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/store"
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
@@ -39,6 +40,7 @@ var (
 	setToken       string
 	setWorkspaceID string
 	setUsername    string
+	setStorage     string
 )
 
 // nolint:gochecknoglobals
@@ -62,26 +64,37 @@ var authSetCmd = &cobra.Command{
 			return errors.New("--workspace-id is required and must not be empty")
 		}
 
-		kc := keychain.New()
-		existing, err := kc.Load()
-		if err != nil && !errors.Is(err, keychain.ErrNotFound) {
+		target, err := store.Select(utils.AllEnvs(), setStorage)
+		if err != nil {
+			return err //nolint:wrapcheck // already user-facing
+		}
+		existing, err := target.Load()
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
 			return fmt.Errorf("load existing credentials: %w", err)
 		}
 		existing.AuthToken = setToken
 		existing.WorkspaceID = setWorkspaceID
 		existing.Username = setUsername
-		if err := kc.Save(existing); err != nil {
-			return fmt.Errorf("save credentials to keychain: %w", err)
+		if err := store.SaveExclusive(target, existing); err != nil {
+			return fmt.Errorf("save credentials: %w", err)
 		}
 
-		logger.TInfof("✅ Credentials saved to the OS keychain")
+		switch target.Kind() {
+		case store.KindKeychain:
+			logger.TInfof("✅ Credentials saved to the OS keychain")
+		case store.KindFile:
+			logger.TInfof("✅ Credentials saved to the multiplatform config file (%s)", displayHomePath(utils.DefaultOsProxy{}, multiplatformconfig.FilePath(utils.DefaultOsProxy{})))
+			if configcommon.DetectCIProvider(utils.AllEnvs()) != "" && setStorage == "" {
+				logger.Infof("(CI detected — keychain skipped because fastlane setup_ci swaps the default keychain and would drop the entry.)")
+			}
+		}
 		if setUsername != "" {
 			logger.TInfof("Display name for local invocations set to %q.", setUsername)
 		}
 
-		switch scrubbed, err := scrubDiskCredentials(); {
+		switch scrubbed, err := scrubDiskCredentials(target.Kind()); {
 		case err != nil:
-			logger.Warnf("Saved to keychain, but could not strip plain-text credentials from disk: %v", err)
+			logger.Warnf("Saved to %s, but could not strip plain-text credentials from disk: %v", target.Kind(), err)
 			logger.Warnf("Run `bitrise-build-cache auth status` to audit remaining sources.")
 		case len(scrubbed) > 0:
 			scrubbedPaths := make([]string, len(scrubbed))
@@ -111,17 +124,22 @@ type scrubbedItem struct {
 	hint string
 }
 
-func scrubDiskCredentials() ([]scrubbedItem, error) {
+func scrubDiskCredentials(target store.Kind) ([]scrubbedItem, error) {
 	osProxy := utils.DefaultOsProxy{}
 
-	var scrubbed []scrubbedItem
-
-	for _, scrub := range []func(utils.OsProxy) (scrubbedItem, error){
-		scrubMultiplatform,
+	scrubbers := []func(utils.OsProxy) (scrubbedItem, error){
 		scrubXcelerate,
 		scrubCcache,
 		scrubGradleInitKts,
-	} {
+	}
+	// Don't scrub the file we just wrote to (different field, same path — confusing on CI logs).
+	if target != store.KindFile {
+		scrubbers = append([]func(utils.OsProxy) (scrubbedItem, error){scrubMultiplatform}, scrubbers...)
+	}
+
+	var scrubbed []scrubbedItem
+
+	for _, scrub := range scrubbers {
 		item, err := scrub(osProxy)
 		if err != nil {
 			return scrubbed, err
@@ -287,9 +305,14 @@ var authStatusCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, _ []string) error {
 		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
-		target, migrationSources := credSources(utils.AllEnvs())
+		targets, migrationSources := credSources(utils.AllEnvs())
 
-		keychainPopulated := renderSource(logger, target, target.probe())
+		var targetPopulated bool
+		for _, t := range targets {
+			if renderSource(logger, t, t.probe()) {
+				targetPopulated = true
+			}
+		}
 
 		var foundElsewhere, suppressed bool
 		for _, s := range migrationSources {
@@ -311,11 +334,11 @@ var authStatusCmd = &cobra.Command{
 		logger.Println()
 		renderUsername(logger, utils.AllEnvs())
 
-		if !keychainPopulated && foundElsewhere {
+		if !targetPopulated && foundElsewhere {
 			logger.Println()
-			logger.Infof("Credentials exist outside the OS keychain — migrate with:")
+			logger.Infof("Credentials exist outside the managed backends — migrate with:")
 			logger.Infof("  bitrise-build-cache auth set --token <token> --workspace-id <workspace-id>")
-			logger.Infof("`auth set` scrubs the multiplatform config in place; xcelerate and ccache configs are re-written cleanly on the next `activate xcode` / `activate c++`.")
+			logger.Infof("`auth set` picks keychain locally and file storage on CI (fastlane setup_ci wipes the keychain).")
 		}
 
 		return nil
@@ -361,25 +384,26 @@ type credSource struct {
 	probe    func() credAudit
 }
 
-// Returns (target, migrationSources). The target is the canonical home for credentials (OS keychain);
-// migrationSources are inspected to nudge the user toward `auth set` when creds live elsewhere.
-func credSources(envs map[string]string) (credSource, []credSource) {
+func credSources(envs map[string]string) ([]credSource, []credSource) {
 	osProxy := utils.DefaultOsProxy{}
 
 	xcelerateConfigPath := xceleratconfig.ConfigFile(osProxy)
 	ccacheConfigPath := ccacheconfig.ConfigFile(osProxy)
 	multiplatformConfigPath := multiplatformconfig.FilePath(osProxy)
 
-	target := credSource{"OS keychain", "<system keychain>", probeKeychain}
+	targets := []credSource{
+		{"OS keychain", "<system keychain>", probeKeychain},
+		{"Config file (CI-safe)", displayHomePath(osProxy, multiplatformConfigPath), probeFileStore},
+	}
 	migrationSources := []credSource{
-		{"Multiplatform config", displayHomePath(osProxy, multiplatformConfigPath), probeMultiplatform},
+		{"Multiplatform config (legacy authConfig)", displayHomePath(osProxy, multiplatformConfigPath), probeMultiplatform},
 		{"Xcelerate config", displayHomePath(osProxy, xcelerateConfigPath), probeRawConfig(xcelerateConfigPath)},
 		{"Ccache config", displayHomePath(osProxy, ccacheConfigPath), probeRawConfig(ccacheConfigPath)},
 		{fmt.Sprintf("Env vars (%s + %s)", configcommon.EnvAuthToken, configcommon.EnvWorkspaceID), "process env", func() credAudit { return probeEnvVars(envs) }},
 		{fmt.Sprintf("CI JWT (%s)", configcommon.EnvJWT), "process env", func() credAudit { return probeJWT(envs) }},
 	}
 
-	return target, migrationSources
+	return targets, migrationSources
 }
 
 func renderSource(logger log.Logger, s credSource, a credAudit) bool {
@@ -443,6 +467,19 @@ func probeKeychain() credAudit {
 	return audit
 }
 
+// Reads mp.Credentials (new file backend), distinct from legacy authConfig in probeMultiplatform.
+func probeFileStore() credAudit {
+	creds, ok := multiplatformconfig.ReadCredentials(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
+	if !ok {
+		return credAudit{state: sourceAbsent, note: "not present"}
+	}
+	if creds.AuthToken == "" {
+		return credAudit{state: sourceAbsent, note: "credentials block present but empty"}
+	}
+
+	return credAudit{state: sourcePopulated, workspaceID: creds.WorkspaceID, authToken: creds.AuthToken, username: creds.Username}
+}
+
 func probeMultiplatform() credAudit {
 	cfg, err := multiplatformconfig.ReadConfig(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
 	switch {
@@ -452,6 +489,8 @@ func probeMultiplatform() credAudit {
 		return credAudit{state: sourceReadError, err: err}
 	case cfg.AuthConfig.AuthToken == "":
 		return credAudit{state: sourceAbsent, note: "present but no credentials"}
+	case cfg.Credentials != nil:
+		return credAudit{state: sourceAbsent, note: "mirrors the file-store credentials above"}
 	}
 
 	return credAudit{state: sourcePopulated, workspaceID: cfg.AuthConfig.WorkspaceID, authToken: cfg.AuthConfig.AuthToken}
@@ -510,18 +549,37 @@ func probeJWT(envs map[string]string) credAudit {
 }
 
 // nolint:gochecknoglobals
+var (
+	clearStorage string
+)
+
+// nolint:gochecknoglobals
 var authClearCmd = &cobra.Command{
 	Use:          "clear",
-	Short:        "Remove Bitrise Build Cache credentials from the OS keychain",
+	Short:        "Remove Bitrise Build Cache credentials from the OS keychain and the multiplatform config file",
+	Long:         "By default clears the OS keychain + the multiplatform config file. Legacy per-tool copies (xcelerate/ccache/gradle-init) are scrubbed via `auth set`, not here. Use --storage=keychain|file to target one backend.",
 	SilenceUsage: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
-		if err := keychain.New().Clear(); err != nil {
-			return fmt.Errorf("clear credentials from keychain: %w", err)
+		var targets []store.Store
+		switch clearStorage {
+		case "", "auto":
+			targets = []store.Store{store.NewKeychain(), store.NewFile()}
+		case "keychain":
+			targets = []store.Store{store.NewKeychain()}
+		case "file":
+			targets = []store.Store{store.NewFile()}
+		default:
+			return fmt.Errorf("unknown --storage %q (want keychain|file|auto)", clearStorage)
 		}
 
-		logger.TInfof("✅ Credentials removed from the OS keychain")
+		for _, t := range targets {
+			if err := t.Clear(); err != nil {
+				return fmt.Errorf("clear %s: %w", t.Kind(), err)
+			}
+			logger.TInfof("✅ Credentials removed from %s", t.Kind())
+		}
 
 		return nil
 	},
@@ -563,8 +621,11 @@ func init() {
 	authSetCmd.Flags().StringVar(&setToken, "token", "", "Bitrise Build Cache auth token (required)")
 	authSetCmd.Flags().StringVar(&setWorkspaceID, "workspace-id", "", "Bitrise workspace ID (required)")
 	authSetCmd.Flags().StringVar(&setUsername, "username", "", fmt.Sprintf("Display name for local invocations (optional). Overrides the OS username. Env var %s takes precedence for a single run.", configcommon.EnvUsername))
+	authSetCmd.Flags().StringVar(&setStorage, "storage", "", "Where to persist credentials: keychain (OS keychain) | file (multiplatform config on disk) | auto (default: CI→file, local→keychain). File storage is required on CI where fastlane setup_ci swaps the default keychain.")
 	_ = authSetCmd.MarkFlagRequired("token")
 	_ = authSetCmd.MarkFlagRequired("workspace-id")
+
+	authClearCmd.Flags().StringVar(&clearStorage, "storage", "", "Which backend to clear: keychain | file | auto (default auto clears both).")
 
 	authCmd.AddCommand(authSetCmd)
 	authCmd.AddCommand(authStatusCmd)

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -14,6 +14,7 @@ import (
 	keyring "github.com/zalando/go-keyring"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
@@ -197,6 +198,55 @@ func TestAuthSetCmd_emptyUsernameLeavesFieldEmpty(t *testing.T) {
 	creds, err := keychain.New().Load()
 	require.NoError(t, err)
 	assert.Empty(t, creds.Username)
+}
+
+func TestAuthSetCmd_storageFileWritesToMultiplatformConfig(t *testing.T) {
+	keyring.MockInit()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	setToken = "tok-file"
+	setWorkspaceID = "ws-file"
+	setUsername = "bob"
+	setStorage = "file"
+	t.Cleanup(func() { setToken, setWorkspaceID, setUsername, setStorage = "", "", "", "" })
+
+	require.NoError(t, authSetCmd.RunE(authSetCmd, nil))
+
+	creds, ok := multiplatformconfig.ReadCredentials(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
+	require.True(t, ok, "credentials must be present in multiplatform config after --storage=file")
+	assert.Equal(t, "tok-file", creds.AuthToken)
+	assert.Equal(t, "ws-file", creds.WorkspaceID)
+	assert.Equal(t, "bob", creds.Username)
+
+	mp, err := multiplatformconfig.ReadConfig(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
+	require.NoError(t, err)
+	assert.Equal(t, "tok-file", mp.AuthConfig.AuthToken, "AuthConfig must mirror for legacy reactnative/invocation readers")
+	assert.Equal(t, "ws-file", mp.AuthConfig.WorkspaceID)
+
+	_, err = keychain.New().Load()
+	assert.ErrorIs(t, err, keychain.ErrNotFound)
+}
+
+func TestAuthSetCmd_ciDetectionRoutesToFile(t *testing.T) {
+	keyring.MockInit()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CIRCLECI", "true")
+
+	setToken = "tok-ci"
+	setWorkspaceID = "ws-ci"
+	setStorage = "" // auto
+	t.Cleanup(func() { setToken, setWorkspaceID, setStorage = "", "", "" })
+
+	require.NoError(t, authSetCmd.RunE(authSetCmd, nil))
+
+	creds, ok := multiplatformconfig.ReadCredentials(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
+	require.True(t, ok)
+	assert.Equal(t, "tok-ci", creds.AuthToken)
+
+	_, err := keychain.New().Load()
+	assert.ErrorIs(t, err, keychain.ErrNotFound)
 }
 
 func TestAuthSetCmd_preservesOAuthFieldsOnUsernameEdit(t *testing.T) {

--- a/cmd/common/activate_interactive_huh.go
+++ b/cmd/common/activate_interactive_huh.go
@@ -117,11 +117,11 @@ func (*huhWizard) Run(ctx context.Context) error {
 	case configcommon.AuthSourceJWT:
 		// Per-build, don't persist.
 		logger.TInfof("Using credentials resolved by the CLI.")
-	case configcommon.AuthSourceMultiplatform:
+	case configcommon.AuthSourceMultiplatform, configcommon.AuthSourceFile:
 		if err := persistCredentials(kc, storedCreds, workspaceID, authToken, username); err != nil {
 			logger.Warnf("Could not save credentials to the OS keychain (%v). Continuing with disk values for this run only.", err)
 		} else {
-			logger.TInfof("Migrated credentials from the multiplatform config to the OS keychain.")
+			logger.TInfof("Migrated credentials from the config file to the OS keychain.")
 			if username != "" {
 				logger.Infof("Saved display name %q for local invocations.", username)
 			}
@@ -161,6 +161,7 @@ func usernamePersistable(source configcommon.AuthSource) bool {
 	return source == configcommon.AuthSourceKeychain ||
 		source == configcommon.AuthSourceEnvVars ||
 		source == configcommon.AuthSourceMultiplatform ||
+		source == configcommon.AuthSourceFile ||
 		source == configcommon.AuthSourceNone
 }
 

--- a/cmd/common/login.go
+++ b/cmd/common/login.go
@@ -8,13 +8,18 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/spf13/cobra"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/store"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/bitriseapi"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/oauth"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
-var loginWorkspace string //nolint:gochecknoglobals
+//nolint:gochecknoglobals
+var (
+	loginWorkspace string
+	loginStorage   string
+)
 
 // LoginCmd signs the user in via the browser (OAuth) and stores a managed,
 // auto-refreshing credential for local build-cache use.
@@ -64,6 +69,7 @@ var LogoutCmd = &cobra.Command{ //nolint:gochecknoglobals
 
 func init() { //nolint:gochecknoinits
 	LoginCmd.Flags().StringVar(&loginWorkspace, "workspace", "", "workspace (organization) slug to use; skips the interactive picker")
+	LoginCmd.Flags().StringVar(&loginStorage, "storage", "", "Where to persist credentials: keychain | file | auto (default: CI→file, local→keychain).")
 	// LoginCmd / LogoutCmd are registered under the `auth` command (cmd/auth).
 }
 
@@ -92,11 +98,20 @@ func runLogin(cmd *cobra.Command) error {
 	}
 	creds.WorkspaceID = workspace
 
-	if err := oauth.Save(creds); err != nil {
+	target, err := store.Select(envs, loginStorage)
+	if err != nil {
+		return err //nolint:wrapcheck
+	}
+	if err := oauth.SaveTo(target, creds); err != nil {
 		return fmt.Errorf("save credentials: %w", err)
 	}
 
-	logger.Infof("Signed in. Using workspace %q for the build cache.", workspace)
+	switch target.Kind() {
+	case store.KindKeychain:
+		logger.Infof("Signed in. Using workspace %q for the build cache. Credentials stored in the OS keychain.", workspace)
+	case store.KindFile:
+		logger.Infof("Signed in. Using workspace %q for the build cache. Credentials stored in the multiplatform config file (CI-safe).", workspace)
+	}
 
 	if shadow := shadowingAuthEnv(); shadow != "" {
 		logger.Warnf("%s is set and takes precedence over the login just saved.", shadow)
@@ -113,7 +128,7 @@ func shadowingAuthEnv() string {
 		return configcommon.EnvAuthToken
 	case configcommon.AuthSourceJWT:
 		return configcommon.EnvJWT
-	case configcommon.AuthSourceNone, configcommon.AuthSourceKeychain, configcommon.AuthSourceMultiplatform:
+	case configcommon.AuthSourceNone, configcommon.AuthSourceKeychain, configcommon.AuthSourceFile, configcommon.AuthSourceMultiplatform:
 	}
 
 	return ""
@@ -145,13 +160,14 @@ func pickWorkspace(ctx context.Context, envs map[string]string, pat string) (str
 	return workspaces[idx].Slug, nil
 }
 
-// hydrateStoredAuth refreshes a stale keychain OAuth login so ResolveAuthConfig
-// serves a live PAT. Skipped when an env credential wins (env precedence, and CI
-// must never refresh); this is the only path that does a network refresh.
+// Skip on Bitrise CI where JWT is env-injected; self-hosted CI with a stored PAT still refreshes.
 func hydrateStoredAuth(ctx context.Context) {
-	// A keychain OAuth login always wins over multiplatform, so only the
-	// keychain source can have one to refresh; env sources take precedence.
-	if _, source, _ := configcommon.ResolveAuthConfig(utils.AllEnvs()); source != configcommon.AuthSourceKeychain {
+	envs := utils.AllEnvs()
+	if envs[configcommon.EnvJWT] != "" {
+		return
+	}
+	_, source, _ := configcommon.ResolveAuthConfig(envs)
+	if source != configcommon.AuthSourceKeychain && source != configcommon.AuthSourceFile {
 		return
 	}
 	logger := log.NewLogger(log.WithDebugLog(IsDebugLogMode))

--- a/cmd/xcode/activate_xcode_test.go
+++ b/cmd/xcode/activate_xcode_test.go
@@ -37,6 +37,8 @@ func TestActivateXcode_activateXcodeCmdFn(t *testing.T) {
 			CreateFunc:    os.Create,
 			OpenFileFunc:  os.OpenFile,
 			WriteFileFunc: os.WriteFile,
+			RenameFunc:    os.Rename,
+			RemoveFunc:    os.Remove,
 		}
 
 		err := xcode.ActivateXcodeCommandFn(

--- a/internal/auth/store/persist.go
+++ b/internal/auth/store/persist.go
@@ -1,0 +1,34 @@
+package store
+
+import (
+	"github.com/bitrise-io/go-utils/v2/log"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
+)
+
+// PersistActivateCreds routes non-JWT activation creds to keychain (local) or the multiplatform Credentials field (CI); JWT keeps the legacy AuthConfig write for downstream reactnative/invocation compat.
+func PersistActivateCreds(logger log.Logger, envs map[string]string, auth configcommon.CacheAuthConfig, mpCfg *multiplatformconfig.Config) {
+	if auth.IsJWT {
+		mpCfg.AuthConfig = auth
+
+		return
+	}
+	target := SelectAuto(envs)
+	if target.Kind() == KindFile {
+		c := keychain.Credentials{AuthToken: auth.AuthToken, WorkspaceID: auth.WorkspaceID}
+		mpCfg.Credentials = &c
+		mpCfg.AuthConfig = auth
+		logger.Infof("Saved auth credentials to the multiplatform config file (CI-safe — fastlane setup_ci swaps the keychain)")
+
+		return
+	}
+	if err := target.Save(keychain.Credentials{AuthToken: auth.AuthToken, WorkspaceID: auth.WorkspaceID}); err != nil {
+		logger.Warnf("Keychain save failed (%v); falling back to multiplatform authConfig", err)
+		mpCfg.AuthConfig = auth
+
+		return
+	}
+	logger.Infof("Saved auth credentials to the OS keychain")
+}

--- a/internal/auth/store/store.go
+++ b/internal/auth/store/store.go
@@ -1,0 +1,147 @@
+// Package store picks the credential backend: CI→file (fastlane setup_ci swaps the keychain), local→keychain.
+package store
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+)
+
+// Sentinel independent of backend; callers can errors.Is either this or keychain.ErrNotFound.
+var ErrNotFound = errors.New("no Bitrise Build Cache credentials in store")
+
+type Kind int
+
+const (
+	KindKeychain Kind = iota
+	KindFile
+)
+
+func (k Kind) String() string {
+	switch k {
+	case KindKeychain:
+		return "keychain"
+	case KindFile:
+		return "file"
+	}
+
+	return "unknown"
+}
+
+// Load returns ErrNotFound when nothing is stored.
+type Store interface {
+	Kind() Kind
+	Load() (keychain.Credentials, error)
+	Save(creds keychain.Credentials) error
+	Clear() error
+}
+
+// CI→file, local→keychain. Total function; no error path.
+func SelectAuto(envs map[string]string) Store {
+	if common.DetectCIProvider(envs) != "" {
+		return NewFile()
+	}
+
+	return NewKeychain()
+}
+
+// override: "keychain" | "file" | "" | "auto"; empty/auto delegates to SelectAuto.
+func Select(envs map[string]string, override string) (Store, error) {
+	switch override {
+	case "", "auto":
+		return SelectAuto(envs), nil
+	case "keychain":
+		return NewKeychain(), nil
+	case "file":
+		return NewFile(), nil
+	}
+
+	return nil, fmt.Errorf("unknown storage backend %q (want keychain|file|auto)", override)
+}
+
+// Saves to target, then best-effort clears every other backend to prevent split-brain.
+func SaveExclusive(target Store, creds keychain.Credentials) error {
+	if err := target.Save(creds); err != nil {
+		return err //nolint:wrapcheck
+	}
+	for _, other := range []Store{NewKeychain(), NewFile()} {
+		if other.Kind() == target.Kind() {
+			continue
+		}
+		_ = other.Clear()
+	}
+
+	return nil
+}
+
+func NewKeychain() Store {
+	return keychainStore{kc: keychain.New()}
+}
+
+func NewFile() Store {
+	return fileStore{
+		osProxy:        utils.DefaultOsProxy{},
+		encoderFactory: utils.DefaultEncoderFactory{},
+		decoderFactory: utils.DefaultDecoderFactory{},
+	}
+}
+
+type keychainStore struct {
+	kc *keychain.Keychain
+}
+
+func (s keychainStore) Kind() Kind { return KindKeychain }
+
+func (s keychainStore) Load() (keychain.Credentials, error) {
+	creds, err := s.kc.Load()
+	if errors.Is(err, keychain.ErrNotFound) {
+		return keychain.Credentials{}, ErrNotFound
+	}
+
+	return creds, err //nolint:wrapcheck // keychain.Keychain already wraps
+}
+
+func (s keychainStore) Save(c keychain.Credentials) error {
+	return s.kc.Save(c) //nolint:wrapcheck
+}
+
+func (s keychainStore) Clear() error {
+	return s.kc.Clear() //nolint:wrapcheck
+}
+
+type fileStore struct {
+	osProxy        utils.OsProxy
+	encoderFactory utils.EncoderFactory
+	decoderFactory utils.DecoderFactory
+}
+
+func (s fileStore) Kind() Kind { return KindFile }
+
+func (s fileStore) Load() (keychain.Credentials, error) {
+	creds, ok := multiplatformconfig.ReadCredentials(s.osProxy, s.decoderFactory)
+	if !ok {
+		return keychain.Credentials{}, ErrNotFound
+	}
+
+	return creds, nil
+}
+
+func (s fileStore) Save(c keychain.Credentials) error {
+	if err := multiplatformconfig.SaveCredentials(s.osProxy, s.encoderFactory, s.decoderFactory, c); err != nil {
+		return fmt.Errorf("save credentials to multiplatform config: %w", err)
+	}
+
+	return nil
+}
+
+func (s fileStore) Clear() error {
+	if err := multiplatformconfig.ClearCredentials(s.osProxy, s.encoderFactory, s.decoderFactory); err != nil {
+		return fmt.Errorf("clear credentials from multiplatform config: %w", err)
+	}
+
+	return nil
+}

--- a/internal/auth/store/store_test.go
+++ b/internal/auth/store/store_test.go
@@ -1,0 +1,106 @@
+//go:build unit
+
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	keyring "github.com/zalando/go-keyring"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+)
+
+func TestSelect_defaultsToKeychainLocally(t *testing.T) {
+	s, err := Select(map[string]string{}, "")
+	require.NoError(t, err)
+	assert.Equal(t, KindKeychain, s.Kind())
+}
+
+func TestSelect_defaultsToFileOnCI(t *testing.T) {
+	envs := map[string]string{"CIRCLECI": "true"}
+	s, err := Select(envs, "")
+	require.NoError(t, err)
+	assert.Equal(t, KindFile, s.Kind())
+}
+
+func TestSelect_overrides(t *testing.T) {
+	envs := map[string]string{"CIRCLECI": "true"} // CI, but override
+	kc, err := Select(envs, "keychain")
+	require.NoError(t, err)
+	assert.Equal(t, KindKeychain, kc.Kind())
+
+	fs, err := Select(map[string]string{}, "file")
+	require.NoError(t, err)
+	assert.Equal(t, KindFile, fs.Kind())
+}
+
+func TestSelect_unknownOverrideErrors(t *testing.T) {
+	_, err := Select(map[string]string{}, "vault")
+	require.Error(t, err)
+}
+
+func TestKeychainStore_LoadNotFoundMapsToErrNotFound(t *testing.T) {
+	keyring.MockInit()
+	s := NewKeychain()
+	_, err := s.Load()
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestSaveExclusive_ClearsOtherBackend(t *testing.T) {
+	keyring.MockInit()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	kc := NewKeychain()
+	require.NoError(t, kc.Save(keychain.Credentials{AuthToken: "old", WorkspaceID: "old-ws"}))
+
+	require.NoError(t, SaveExclusive(NewFile(), keychain.Credentials{AuthToken: "new", WorkspaceID: "new-ws"}))
+
+	_, err := kc.Load()
+	require.ErrorIs(t, err, ErrNotFound, "keychain must be cleared after exclusive file save")
+
+	got, err := NewFile().Load()
+	require.NoError(t, err)
+	assert.Equal(t, "new", got.AuthToken)
+}
+
+func TestFileStore_SavePersistsAtRestrictedPerms(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	s := NewFile()
+	require.NoError(t, s.Save(keychain.Credentials{AuthToken: "t", WorkspaceID: "w"}))
+
+	info, err := os.Stat(filepath.Join(home, ".bitrise", "analytics", "multiplatform", "config.json"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "file must be 0600 (token + refresh token inside)")
+
+	dirInfo, err := os.Stat(filepath.Join(home, ".bitrise", "analytics", "multiplatform"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm())
+}
+
+func TestFileStore_RoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".bitrise", "analytics", "multiplatform"), 0o755))
+
+	s := NewFile()
+	_, err := s.Load()
+	require.ErrorIs(t, err, ErrNotFound)
+
+	want := keychain.Credentials{AuthToken: "tok", WorkspaceID: "ws", Username: "u"}
+	require.NoError(t, s.Save(want))
+
+	got, err := s.Load()
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	require.NoError(t, s.Clear())
+	_, err = s.Load()
+	require.ErrorIs(t, err, ErrNotFound)
+}

--- a/internal/config/common/auth.go
+++ b/internal/config/common/auth.go
@@ -52,6 +52,7 @@ const (
 	AuthSourceEnvVars
 	AuthSourceJWT
 	AuthSourceKeychain
+	AuthSourceFile
 	AuthSourceMultiplatform
 )
 
@@ -79,20 +80,28 @@ const (
 	UsernameSourceNone UsernameSource = iota
 	UsernameSourceEnv
 	UsernameSourceKeychain
+	UsernameSourceFile
 	UsernameSourceOS
 )
 
 func ResolveUsername(envs map[string]string) (string, UsernameSource) {
-	return resolveUsername(envs, keychain.New(), osUsername)
+	return resolveUsername(envs, keychain.New(), fileCredentialsReader, osUsername)
 }
 
-func resolveUsername(envs map[string]string, loader AuthLoader, osResolver func() string) (string, UsernameSource) {
+func resolveUsername(envs map[string]string, loader AuthLoader, readFile func() (keychain.Credentials, bool), osResolver func() string) (string, UsernameSource) {
 	if v := strings.TrimSpace(envs[EnvUsername]); v != "" {
 		return v, UsernameSourceEnv
 	}
 	if creds, err := loader.Load(); err == nil {
 		if v := strings.TrimSpace(creds.Username); v != "" {
 			return v, UsernameSourceKeychain
+		}
+	}
+	if readFile != nil {
+		if creds, ok := readFile(); ok {
+			if v := strings.TrimSpace(creds.Username); v != "" {
+				return v, UsernameSourceFile
+			}
 		}
 	}
 	if v := strings.TrimSpace(osResolver()); v != "" {
@@ -120,20 +129,33 @@ func RegisterMultiplatformReader(fn func() (CacheAuthConfig, error)) {
 	multiplatformConfigReader = fn
 }
 
-// ResolveAuthConfig resolves credentials in priority order: env vars → keychain
-// → multiplatform config → env-vars error. The returned AuthSource identifies
-// which source actually populated the result.
-func ResolveAuthConfig(envs map[string]string) (CacheAuthConfig, AuthSource, error) {
-	return resolveAuthConfig(envs, keychain.New(), multiplatformConfigReader)
+// Wired from multiplatform to avoid the import cycle.
+//
+//nolint:gochecknoglobals
+var fileCredentialsReader func() (keychain.Credentials, bool)
+
+func RegisterFileCredentialsReader(fn func() (keychain.Credentials, bool)) {
+	fileCredentialsReader = fn
 }
 
-func resolveAuthConfig(envs map[string]string, loader AuthLoader, readMultiplatform func() (CacheAuthConfig, error)) (CacheAuthConfig, AuthSource, error) {
+// Precedence: env → keychain → multiplatform Credentials (CI-safe file) → legacy authConfig → not-set error.
+func ResolveAuthConfig(envs map[string]string) (CacheAuthConfig, AuthSource, error) {
+	return resolveAuthConfig(envs, keychain.New(), fileCredentialsReader, multiplatformConfigReader)
+}
+
+func resolveAuthConfig(envs map[string]string, loader AuthLoader, readFile func() (keychain.Credentials, bool), readMultiplatform func() (CacheAuthConfig, error)) (CacheAuthConfig, AuthSource, error) {
 	if hasAuthEnvVars(envs) {
 		return readAuthConfigFromEnvironments(envs)
 	}
 
 	if cfg, ok := GetKeychainCredentialsWith(loader); ok {
 		return cfg, AuthSourceKeychain, nil
+	}
+
+	if readFile != nil {
+		if creds, ok := readFile(); ok && creds.AuthToken != "" && creds.WorkspaceID != "" {
+			return CacheAuthConfig{AuthToken: creds.AuthToken, WorkspaceID: creds.WorkspaceID}, AuthSourceFile, nil
+		}
 	}
 
 	if readMultiplatform != nil {

--- a/internal/config/common/auth_test.go
+++ b/internal/config/common/auth_test.go
@@ -26,7 +26,7 @@ func TestResolveAuthConfig_envVarsWinOverKeychain(t *testing.T) {
 		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
 	}
 
-	got, _, err := resolveAuthConfig(envs, loader, nil)
+	got, _, err := resolveAuthConfig(envs, loader, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "env-tok", got.AuthToken, "env vars take precedence over stored creds")
 	assert.Equal(t, "env-ws", got.WorkspaceID)
@@ -38,7 +38,7 @@ func TestResolveAuthConfig_jwtEnvWinsOverKeychain(t *testing.T) {
 		"BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN": makeUMAJWT("ci-ws"),
 	}
 
-	got, _, err := resolveAuthConfig(envs, loader, nil)
+	got, _, err := resolveAuthConfig(envs, loader, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "ci-ws", got.WorkspaceID, "CI JWT env var overrides stored creds")
 	assert.True(t, got.IsJWT)
@@ -47,7 +47,7 @@ func TestResolveAuthConfig_jwtEnvWinsOverKeychain(t *testing.T) {
 func TestResolveAuthConfig_noEnv_keychainHit(t *testing.T) {
 	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok", WorkspaceID: "kc-ws"}}
 
-	got, _, err := resolveAuthConfig(map[string]string{}, loader, nil)
+	got, _, err := resolveAuthConfig(map[string]string{}, loader, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "kc-tok", got.AuthToken)
 	assert.Equal(t, "kc-ws", got.WorkspaceID)
@@ -56,21 +56,21 @@ func TestResolveAuthConfig_noEnv_keychainHit(t *testing.T) {
 func TestResolveAuthConfig_noEnv_keychainNotFound_returnsEnvNotSetError(t *testing.T) {
 	loader := fakeAuthLoader{err: keychain.ErrNotFound}
 
-	_, _, err := resolveAuthConfig(map[string]string{}, loader, nil)
+	_, _, err := resolveAuthConfig(map[string]string{}, loader, nil, nil)
 	require.ErrorIs(t, err, ErrAuthTokenNotProvided)
 }
 
 func TestResolveAuthConfig_noEnv_keychainError_returnsEnvNotSetError(t *testing.T) {
 	loader := fakeAuthLoader{err: errors.New("dbus connection failed")}
 
-	_, _, err := resolveAuthConfig(map[string]string{}, loader, nil)
+	_, _, err := resolveAuthConfig(map[string]string{}, loader, nil, nil)
 	require.ErrorIs(t, err, ErrAuthTokenNotProvided)
 }
 
 func TestResolveAuthConfig_noEnv_keychainPartial_returnsEnvNotSetError(t *testing.T) {
 	loader := fakeAuthLoader{creds: keychain.Credentials{AuthToken: "kc-tok"}}
 
-	_, _, err := resolveAuthConfig(map[string]string{}, loader, nil)
+	_, _, err := resolveAuthConfig(map[string]string{}, loader, nil, nil)
 	require.ErrorIs(t, err, ErrAuthTokenNotProvided)
 }
 
@@ -80,7 +80,7 @@ func TestResolveAuthConfig_partialEnv_fallsBackToKeychain(t *testing.T) {
 		"BITRISE_BUILD_CACHE_AUTH_TOKEN": "env-tok",
 	}
 
-	got, _, err := resolveAuthConfig(envs, loader, nil)
+	got, _, err := resolveAuthConfig(envs, loader, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "kc-tok", got.AuthToken, "incomplete env vars should not silently mix with keychain")
 	assert.Equal(t, "kc-ws", got.WorkspaceID)
@@ -92,7 +92,7 @@ func TestResolveAuthConfig_noEnv_noKeychain_fallsBackToMultiplatformConfig(t *te
 		return CacheAuthConfig{AuthToken: "mp-tok", WorkspaceID: "mp-ws"}, nil
 	}
 
-	got, _, err := resolveAuthConfig(map[string]string{}, loader, readMp)
+	got, _, err := resolveAuthConfig(map[string]string{}, loader, nil, readMp)
 	require.NoError(t, err)
 	assert.Equal(t, "mp-tok", got.AuthToken)
 	assert.Equal(t, "mp-ws", got.WorkspaceID)
@@ -104,7 +104,7 @@ func TestResolveAuthConfig_keychainWinsOverMultiplatformConfig(t *testing.T) {
 		return CacheAuthConfig{AuthToken: "mp-tok", WorkspaceID: "mp-ws"}, nil
 	}
 
-	got, _, err := resolveAuthConfig(map[string]string{}, loader, readMp)
+	got, _, err := resolveAuthConfig(map[string]string{}, loader, nil, readMp)
 	require.NoError(t, err)
 	assert.Equal(t, "kc-tok", got.AuthToken, "keychain takes precedence over multiplatform config")
 	assert.Equal(t, "kc-ws", got.WorkspaceID)
@@ -120,7 +120,7 @@ func TestResolveAuthConfig_envWinsOverMultiplatformConfig(t *testing.T) {
 		"BITRISE_BUILD_CACHE_WORKSPACE_ID": "env-ws",
 	}
 
-	got, _, err := resolveAuthConfig(envs, loader, readMp)
+	got, _, err := resolveAuthConfig(envs, loader, nil, readMp)
 	require.NoError(t, err)
 	assert.Equal(t, "env-tok", got.AuthToken, "env vars take precedence over multiplatform config")
 	assert.Equal(t, "env-ws", got.WorkspaceID)
@@ -132,7 +132,7 @@ func TestResolveAuthConfig_multiplatformReaderErrorIsSwallowed(t *testing.T) {
 		return CacheAuthConfig{}, errors.New("disk read failed")
 	}
 
-	_, _, err := resolveAuthConfig(map[string]string{}, loader, readMp)
+	_, _, err := resolveAuthConfig(map[string]string{}, loader, nil, readMp)
 	require.ErrorIs(t, err, ErrAuthTokenNotProvided, "multiplatform read error falls through to env-not-set canonical error")
 }
 
@@ -142,7 +142,7 @@ func TestResolveAuthConfig_multiplatformPartial_fallsThroughToEnvError(t *testin
 		return CacheAuthConfig{AuthToken: "mp-tok"}, nil
 	}
 
-	_, _, err := resolveAuthConfig(map[string]string{}, loader, readMp)
+	_, _, err := resolveAuthConfig(map[string]string{}, loader, nil, readMp)
 	require.ErrorIs(t, err, ErrAuthTokenNotProvided)
 }
 
@@ -463,7 +463,7 @@ func TestResolveUsername_envWins(t *testing.T) {
 	loader := fakeAuthLoader{creds: keychain.Credentials{Username: "kc-user"}}
 	envs := map[string]string{EnvUsername: "env-user"}
 
-	got, src := resolveUsername(envs, loader, osUserStub)
+	got, src := resolveUsername(envs, loader, nil, osUserStub)
 	assert.Equal(t, "env-user", got)
 	assert.Equal(t, UsernameSourceEnv, src)
 }
@@ -471,7 +471,7 @@ func TestResolveUsername_envWins(t *testing.T) {
 func TestResolveUsername_keychainWinsOverOS(t *testing.T) {
 	loader := fakeAuthLoader{creds: keychain.Credentials{Username: "kc-user"}}
 
-	got, src := resolveUsername(map[string]string{}, loader, osUserStub)
+	got, src := resolveUsername(map[string]string{}, loader, nil, osUserStub)
 	assert.Equal(t, "kc-user", got)
 	assert.Equal(t, UsernameSourceKeychain, src)
 }
@@ -479,7 +479,7 @@ func TestResolveUsername_keychainWinsOverOS(t *testing.T) {
 func TestResolveUsername_osFallback(t *testing.T) {
 	loader := fakeAuthLoader{creds: keychain.Credentials{}}
 
-	got, src := resolveUsername(map[string]string{}, loader, osUserStub)
+	got, src := resolveUsername(map[string]string{}, loader, nil, osUserStub)
 	assert.Equal(t, "os-user", got)
 	assert.Equal(t, UsernameSourceOS, src)
 }
@@ -488,7 +488,7 @@ func TestResolveUsername_envEmptyStringSkipped(t *testing.T) {
 	loader := fakeAuthLoader{creds: keychain.Credentials{Username: "kc-user"}}
 	envs := map[string]string{EnvUsername: "  "}
 
-	got, src := resolveUsername(envs, loader, osUserStub)
+	got, src := resolveUsername(envs, loader, nil, osUserStub)
 	assert.Equal(t, "kc-user", got)
 	assert.Equal(t, UsernameSourceKeychain, src)
 }
@@ -496,7 +496,7 @@ func TestResolveUsername_envEmptyStringSkipped(t *testing.T) {
 func TestResolveUsername_allEmpty(t *testing.T) {
 	loader := fakeAuthLoader{err: keychain.ErrNotFound}
 
-	got, src := resolveUsername(map[string]string{}, loader, func() string { return "" })
+	got, src := resolveUsername(map[string]string{}, loader, nil, func() string { return "" })
 	assert.Empty(t, got)
 	assert.Equal(t, UsernameSourceNone, src)
 }

--- a/internal/config/common/authsource.go
+++ b/internal/config/common/authsource.go
@@ -30,6 +30,8 @@ func SourceLabel(source AuthSource, isOAuthLogin bool) string {
 		}
 
 		return "OS keychain"
+	case AuthSourceFile:
+		return "config file (CI-safe)"
 	case AuthSourceMultiplatform:
 		return "multiplatform config"
 	case AuthSourceNone:

--- a/internal/config/multiplatform/config.go
+++ b/internal/config/multiplatform/config.go
@@ -1,9 +1,13 @@
 package multiplatform
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
@@ -19,11 +23,10 @@ const (
 	ErrFmtCreateFolder     = "failed to create %s folder: %w"
 )
 
-// Config holds the auth credentials needed by the react-native run wrapper to
-// send invocation analytics. It is written by `activate react-native` and read
-// by the `react-native run` command, independently of any ccache activation.
+// Credentials is the CI-safe file backend for auth set/login; AuthConfig stays for backward compatibility with older analytics readers.
 type Config struct {
 	AuthConfig   common.CacheAuthConfig `json:"authConfig"`
+	Credentials  *keychain.Credentials  `json:"credentials,omitempty"`
 	DebugLogging bool                   `json:"debugLogging,omitempty"`
 }
 
@@ -44,32 +47,78 @@ func FilePath(osProxy utils.OsProxy) string {
 	return filepath.Join(dirPath(osProxy), configFile)
 }
 
-// Save writes the config to disk, creating the directory if needed.
+// Atomic write with 0600 perms — file holds PATs and OAuth refresh tokens.
 func (c Config) Save(osProxy utils.OsProxy, encoderFactory utils.EncoderFactory) error {
 	dir := dirPath(osProxy)
-	if err := osProxy.MkdirAll(dir, 0o755); err != nil {
+	if err := osProxy.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf(ErrFmtCreateFolder, dir, err)
 	}
 
-	path := FilePath(osProxy)
-	f, err := osProxy.Create(path)
-	if err != nil {
-		return fmt.Errorf(ErrFmtCreateConfigFile, err)
-	}
-	defer f.Close()
-
-	enc := encoderFactory.Encoder(f)
+	var buf bytes.Buffer
+	enc := encoderFactory.Encoder(&buf)
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
 	if err := enc.Encode(c); err != nil {
 		return fmt.Errorf(ErrFmtEncodeConfigFile, err)
 	}
 
-	if err := f.Sync(); err != nil {
-		return fmt.Errorf("failed to sync multiplatform config file: %w", err)
+	path := FilePath(osProxy)
+	tmp := path + ".tmp"
+	if err := osProxy.WriteFile(tmp, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf(ErrFmtCreateConfigFile, err)
+	}
+	if err := osProxy.Rename(tmp, path); err != nil {
+		_ = osProxy.Remove(tmp)
+
+		return fmt.Errorf("rename multiplatform config file: %w", err)
 	}
 
 	return nil
+}
+
+// Mirrors creds into legacy AuthConfig so downstream reactnative/invocation readers keep working.
+func SaveCredentials(osProxy utils.OsProxy, encoderFactory utils.EncoderFactory, decoderFactory utils.DecoderFactory, creds keychain.Credentials) error {
+	cfg, err := ReadConfig(osProxy, decoderFactory)
+	if err != nil && !isNotExist(err) {
+		return err
+	}
+
+	c := creds
+	cfg.Credentials = &c
+	cfg.AuthConfig = common.CacheAuthConfig{AuthToken: creds.AuthToken, WorkspaceID: creds.WorkspaceID}
+
+	return cfg.Save(osProxy, encoderFactory)
+}
+
+func ReadCredentials(osProxy utils.OsProxy, decoderFactory utils.DecoderFactory) (keychain.Credentials, bool) {
+	cfg, err := ReadConfig(osProxy, decoderFactory)
+	if err != nil || cfg.Credentials == nil {
+		return keychain.Credentials{}, false
+	}
+
+	return *cfg.Credentials, true
+}
+
+func ClearCredentials(osProxy utils.OsProxy, encoderFactory utils.EncoderFactory, decoderFactory utils.DecoderFactory) error {
+	cfg, err := ReadConfig(osProxy, decoderFactory)
+	if err != nil {
+		if isNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+	if cfg.Credentials == nil && cfg.AuthConfig.AuthToken == "" {
+		return nil
+	}
+	cfg.Credentials = nil
+	cfg.AuthConfig = common.CacheAuthConfig{}
+
+	return cfg.Save(osProxy, encoderFactory)
+}
+
+func isNotExist(err error) bool {
+	return errors.Is(err, fs.ErrNotExist)
 }
 
 // ReadConfig loads the config from disk.

--- a/internal/config/multiplatform/register.go
+++ b/internal/config/multiplatform/register.go
@@ -1,12 +1,14 @@
 package multiplatform
 
 import (
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 func init() { //nolint:gochecknoinits
 	common.RegisterMultiplatformReader(readMultiplatformAuthConfig)
+	common.RegisterFileCredentialsReader(readMultiplatformCredentials)
 }
 
 func readMultiplatformAuthConfig() (common.CacheAuthConfig, error) {
@@ -16,4 +18,8 @@ func readMultiplatformAuthConfig() (common.CacheAuthConfig, error) {
 	}
 
 	return cfg.AuthConfig, nil
+}
+
+func readMultiplatformCredentials() (keychain.Credentials, bool) {
+	return ReadCredentials(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
 }

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/shirou/gopsutil/v4/process"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/store"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
@@ -90,21 +90,7 @@ func Activate(
 	}
 
 	mpCfg := multiplatformconfig.Config{DebugLogging: config.DebugLogging}
-	if config.AuthConfig.IsJWT {
-		mpCfg.AuthConfig = config.AuthConfig
-	} else {
-		wrote, err := keychain.New().SaveIfChanged(keychain.Credentials{
-			AuthToken:   config.AuthConfig.AuthToken,
-			WorkspaceID: config.AuthConfig.WorkspaceID,
-		})
-		switch {
-		case err != nil:
-			logger.Warnf("Failed to save auth credentials to the OS keychain, falling back to inline auth config: %s", err)
-			mpCfg.AuthConfig = config.AuthConfig
-		case wrote:
-			logger.Infof("Saved auth credentials to the OS keychain")
-		}
-	}
+	store.PersistActivateCreds(logger, envs, config.AuthConfig, &mpCfg)
 	if err := mpCfg.Save(osProxy, encoderFactory); err != nil {
 		return fmt.Errorf("failed to save multiplatform analytics config: %w", err)
 	}

--- a/internal/doctor/check_auth.go
+++ b/internal/doctor/check_auth.go
@@ -21,6 +21,12 @@ func (d *Doctor) authCheck() Check {
 				}
 			}
 
+			if cfg, source, err := common.ResolveAuthConfig(d.Envs); err == nil && source == common.AuthSourceFile {
+				desc := common.DescribeResolved(cfg, source)
+
+				return Result{State: StateOK, Detail: desc.Detail()}
+			}
+
 			if ws, tok := d.Envs[common.EnvWorkspaceID], d.Envs[common.EnvAuthToken]; ws != "" && tok != "" {
 				desc := common.DescribeResolved(common.CacheAuthConfig{AuthToken: tok, WorkspaceID: ws}, common.AuthSourceEnvVars)
 

--- a/internal/doctor/check_auth_backend.go
+++ b/internal/doctor/check_auth_backend.go
@@ -181,6 +181,8 @@ func sourceLabel(s common.AuthSource) string {
 		return "env"
 	case common.AuthSourceJWT:
 		return "jwt"
+	case common.AuthSourceFile:
+		return "config-file"
 	case common.AuthSourceMultiplatform:
 		return "multiplatform-config"
 	case common.AuthSourceNone:

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -112,9 +112,13 @@ func (c Config) authorizeURL(challenge, state, redirectURI string) string {
 // Returns ErrNotLoggedIn when no OAuth credential is stored. Persists any new
 // tokens back to disk.
 func (c Config) EnsureFresh(ctx context.Context) (Credentials, error) {
-	creds, err := Load()
+	creds, src, err := LoadWithSource()
 	if err != nil {
 		return Credentials{}, err
+	}
+	save := Save
+	if src != nil {
+		save = func(cr Credentials) error { return SaveTo(src, cr) }
 	}
 	if !creds.IsOAuthManaged() {
 		return Credentials{}, ErrNotLoggedIn
@@ -131,7 +135,7 @@ func (c Config) EnsureFresh(ctx context.Context) (Credentials, error) {
 	if creds.JWT != "" && now.Add(refreshSkew).Before(creds.JWTExpiry) {
 		if pat, expiry, exErr := c.exchangeJWTForPAT(ctx, creds.JWT); exErr == nil {
 			creds.PAT, creds.PATExpiry = pat, expiry
-			if err := Save(creds); err != nil {
+			if err := save(creds); err != nil {
 				return Credentials{}, err
 			}
 			c.infof("Refreshed Bitrise access token.")
@@ -161,7 +165,7 @@ func (c Config) EnsureFresh(ctx context.Context) (Credentials, error) {
 		return Credentials{}, fmt.Errorf("exchange refreshed token for a PAT: %w", err)
 	}
 	creds.PAT, creds.PATExpiry = pat, expiry
-	if err := Save(creds); err != nil {
+	if err := save(creds); err != nil {
 		return Credentials{}, err
 	}
 	c.infof("Refreshed Bitrise access token.")

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/store"
 )
 
 // Credentials is the OAuth login credential, persisted in the OS keychain as a
@@ -50,36 +51,57 @@ func fromKeychain(kc keychain.Credentials) Credentials {
 	}
 }
 
-// Load reads the stored credential from the keychain. A missing item returns the
-// zero Credentials so a not-logged-in user doesn't see an error.
 func Load() (Credentials, error) {
-	kc, err := keychain.New().Load()
-	if errors.Is(err, keychain.ErrNotFound) {
-		return Credentials{}, nil
-	}
-	if err != nil {
-		return Credentials{}, fmt.Errorf("load credentials: %w", err)
-	}
+	c, _, err := LoadWithSource()
 
-	return fromKeychain(kc), nil
+	return c, err
 }
 
-// Save writes c to the keychain.
+// Second return is nil when nothing was found; refresh flows save back into the same store.
+func LoadWithSource() (Credentials, store.Store, error) {
+	return loadFrom(store.NewKeychain(), store.NewFile())
+}
+
+func loadFrom(backends ...store.Store) (Credentials, store.Store, error) {
+	for _, s := range backends {
+		kc, err := s.Load()
+		switch {
+		case errors.Is(err, store.ErrNotFound):
+			continue
+		case err != nil:
+			return Credentials{}, nil, fmt.Errorf("load credentials: %w", err)
+		}
+
+		return fromKeychain(kc), s, nil
+	}
+
+	return Credentials{}, nil, nil
+}
+
 func Save(c Credentials) error {
+	return SaveTo(store.NewKeychain(), c)
+}
+
+func SaveTo(s store.Store, c Credentials) error {
 	if c.PAT == "" {
 		return errors.New("refusing to save credentials with empty PAT")
 	}
-	if err := keychain.New().Save(c.toKeychain()); err != nil {
+	if err := store.SaveExclusive(s, c.toKeychain()); err != nil {
 		return fmt.Errorf("save credentials: %w", err)
 	}
 
 	return nil
 }
 
-// Clear removes the stored credential from the keychain.
 func Clear() error {
-	if err := keychain.New().Clear(); err != nil {
-		return fmt.Errorf("clear credentials: %w", err)
+	return ClearFrom(store.NewKeychain(), store.NewFile())
+}
+
+func ClearFrom(backends ...store.Store) error {
+	for _, s := range backends {
+		if err := s.Clear(); err != nil {
+			return fmt.Errorf("clear credentials: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/utils/mocks/os_proxy_mock.go
+++ b/internal/utils/mocks/os_proxy_mock.go
@@ -46,6 +46,9 @@ var _ utils.OsProxy = &OsProxyMock{}
 //			RemoveFunc: func(name string) error {
 //				panic("mock out the Remove method")
 //			},
+//			RenameFunc: func(oldpath string, newpath string) error {
+//				panic("mock out the Rename method")
+//			},
 //			StatFunc: func(pth string) (os.FileInfo, error) {
 //				panic("mock out the Stat method")
 //			},
@@ -91,6 +94,9 @@ type OsProxyMock struct {
 
 	// RemoveFunc mocks the Remove method.
 	RemoveFunc func(name string) error
+
+	// RenameFunc mocks the Rename method.
+	RenameFunc func(oldpath string, newpath string) error
 
 	// StatFunc mocks the Stat method.
 	StatFunc func(pth string) (os.FileInfo, error)
@@ -151,6 +157,13 @@ type OsProxyMock struct {
 			// Name is the name argument value.
 			Name string
 		}
+		// Rename holds details about calls to the Rename method.
+		Rename []struct {
+			// Oldpath is the oldpath argument value.
+			Oldpath string
+			// Newpath is the newpath argument value.
+			Newpath string
+		}
 		// Stat holds details about calls to the Stat method.
 		Stat []struct {
 			// Pth is the pth argument value.
@@ -181,6 +194,7 @@ type OsProxyMock struct {
 	lockOpenFile         sync.RWMutex
 	lockReadFileIfExists sync.RWMutex
 	lockRemove           sync.RWMutex
+	lockRename           sync.RWMutex
 	lockStat             sync.RWMutex
 	lockTempDir          sync.RWMutex
 	lockUserHomeDir      sync.RWMutex
@@ -469,6 +483,42 @@ func (mock *OsProxyMock) RemoveCalls() []struct {
 	mock.lockRemove.RLock()
 	calls = mock.calls.Remove
 	mock.lockRemove.RUnlock()
+	return calls
+}
+
+// Rename calls RenameFunc.
+func (mock *OsProxyMock) Rename(oldpath string, newpath string) error {
+	if mock.RenameFunc == nil {
+		panic("OsProxyMock.RenameFunc: method is nil but OsProxy.Rename was just called")
+	}
+	callInfo := struct {
+		Oldpath string
+		Newpath string
+	}{
+		Oldpath: oldpath,
+		Newpath: newpath,
+	}
+	mock.lockRename.Lock()
+	mock.calls.Rename = append(mock.calls.Rename, callInfo)
+	mock.lockRename.Unlock()
+	return mock.RenameFunc(oldpath, newpath)
+}
+
+// RenameCalls gets all the calls that were made to Rename.
+// Check the length with:
+//
+//	len(mockedOsProxy.RenameCalls())
+func (mock *OsProxyMock) RenameCalls() []struct {
+	Oldpath string
+	Newpath string
+} {
+	var calls []struct {
+		Oldpath string
+		Newpath string
+	}
+	mock.lockRename.RLock()
+	calls = mock.calls.Rename
+	mock.lockRename.RUnlock()
 	return calls
 }
 

--- a/internal/utils/os_proxy.go
+++ b/internal/utils/os_proxy.go
@@ -19,6 +19,7 @@ type OsProxy interface {
 	OpenFile(name string, flag int, perm os.FileMode) (*os.File, error)
 	ReadFileIfExists(name string) (string, bool, error)
 	Remove(name string) error
+	Rename(oldpath, newpath string) error
 	Stat(pth string) (os.FileInfo, error)
 	TempDir() string
 	UserHomeDir() (string, error)
@@ -66,6 +67,10 @@ func (d DefaultOsProxy) TempDir() string {
 
 func (d DefaultOsProxy) Remove(name string) error {
 	return os.Remove(name) //nolint:wrapcheck
+}
+
+func (d DefaultOsProxy) Rename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath) //nolint:wrapcheck
 }
 
 func (d DefaultOsProxy) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {

--- a/pkg/ccache/activator.go
+++ b/pkg/ccache/activator.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 
-	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/store"
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
@@ -116,21 +116,7 @@ func (a *Activator) Activate(ctx context.Context) error {
 	}
 
 	mpCfg := multiplatformconfig.Config{DebugLogging: a.debugLogging}
-	if config.AuthConfig.IsJWT {
-		mpCfg.AuthConfig = config.AuthConfig
-	} else {
-		wrote, err := keychain.New().SaveIfChanged(keychain.Credentials{
-			AuthToken:   config.AuthConfig.AuthToken,
-			WorkspaceID: config.AuthConfig.WorkspaceID,
-		})
-		switch {
-		case err != nil:
-			a.logger.Warnf("Failed to save auth credentials to the OS keychain, falling back to inline auth config: %s", err)
-			mpCfg.AuthConfig = config.AuthConfig
-		case wrote:
-			a.logger.Infof("Saved auth credentials to the OS keychain")
-		}
-	}
+	store.PersistActivateCreds(a.logger, a.envs, config.AuthConfig, &mpCfg)
 	if err := mpCfg.Save(a.osProxy, a.encoderFactory); err != nil {
 		return fmt.Errorf("failed to save multiplatform analytics config: %w", err)
 	}

--- a/pkg/ccache/activator_test.go
+++ b/pkg/ccache/activator_test.go
@@ -58,6 +58,9 @@ func newOsProxyMock(t *testing.T) *mocks.OsProxyMock {
 		CreateFunc: func(_ string) (*os.File, error) {
 			return os.CreateTemp(tmpDir, "ccache-config-*.json")
 		},
+		WriteFileFunc: func(_ string, _ []byte, _ os.FileMode) error { return nil },
+		RenameFunc:    func(_, _ string) error { return nil },
+		RemoveFunc:    func(_ string) error { return nil },
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fastlane `setup_ci` swaps the default macOS keychain, wiping any credentials the CLI wrote earlier. `auth set` / `auth login` / `activate {xcode,c++}` now auto-detect CI and write to the multiplatform config's new `credentials` field; keychain remains default locally.
- `--storage=keychain|file|auto` on `auth set` / `auth login` / `auth clear` for explicit overrides.
- File writes are atomic (tmp + rename) at `0o600` (dir `0o700`) — file now holds PATs + OAuth refresh tokens.
- New `internal/auth/store` package: `Store` interface (Load/Save/Clear/Kind), `SelectAuto(envs)`, `SaveExclusive` (clears non-target backend to prevent split-brain), `PersistActivateCreds` (JWT → legacy `authConfig`; non-JWT → CI/local backend).
- `credentials` writes mirror into legacy `authConfig` so `pkg/reactnative` + `pkg/common/invocation_registry` readers keep working.
- `hydrateStoredAuth` now gates OAuth refresh on `EnvJWT != ""` instead of any-CI, so self-hosted CI with a stored PAT still refreshes.
- `auth clear` default clears both backends; `auth status` probes both as first-class targets (`OS keychain` + `Config file (CI-safe)`).

## Test plan
- [ ] `make check` passes locally (`make lint` clean; baseline pre-existing failures in `cmd/{bazel,gradle}`, `internal/config/{bazel,gradle}`, `pkg/ccache` unchanged — dev-keychain contamination on main, unrelated to this diff)
- [ ] Manual: `CIRCLECI=true bitrise-build-cache auth set --token X --workspace-id Y` writes to `~/.bitrise/analytics/multiplatform/config.json` with `credentials` + `authConfig` mirror at `0o600`, does NOT touch OS keychain
- [ ] Manual: `bitrise-build-cache auth set --token X --workspace-id Y` (no CI env) writes to OS keychain
- [ ] Manual: `bitrise-build-cache auth set --storage=file --token X --workspace-id Y` on local writes to file, clears keychain
- [ ] Manual: `bitrise-build-cache auth clear` (no flag) wipes both backends
- [ ] Manual: `bitrise-build-cache auth status` shows both targets + notes mirror on legacy source
- [ ] Fastlane setup_ci scenario end-to-end on a CI iOS build

🤖 Generated with [Claude Code](https://claude.com/claude-code)