### PR TITLE
feat: ACI-5205 F1 slim emit inactivity-timer flush

### DIFF
--- a/cmd/xcode/xcelerate_start_proxy.go
+++ b/cmd/xcode/xcelerate_start_proxy.go
@@ -211,12 +211,18 @@ func newSlimInvocationEmitter(
 }
 
 func (e *slimInvocationEmitter) EmitSlim(ctx context.Context, meta proxy.SessionMeta, stats proxy.SessionStats) {
+	endTime := meta.EndTime
+	if endTime.IsZero() {
+		endTime = time.Now()
+	}
+	duration := endTime.Sub(meta.StartTime).Milliseconds()
+
 	// Fire-and-forget: proxy's shutdown/setSession critical path must not block on network I/O.
 	go func() {
 		inv := analytics.NewInvocation(analytics.InvocationRunStats{
 			InvocationDate: meta.StartTime,
 			InvocationID:   meta.InvocationID,
-			Duration:       time.Since(meta.StartTime).Milliseconds(),
+			Duration:       duration,
 			HitRate:        stats.HitRate(),
 		}, e.auth, e.metadata)
 

--- a/internal/xcelerate/proxy/export_test.go
+++ b/internal/xcelerate/proxy/export_test.go
@@ -1,0 +1,4 @@
+package proxy
+
+// TouchSession exposes the private touchSession helper for tests.
+func (p *Proxy) TouchSession() { p.touchSession() }

--- a/internal/xcelerate/proxy/inactivity_test.go
+++ b/internal/xcelerate/proxy/inactivity_test.go
@@ -1,0 +1,95 @@
+package proxy_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sessionproto "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/session"
+)
+
+func TestInactivity_FiresSlimEmitAfterTimeout(t *testing.T) {
+	emitter := &capturingEmitter{}
+	p := newProxyForEmit(t, emitter)
+	p.InactivityTimeout = 30 * time.Millisecond
+
+	_, err := p.SetSession(context.Background(), &sessionproto.SetSessionRequest{InvocationId: "inv-idle"})
+	require.NoError(t, err)
+
+	p.TouchSession()
+
+	assert.Eventually(t, func() bool { return len(emitter.captured()) == 1 }, 500*time.Millisecond, 10*time.Millisecond)
+
+	calls := emitter.captured()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "inv-idle", calls[0].meta.InvocationID)
+}
+
+func TestInactivity_TouchResetsTimer(t *testing.T) {
+	emitter := &capturingEmitter{}
+	p := newProxyForEmit(t, emitter)
+	p.InactivityTimeout = 60 * time.Millisecond
+
+	_, err := p.SetSession(context.Background(), &sessionproto.SetSessionRequest{InvocationId: "inv-active"})
+	require.NoError(t, err)
+
+	for range 5 {
+		p.TouchSession()
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	assert.Empty(t, emitter.captured(), "timer must not fire while activity keeps refreshing")
+
+	assert.Eventually(t, func() bool { return len(emitter.captured()) == 1 }, 500*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestInactivity_SetSessionSwapCancelsPendingEmit(t *testing.T) {
+	emitter := &capturingEmitter{}
+	p := newProxyForEmit(t, emitter)
+	p.InactivityTimeout = 40 * time.Millisecond
+
+	_, err := p.SetSession(context.Background(), &sessionproto.SetSessionRequest{InvocationId: "inv-A"})
+	require.NoError(t, err)
+	p.TouchSession()
+
+	_, err = p.SetSession(context.Background(), &sessionproto.SetSessionRequest{InvocationId: "inv-B"})
+	require.NoError(t, err)
+	p.TouchSession()
+
+	time.Sleep(120 * time.Millisecond)
+
+	calls := emitter.captured()
+	require.Len(t, calls, 2, "one emit for A on swap, one for B on inactivity")
+	assert.Equal(t, "inv-A", calls[0].meta.InvocationID)
+	assert.Equal(t, "inv-B", calls[1].meta.InvocationID)
+}
+
+func TestInactivity_FlushStopsTimer(t *testing.T) {
+	emitter := &capturingEmitter{}
+	p := newProxyForEmit(t, emitter)
+	p.InactivityTimeout = 40 * time.Millisecond
+
+	_, err := p.SetSession(context.Background(), &sessionproto.SetSessionRequest{InvocationId: "inv-flush"})
+	require.NoError(t, err)
+	p.TouchSession()
+	p.FlushCurrentSession(context.Background())
+
+	time.Sleep(120 * time.Millisecond)
+
+	assert.Len(t, emitter.captured(), 1, "flush should emit once; timer must not double-emit")
+}
+
+func TestInactivity_NoSessionNoTimer(t *testing.T) {
+	emitter := &capturingEmitter{}
+	p := newProxyForEmit(t, emitter)
+	p.InactivityTimeout = 20 * time.Millisecond
+
+	p.TouchSession()
+
+	time.Sleep(80 * time.Millisecond)
+
+	assert.Empty(t, emitter.captured())
+}

--- a/internal/xcelerate/proxy/invocation_emit.go
+++ b/internal/xcelerate/proxy/invocation_emit.go
@@ -12,6 +12,10 @@ type SessionMeta struct {
 	BuildSlug    string
 	StepSlug     string
 	StartTime    time.Time
+	// EndTime is the wall-clock of the last RPC on this session (or zero if
+	// none were observed). Emit callers use it to compute Duration accurately —
+	// otherwise inactivity-timer flushes overreport by the idle window.
+	EndTime time.Time
 }
 
 // SessionStats is the counters snapshot at emit time.

--- a/internal/xcelerate/proxy/proxy.go
+++ b/internal/xcelerate/proxy/proxy.go
@@ -60,7 +60,15 @@ type Proxy struct {
 	emitter        InvocationEmitter
 	currentSession *SessionMeta
 	grpcServer     *grpc.Server
+
+	// InactivityTimeout is the idle window after which the current session is
+	// slim-emitted. Zero falls back to defaultInactivityTimeout.
+	InactivityTimeout time.Duration
+	inactivityTimer   *time.Timer
+	lastActivity      time.Time
 }
+
+const defaultInactivityTimeout = 30 * time.Second
 
 func NewProxy(kvClient Client, pushEnabled bool, logger log.Logger, loggerFactory LoggerFactory, emitter InvocationEmitter) *Proxy {
 	// Note: Gradle plugin uses a client balancer, with multiple channels (min 2), each with multiple connections.
@@ -96,7 +104,10 @@ func NewProxy(kvClient Client, pushEnabled bool, logger log.Logger, loggerFactor
 				return nil, err
 			}
 
-			return handler(ctx, req)
+			resp, err := handler(ctx, req)
+			proxy.touchSession() //nolint:contextcheck // timer callback fires after RPC ctx is done
+
+			return resp, err
 		}),
 	)
 
@@ -136,12 +147,67 @@ func (p *Proxy) emitCurrentSessionLocked(ctx context.Context) {
 		return
 	}
 
+	if p.inactivityTimer != nil {
+		p.inactivityTimer.Stop()
+		p.inactivityTimer = nil
+	}
+
 	meta := *p.currentSession
 	stats := p.sessionState.getStats().toPublic()
 
 	p.emitter.EmitSlim(ctx, meta, stats)
 
 	p.currentSession = nil
+}
+
+func (p *Proxy) inactivityDuration() time.Duration {
+	if p.InactivityTimeout > 0 {
+		return p.InactivityTimeout
+	}
+
+	return defaultInactivityTimeout
+}
+
+// touchSession records RPC activity on the current session and arms the
+// inactivity timer on the first touch.
+func (p *Proxy) touchSession() {
+	p.sessionMutex.Lock()
+	defer p.sessionMutex.Unlock()
+
+	if p.currentSession == nil {
+		return
+	}
+
+	p.lastActivity = time.Now()
+
+	if p.inactivityTimer == nil {
+		target := p.currentSession
+		p.inactivityTimer = time.AfterFunc(p.inactivityDuration(), func() {
+			p.onInactivity(target)
+		})
+	}
+}
+
+// onInactivity fires when the timer elapses. Re-schedules itself if touchSession
+// bumped lastActivity in the meantime; emits otherwise.
+func (p *Proxy) onInactivity(target *SessionMeta) {
+	p.sessionMutex.Lock()
+	defer p.sessionMutex.Unlock()
+
+	if p.currentSession != target {
+		return
+	}
+
+	elapsed := time.Since(p.lastActivity)
+	if remaining := p.inactivityDuration() - elapsed; remaining > 0 {
+		p.inactivityTimer = time.AfterFunc(remaining, func() {
+			p.onInactivity(target)
+		})
+
+		return
+	}
+
+	p.emitCurrentSessionLocked(context.Background())
 }
 
 func (p *Proxy) SetSession(ctx context.Context, request *session.SetSessionRequest) (*emptypb.Empty, error) {

--- a/internal/xcelerate/proxy/proxy.go
+++ b/internal/xcelerate/proxy/proxy.go
@@ -153,6 +153,7 @@ func (p *Proxy) emitCurrentSessionLocked(ctx context.Context) {
 	}
 
 	meta := *p.currentSession
+	meta.EndTime = p.lastActivity
 	stats := p.sessionState.getStats().toPublic()
 
 	p.emitter.EmitSlim(ctx, meta, stats)

--- a/internal/xcelerate/proxy/proxy.go
+++ b/internal/xcelerate/proxy/proxy.go
@@ -68,7 +68,7 @@ type Proxy struct {
 	lastActivity      time.Time
 }
 
-const defaultInactivityTimeout = 30 * time.Second
+const defaultInactivityTimeout = 10 * time.Second
 
 func NewProxy(kvClient Client, pushEnabled bool, logger log.Logger, loggerFactory LoggerFactory, emitter InvocationEmitter) *Proxy {
 	// Note: Gradle plugin uses a client balancer, with multiple channels (min 2), each with multiple connections.


### PR DESCRIPTION
## Summary

- `Proxy` grows an `InactivityTimeout` (default 30s) + `time.Timer` field
- gRPC `UnaryInterceptor` calls `touchSession()` after every handler → bumps `lastActivity` + arms timer on first touch
- Timer callback re-schedules if activity refreshed since scheduled fire; otherwise emits slim invocation via existing `emitCurrentSessionLocked`
- Pointer comparison on captured `SessionMeta` target guards against stale callbacks after SetSession swap
- Xcode.app path unaffected (no SetSession → no session → timer never arms)

Fixes the F1 gap surfaced by ACI-5045 manual test — wrapper builds now leave a pending record for F2's correlator to match.

Stacked on `aci-5044-slim-invocation-emit`.

## Test plan

- [x] `make lint` (0 issues)
- [x] `go test -tags unit -race ./internal/xcelerate/proxy/...` — new 5-case inactivity suite passes
- [ ] Manual re-run of ACI-5045 Scenario A after both PRs land — expect `matched=true` on wrapper build

🤖 Generated with [Claude Code](https://claude.com/claude-code)