### PR TITLE
fix: doctor xcelerate-proxy check probes socket instead of pid file

### DIFF
--- a/cmd/xcode/xcelerate_stop_proxy.go
+++ b/cmd/xcode/xcelerate_stop_proxy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
@@ -34,7 +35,7 @@ func init() {
 }
 
 func stopXcelerateProxyCommandFn(osProxy utils.OsProxy, logger log.Logger) error {
-	pidPath := xcelerate.PathFor(osProxy, pidFile)
+	pidPath := xcelerate.PathFor(osProxy, paths.ProxyPidFileName)
 
 	logger.TInfof("Stopping xcelerate-proxy...")
 

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -36,7 +36,6 @@ import (
 )
 
 const (
-	pidFile      = "proxy.pid"
 	startedProxy = "Started xcelerate_proxy pid = %d"
 
 	NoBitriseBuildCacheFlag     = "--no-bitrise-build-cache"
@@ -631,7 +630,7 @@ func startProxy(
 	commandFunc utils.CommandFunc,
 	killFunc func(pid int, signum syscall.Signal),
 ) error {
-	pidFilePth := xcelerate.PathFor(osProxy, pidFile)
+	pidFilePth := xcelerate.PathFor(osProxy, paths.ProxyPidFileName)
 
 	content, exists, err := osProxy.ReadFileIfExists(pidFilePth)
 	if err != nil {

--- a/internal/config/xcelerate/paths.go
+++ b/internal/config/xcelerate/paths.go
@@ -57,12 +57,3 @@ func ResolveProxySocketPath(override string, envs map[string]string, osProxy uti
 
 	return paths.FromHome("").ProxySocketPath(osProxy.TempDir())
 }
-
-// ProxyPidFile returns the absolute path of the xcelerate proxy pid file.
-func ProxyPidFile(osProxy utils.OsProxy) string {
-	if home, err := osProxy.UserHomeDir(); err == nil {
-		return paths.FromHome(home).ProxyPidFile()
-	}
-
-	return filepath.Join(DirPath(osProxy), paths.ProxyPidFileName)
-}

--- a/internal/doctor/check_ccache.go
+++ b/internal/doctor/check_ccache.go
@@ -2,12 +2,6 @@ package doctor
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"io/fs"
-	"net"
-	"os"
-	"time"
 
 	ccacheconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/ccache"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
@@ -17,43 +11,7 @@ import (
 func (d *Doctor) ccacheHelperCheck() Check {
 	socketPath := ccacheconfig.ResolveIPCSocketPath("", d.Envs, utils.DefaultOsProxy{})
 
-	return Check{
-		Name: "ccache-helper",
-		Diagnose: func(ctx context.Context) Result {
-			if !d.toolActivated(toolconfig.Ccache) {
-				return Result{State: StateOK, Detail: "skipped (c++ not activated)"}
-			}
-
-			if _, err := os.Stat(socketPath); err != nil {
-				if errors.Is(err, fs.ErrNotExist) {
-					return Result{
-						State:   StateWarn,
-						Detail:  "not running (no socket file)",
-						Fixable: true,
-						Fixer:   DaemonUpFixer{},
-					}
-				}
-
-				return Result{State: StateError, Detail: "stat ccache socket: " + err.Error()}
-			}
-
-			dialer := &net.Dialer{Timeout: 500 * time.Millisecond}
-			probeCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-			defer cancel()
-			conn, err := dialer.DialContext(probeCtx, "unix", socketPath)
-			if err != nil {
-				return Result{
-					State:   StateWarn,
-					Detail:  fmt.Sprintf("stuck: socket %s present but not accepting connections (%v) — fixable", socketPath, err),
-					Fixable: true,
-					Fixer:   DaemonRestartFixer{},
-				}
-			}
-			_ = conn.Close()
-
-			return Result{State: StateOK, Detail: "running (" + socketPath + ")"}
-		},
-	}
+	return d.socketDaemonCheck("ccache-helper", toolconfig.Ccache, "c++", socketPath)
 }
 
 func (d *Doctor) ccacheBinaryCheck() Check {

--- a/internal/doctor/check_xcelerate.go
+++ b/internal/doctor/check_xcelerate.go
@@ -1,82 +1,13 @@
 package doctor
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io/fs"
-	"net"
-	"os"
-	"strconv"
-	"strings"
-	"syscall"
-	"time"
-
 	xceleratconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
 func (d *Doctor) xcelerateProxyCheck() Check {
-	osProxy := utils.DefaultOsProxy{}
-	pidPath := xceleratconfig.ProxyPidFile(osProxy)
-	socketPath := xceleratconfig.ResolveProxySocketPath("", d.Envs, osProxy)
+	socketPath := xceleratconfig.ResolveProxySocketPath("", d.Envs, utils.DefaultOsProxy{})
 
-	return Check{
-		Name: "xcelerate-proxy",
-		Diagnose: func(ctx context.Context) Result {
-			if !d.toolActivated(toolconfig.Xcelerate) {
-				return Result{State: StateOK, Detail: "skipped (xcode not activated)"}
-			}
-
-			content, err := os.ReadFile(pidPath) //nolint:gosec // path resolved via xceleratconfig helper
-			if err != nil {
-				if errors.Is(err, fs.ErrNotExist) {
-					return Result{
-						State:   StateWarn,
-						Detail:  "not running (no pid file)",
-						Fixable: true,
-						Fixer:   DaemonUpFixer{},
-					}
-				}
-
-				return Result{State: StateError, Detail: "read pid file: " + err.Error()}
-			}
-
-			pid, err := strconv.Atoi(strings.TrimSpace(string(content)))
-			if err != nil {
-				return Result{
-					State:   StateWarn,
-					Detail:  "pid file content invalid (" + err.Error() + ") — fixable",
-					Fixable: true,
-					Fixer:   RemoveFileFixer{Path: pidPath, Label: "corrupt pid file"},
-				}
-			}
-
-			if err := syscall.Kill(pid, 0); err != nil {
-				return Result{
-					State:   StateWarn,
-					Detail:  fmt.Sprintf("stale pid file: pid %d not running — fixable", pid),
-					Fixable: true,
-					Fixer:   RemoveFileFixer{Path: pidPath, Label: "stale pid file"},
-				}
-			}
-
-			dialer := &net.Dialer{Timeout: 500 * time.Millisecond}
-			probeCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-			defer cancel()
-			conn, dialErr := dialer.DialContext(probeCtx, "unix", socketPath)
-			if dialErr != nil {
-				return Result{
-					State:   StateWarn,
-					Detail:  fmt.Sprintf("stuck: pid %d alive but socket %s not accepting connections (%v) — fixable", pid, socketPath, dialErr),
-					Fixable: true,
-					Fixer:   DaemonRestartFixer{},
-				}
-			}
-			_ = conn.Close()
-
-			return Result{State: StateOK, Detail: fmt.Sprintf("running (pid %d, %s)", pid, socketPath)}
-		},
-	}
+	return d.socketDaemonCheck("xcelerate-proxy", toolconfig.Xcelerate, "xcode", socketPath)
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -208,73 +207,27 @@ func TestKeychainSmokeCheck_deleteFailIsWarn(t *testing.T) {
 
 // ──────────────────────────── xcelerate proxy ────────────────────────────
 
-// xcelerateProxyPidPath returns the proxy.pid path resolved through paths
-// against the per-test HOME override.
-func xcelerateProxyPidPath(t *testing.T, home string) string {
-	t.Helper()
-	t.Setenv("HOME", home)
+func TestXcelerateProxyCheck_noSocketIsFixableViaDaemonUp(t *testing.T) {
+	r := &Doctor{
+		Envs:           map[string]string{"BITRISE_XCELERATE_PROXY_SOCKET_PATH": filepath.Join(t.TempDir(), "missing.sock")},
+		ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Xcelerate: true} },
+	}
 
-	return filepath.Join(home, ".bitrise-xcelerate", "proxy.pid")
-}
-
-func TestXcelerateProxyCheck_noPidIsFixableViaDaemonUp(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-
-	r := &Doctor{ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Xcelerate: true} }}
 	res := r.xcelerateProxyCheck().Diagnose(context.Background())
 	assert.Equal(t, StateWarn, res.State)
-	assert.True(t, res.Fixable, "no pid file → Fix runs `daemon up` to start the service")
+	assert.Contains(t, res.Detail, "no socket file")
+	assert.True(t, res.Fixable)
 }
 
 func TestXcelerateProxyCheck_skippedWhenNotActivated(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	r := &Doctor{
+		Envs:           map[string]string{"BITRISE_XCELERATE_PROXY_SOCKET_PATH": filepath.Join(t.TempDir(), "missing.sock")},
+		ActivatedTools: func() map[toolconfig.Tool]bool { return nil },
+	}
 
-	r := &Doctor{ActivatedTools: func() map[toolconfig.Tool]bool { return nil }}
 	res := r.xcelerateProxyCheck().Diagnose(context.Background())
 	assert.Equal(t, StateOK, res.State)
 	assert.Contains(t, res.Detail, "skipped")
-}
-
-func TestXcelerateProxyCheck_stalePidIsFixable(t *testing.T) {
-	home := t.TempDir()
-	pidPath := xcelerateProxyPidPath(t, home)
-	require.NoError(t, os.MkdirAll(filepath.Dir(pidPath), 0o755))
-	require.NoError(t, os.WriteFile(pidPath, []byte(strconv.Itoa(99999999)), 0o600))
-
-	r := &Doctor{ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Xcelerate: true} }}
-	res := r.xcelerateProxyCheck().Diagnose(context.Background())
-	assert.Equal(t, StateWarn, res.State)
-	assert.True(t, res.Fixable)
-}
-
-func TestXcelerateProxyCheck_fixRemovesStaleFile(t *testing.T) {
-	home := t.TempDir()
-	pidPath := xcelerateProxyPidPath(t, home)
-	require.NoError(t, os.MkdirAll(filepath.Dir(pidPath), 0o755))
-	require.NoError(t, os.WriteFile(pidPath, []byte("99999999"), 0o600))
-
-	r := &Doctor{ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Xcelerate: true} }}
-	res := r.xcelerateProxyCheck().Diagnose(context.Background())
-	require.NotNil(t, res.Fixer)
-
-	detail, err := res.Fixer.Fix()
-	require.NoError(t, err)
-	assert.Contains(t, detail, "removed")
-
-	_, err = os.Stat(pidPath)
-	assert.True(t, os.IsNotExist(err))
-}
-
-func TestXcelerateProxyCheck_corruptPidIsFixable(t *testing.T) {
-	home := t.TempDir()
-	pidPath := xcelerateProxyPidPath(t, home)
-	require.NoError(t, os.MkdirAll(filepath.Dir(pidPath), 0o755))
-	require.NoError(t, os.WriteFile(pidPath, []byte("not-a-number"), 0o600))
-
-	r := &Doctor{}
-	res := r.xcelerateProxyCheck().Diagnose(context.Background())
-	assert.Equal(t, StateWarn, res.State)
-	assert.True(t, res.Fixable)
 }
 
 // ──────────────────────────── ccache ────────────────────────────
@@ -607,9 +560,9 @@ func TestProbeKey_lengthAndPrefix(t *testing.T) {
 
 // ──────────────────────────── daemon-up + update fixes ────────────────────────────
 
-func TestXcelerateProxyCheck_fixerIsDaemonUpWhenNoPid(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+func TestXcelerateProxyCheck_fixerIsDaemonUpWhenNoSocket(t *testing.T) {
 	r := &Doctor{
+		Envs:           map[string]string{"BITRISE_XCELERATE_PROXY_SOCKET_PATH": filepath.Join(t.TempDir(), "missing.sock")},
 		ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Xcelerate: true} },
 	}
 
@@ -688,34 +641,23 @@ func TestCLIVersionCheck_fixerIsUpdateFixer(t *testing.T) {
 	require.IsType(t, UpdateFixer{}, res.Fixer)
 }
 
-func TestXcelerateProxyCheck_socketDeadIsFixableViaRestart(t *testing.T) {
-	home := t.TempDir()
-	pidPath := xcelerateProxyPidPath(t, home)
-	require.NoError(t, os.MkdirAll(filepath.Dir(pidPath), 0o755))
-	require.NoError(t, os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600))
+func TestXcelerateProxyCheck_stuckSocketFixerIsDaemonRestart(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "doctor-xcelerate-stuck-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	socketPath := filepath.Join(dir, "stale.sock")
+	f, err := os.Create(socketPath)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
 
 	r := &Doctor{
-		Envs:           map[string]string{"BITRISE_XCELERATE_PROXY_SOCKET_PATH": filepath.Join(home, "missing.sock")},
+		Envs:           map[string]string{"BITRISE_XCELERATE_PROXY_SOCKET_PATH": socketPath},
 		ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Xcelerate: true} },
 	}
 
 	res := r.xcelerateProxyCheck().Diagnose(context.Background())
 	assert.Equal(t, StateWarn, res.State)
-	assert.True(t, res.Fixable)
-}
-
-func TestXcelerateProxyCheck_socketDeadFixerIsDaemonRestart(t *testing.T) {
-	home := t.TempDir()
-	pidPath := xcelerateProxyPidPath(t, home)
-	require.NoError(t, os.MkdirAll(filepath.Dir(pidPath), 0o755))
-	require.NoError(t, os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600))
-
-	r := &Doctor{
-		Envs:           map[string]string{"BITRISE_XCELERATE_PROXY_SOCKET_PATH": filepath.Join(home, "missing.sock")},
-		ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Xcelerate: true} },
-	}
-
-	res := r.xcelerateProxyCheck().Diagnose(context.Background())
+	assert.Contains(t, res.Detail, "stuck")
 	require.IsType(t, DaemonRestartFixer{}, res.Fixer)
 }
 

--- a/internal/doctor/socket_probe.go
+++ b/internal/doctor/socket_probe.go
@@ -1,0 +1,58 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"time"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
+)
+
+// socketDaemonCheck returns a Check that reports "running" iff `socketPath`
+// exists and accepts a unix-domain connection within probeTimeout. The check
+// short-circuits to StateOK when the referenced tool isn't activated.
+func (d *Doctor) socketDaemonCheck(name string, tool toolconfig.Tool, toolLabel, socketPath string) Check {
+	return Check{
+		Name: name,
+		Diagnose: func(ctx context.Context) Result {
+			if !d.toolActivated(tool) {
+				return Result{State: StateOK, Detail: "skipped (" + toolLabel + " not activated)"}
+			}
+
+			if _, err := os.Stat(socketPath); err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return Result{
+						State:   StateWarn,
+						Detail:  "not running (no socket file)",
+						Fixable: true,
+						Fixer:   DaemonUpFixer{},
+					}
+				}
+
+				return Result{State: StateError, Detail: fmt.Sprintf("stat %s socket: %s", name, err.Error())}
+			}
+
+			dialer := &net.Dialer{Timeout: probeSocketTimeout}
+			probeCtx, cancel := context.WithTimeout(ctx, probeSocketTimeout)
+			defer cancel()
+			conn, dialErr := dialer.DialContext(probeCtx, "unix", socketPath)
+			if dialErr != nil {
+				return Result{
+					State:   StateWarn,
+					Detail:  fmt.Sprintf("stuck: socket %s present but not accepting connections (%v) — fixable", socketPath, dialErr),
+					Fixable: true,
+					Fixer:   DaemonRestartFixer{},
+				}
+			}
+			_ = conn.Close()
+
+			return Result{State: StateOK, Detail: "running (" + socketPath + ")"}
+		},
+	}
+}
+
+const probeSocketTimeout = 500 * time.Millisecond

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -190,11 +190,6 @@ func (p Paths) ProxySocketPath(tempDir string) string {
 	return filepath.Join(tempDir, ProxySocketName)
 }
 
-// ProxyPidFile returns the xcelerate proxy pid file path under XcelerateRoot.
-func (p Paths) ProxyPidFile() string {
-	return filepath.Join(p.XcelerateRoot(), ProxyPidFileName)
-}
-
 // CcacheSocketPath returns the ccache IPC unix-socket path under the supplied temp dir.
 func (p Paths) CcacheSocketPath(tempDir string) string {
 	return filepath.Join(tempDir, CcacheSocketName)


### PR DESCRIPTION
## Summary

- `doctor` reported `xcelerate-proxy not running (no pid file)` while `daemon info` correctly reported `running`. Cause: `daemon info` probes the unix socket; `doctor` was reading `~/.bitrise-xcelerate/proxy.pid`, which is only written by the on-demand proxy spawner in `cmd/xcode/xcodebuild.go` — not by `xcelerate start-proxy` (what the LaunchAgent runs). So the LaunchAgent-managed proxy was invisible to `doctor`.
- Aligned `xcelerateProxyCheck` with `ccacheHelperCheck`; both delegate to a shared `socketDaemonCheck` helper (new `internal/doctor/socket_probe.go`).
- Dropped now-unused `Paths.ProxyPidFile` / `xceleratconfig.ProxyPidFile` helpers; routed the remaining `proxy.pid` literal in `cmd/xcode` through `paths.ProxyPidFileName`.

## Test plan

- [ ] `make check` (lint + unit tests) — green
- [ ] Manual: `daemon install` on macOS Sequoia → `daemon info` reports `running` AND `doctor` now reports `running (…)` for xcelerate-proxy (previously reported "not running (no pid file)")
- [ ] Manual: `daemon down` → both `daemon info` and `doctor` report `stopped` / `not running (no socket file)` consistently
- [ ] Manual: verify `bitrise-build-cache xcodebuild …` on-demand proxy path still writes `proxy.pid` (only side effect now, no doctor coupling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)