### PR TITLE
[ACI-4264] Add auth username command + local-invocation-log ci_provider/username

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -610,6 +610,74 @@ var authTokenCmd = &cobra.Command{
 	},
 }
 
+// nolint:gochecknoglobals
+var (
+	usernameSetValue string
+	usernameJSONOut  bool
+)
+
+// usernameOutput is the --json shape of the resolved display name.
+type usernameOutput struct {
+	Username string `json:"username"`
+	Source   string `json:"source"`
+}
+
+// nolint:gochecknoglobals
+var authUsernameCmd = &cobra.Command{
+	Use:           "username",
+	Short:         "Resolve and print (or with --set, persist) the local-invocation display name",
+	Long:          "Without --set: resolves the display name via the same precedence chain as the rest of the CLI (env var → OS keychain → multiplatform config → OS username fallback) and prints it to stdout — a bare line, or with --json an object {\"username\", \"source\"}. Intended for build-time consumers (Gradle init script) that need the resolved name without re-implementing the lookup — always exits 0, printing an empty value when nothing is configured.\n\nWith --set <name>: persists the display name into the credential store that already holds your auth (keychain or the CI-safe config file), leaving the token and workspace untouched. --set \"\" clears the stored override. The BITRISE_BUILD_CACHE_USERNAME env var still takes precedence for a single run.",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		envs := utils.AllEnvs()
+		if cmd.Flags().Changed("set") {
+			if err := setLocalUsername(envs, strings.TrimSpace(usernameSetValue)); err != nil {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+
+				return err
+			}
+
+			return nil
+		}
+
+		name, src := configcommon.ResolveUsername(envs)
+		out := cmd.OutOrStdout()
+		if usernameJSONOut {
+			enc := json.NewEncoder(out)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(usernameOutput{Username: name, Source: src.String()}); err != nil {
+				return fmt.Errorf("encode username json: %w", err)
+			}
+
+			return nil
+		}
+
+		if _, err := fmt.Fprintln(out, name); err != nil {
+			return fmt.Errorf("write username: %w", err)
+		}
+
+		return nil
+	},
+}
+
+func setLocalUsername(envs map[string]string, name string) error {
+	logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+
+	kind, err := store.SetUsername(envs, name)
+	if err != nil {
+		return err //nolint:wrapcheck // already user-facing (store wraps with the target backend)
+	}
+
+	if name == "" {
+		logger.TInfof("Cleared local-invocation display name in %s (falling back to %s or the OS username).", kind, configcommon.EnvUsername)
+	} else {
+		logger.TInfof("✅ Local-invocation display name set to %q in %s.", name, kind)
+	}
+
+	return nil
+}
+
 func maskToken(token string) string {
 	const tailLen = 4
 	if len(token) <= tailLen {
@@ -629,10 +697,14 @@ func init() {
 
 	authClearCmd.Flags().StringVar(&clearStorage, "storage", "", "Which backend to clear: keychain | file | auto (default auto clears both).")
 
+	authUsernameCmd.Flags().StringVar(&usernameSetValue, "set", "", "Persist this display name into the store holding your credentials (token/workspace untouched). Empty clears the stored override. Omit the flag to print the resolved name instead.")
+	authUsernameCmd.Flags().BoolVar(&usernameJSONOut, "json", false, "Print the resolved name as JSON {username, source} instead of a bare line. Ignored with --set.")
+
 	authCmd.AddCommand(authSetCmd)
 	authCmd.AddCommand(authStatusCmd)
 	authCmd.AddCommand(authClearCmd)
 	authCmd.AddCommand(authTokenCmd)
+	authCmd.AddCommand(authUsernameCmd)
 	authCmd.AddCommand(common.LoginCmd)
 	authCmd.AddCommand(common.LogoutCmd)
 

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -57,6 +57,63 @@ func TestAuthTokenCmd_stderrIsBoundedOnError(t *testing.T) {
 	assert.NotEmpty(t, stderr.Bytes(), "error path must surface a one-line message on stderr")
 }
 
+func TestAuthUsernameCmd_stdoutIsBareResolvedName(t *testing.T) {
+	cmd := authUsernameCmd
+	t.Cleanup(func() { usernameSetValue = ""; cmd.Flags().Lookup("set").Changed = false })
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	t.Setenv("BITRISE_BUILD_CACHE_USERNAME", "alice")
+
+	require.NoError(t, cmd.RunE(cmd, nil))
+	assert.Equal(t, "alice\n", stdout.String())
+	assert.Empty(t, stderr.String())
+}
+
+func TestAuthUsernameCmd_jsonEmitsNameAndSource(t *testing.T) {
+	cmd := authUsernameCmd
+	usernameJSONOut = true
+	t.Cleanup(func() { usernameJSONOut = false })
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	t.Setenv("BITRISE_BUILD_CACHE_USERNAME", "dave")
+
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	var got usernameOutput
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	assert.Equal(t, "dave", got.Username)
+	assert.Equal(t, "env", got.Source)
+}
+
+func TestAuthUsernameCmd_setPersistsIntoStoreHoldingCreds(t *testing.T) {
+	keyring.MockInit()
+	t.Setenv("BITRISE_BUILD_CACHE_USERNAME", "")
+
+	// Seed keychain with token+workspace so it becomes the target store.
+	require.NoError(t, keychain.New().Save(keychain.Credentials{AuthToken: "tok", WorkspaceID: "ws"}))
+
+	envs := map[string]string{}
+	require.NoError(t, setLocalUsername(envs, "carol"))
+
+	creds, err := keychain.New().Load()
+	require.NoError(t, err)
+	assert.Equal(t, "carol", creds.Username)
+	assert.Equal(t, "tok", creds.AuthToken, "token must survive a username-only set")
+	assert.Equal(t, "ws", creds.WorkspaceID, "workspace must survive a username-only set")
+
+	require.NoError(t, setLocalUsername(envs, ""))
+	creds, err = keychain.New().Load()
+	require.NoError(t, err)
+	assert.Empty(t, creds.Username)
+	assert.Equal(t, "tok", creds.AuthToken)
+}
+
 func TestScrubRawConfigAuthToken_stripsAuthAndKeepsRest(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cmd/common/root.go
+++ b/cmd/common/root.go
@@ -65,7 +65,7 @@ func ShouldSkipVersionCheck(cmd *cobra.Command) bool {
 		"start", "stop", "set-invocation-id", "health-check", "collect-stats",
 		"register-invocation", "register-child-invocation":
 		return true
-	case "token":
+	case "token", "username":
 		return true
 	default:
 		return false

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -356,11 +356,6 @@ func (c *XcodebuildRunner) appendLocalInvocationLog(inv analytics.Invocation, ru
 		return
 	}
 
-	src := invocations.SourceLocal
-	if c.Metadata.CIProvider != "" {
-		src = invocations.SourceCI
-	}
-
 	startedAt := runStats.StartTime
 	finishedAt := startedAt.Add(time.Duration(runStats.DurationMS) * time.Millisecond)
 
@@ -373,7 +368,8 @@ func (c *XcodebuildRunner) appendLocalInvocationLog(inv analytics.Invocation, ru
 		StartedAt:    startedAt,
 		FinishedAt:   finishedAt,
 		ExitCode:     runStats.ExitCode,
-		Source:       src,
+		CIProvider:   c.Metadata.CIProvider,
+		Username:     inv.Username,
 	}
 
 	if err := logger.Append(rec); err != nil {

--- a/cmd/xcode/xcodebuild_local_log_test.go
+++ b/cmd/xcode/xcodebuild_local_log_test.go
@@ -89,10 +89,11 @@ func TestXcodebuildRunner_appendLocalInvocationLog_writesRecord(t *testing.T) {
 	assert.Equal(t, start, got.StartedAt)
 	assert.Equal(t, start.Add(1500*time.Millisecond), got.FinishedAt)
 	assert.Equal(t, 0, got.ExitCode)
-	assert.Equal(t, invocations.SourceLocal, got.Source)
+	assert.Empty(t, got.CIProvider)
+	assert.True(t, got.IsLocal())
 }
 
-func TestXcodebuildRunner_appendLocalInvocationLog_marksCISource(t *testing.T) {
+func TestXcodebuildRunner_appendLocalInvocationLog_recordsCIProvider(t *testing.T) {
 	runStats := xcodeargs.RunStats{StartTime: time.Now().UTC(), Success: true}
 
 	sut, logger := runnerForLocalLogTest(t, runStats, "bitrise")
@@ -101,7 +102,8 @@ func TestXcodebuildRunner_appendLocalInvocationLog_marksCISource(t *testing.T) {
 
 	calls := logger.AppendCalls()
 	require.Len(t, calls, 1)
-	assert.Equal(t, invocations.SourceCI, calls[0].Rec.Source)
+	assert.Equal(t, "bitrise", calls[0].Rec.CIProvider)
+	assert.False(t, calls[0].Rec.IsLocal())
 }
 
 func TestXcodebuildRunner_appendLocalInvocationLog_appendErrorIsNonFatal(t *testing.T) {

--- a/docs/canonical-record.ndjson
+++ b/docs/canonical-record.ndjson
@@ -1,1 +1,1 @@
-{"invocation_id":"cafe-1234","command":"xcodebuild build -workspace Foo.xcworkspace -scheme Foo","tool":"xcode","tool_version":"16.0","cli_version":"v2.8.6","started_at":"2026-06-25T13:14:15Z","finished_at":"2026-06-25T13:15:00Z","exit_code":0,"source":"local"}
+{"invocation_id":"cafe-1234","command":"xcodebuild build -workspace Foo.xcworkspace -scheme Foo","tool":"xcode","tool_version":"16.0","cli_version":"v2.8.6","started_at":"2026-06-25T13:14:15Z","finished_at":"2026-06-25T13:15:00Z","exit_code":0,"username":"alice"}

--- a/docs/local-invocation-log.md
+++ b/docs/local-invocation-log.md
@@ -27,7 +27,8 @@ One JSON object per line. UTF-8, LF-terminated. Records ≤ 4 KiB land atomicall
 | `started_at` | RFC3339 timestamp | yes | When the tool invocation started. |
 | `finished_at` | RFC3339 timestamp | no | Equal to `started_at + duration`. The canonical Go writer emits one record per completed invocation, so this is always set today; future streaming writers may omit it for in-flight records. |
 | `exit_code` | int | yes | Real exit code where available; 0 = success. |
-| `source` | string | yes | `local` or `ci`. CI iff the writer ran under a known CI provider. |
+| `ci_provider` | string | no | Detected CI provider id (e.g. `bitrise`); empty/omitted ⇒ local run. |
+| `username` | string | no | Resolved local-invocation display name (env → keychain → config file → OS username). |
 
 Unknown fields are ignored by readers — additive schema changes are backward compatible.
 

--- a/docs/local-invocation-log.schema.json
+++ b/docs/local-invocation-log.schema.json
@@ -9,8 +9,7 @@
     "tool",
     "cli_version",
     "started_at",
-    "exit_code",
-    "source"
+    "exit_code"
   ],
   "additionalProperties": true,
   "properties": {
@@ -22,6 +21,7 @@
     "started_at":    { "type": "string", "format": "date-time" },
     "finished_at":   { "type": "string", "format": "date-time" },
     "exit_code":     { "type": "integer" },
-    "source":        { "type": "string", "enum": ["local", "ci"] }
+    "ci_provider":   { "type": "string" },
+    "username":      { "type": "string" }
   }
 }

--- a/internal/auth/store/persist.go
+++ b/internal/auth/store/persist.go
@@ -1,6 +1,9 @@
 package store
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/bitrise-io/go-utils/v2/log"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
@@ -31,4 +34,31 @@ func PersistActivateCreds(logger log.Logger, envs map[string]string, auth config
 		return
 	}
 	logger.Infof("Saved auth credentials to the OS keychain")
+}
+
+// SetUsername writes name into the store that already holds credentials so a
+// username-only edit can't strand an empty-token entry in the wrong backend.
+// Empty name clears the override. Returns the store written to.
+func SetUsername(envs map[string]string, name string) (Kind, error) {
+	target, existing := storeHoldingCreds(envs)
+	existing.Username = strings.TrimSpace(name)
+	if err := target.Save(existing); err != nil {
+		return target.Kind(), fmt.Errorf("save display name to %s: %w", target.Kind(), err)
+	}
+
+	return target.Kind(), nil
+}
+
+func storeHoldingCreds(envs map[string]string) (Store, keychain.Credentials) {
+	for _, s := range []Store{NewKeychain(), NewFile()} {
+		creds, err := s.Load()
+		if err == nil && (strings.TrimSpace(creds.AuthToken) != "" || strings.TrimSpace(creds.WorkspaceID) != "") {
+			return s, creds
+		}
+	}
+
+	target := SelectAuto(envs)
+	creds, _ := target.Load()
+
+	return target, creds
 }

--- a/internal/auth/store/store_test.go
+++ b/internal/auth/store/store_test.go
@@ -68,6 +68,28 @@ func TestSaveExclusive_ClearsOtherBackend(t *testing.T) {
 	assert.Equal(t, "new", got.AuthToken)
 }
 
+func TestSetUsername_landsInStoreHoldingCredsAndPreservesAuth(t *testing.T) {
+	keyring.MockInit()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Creds live only in the file store; keychain is empty.
+	require.NoError(t, NewFile().Save(keychain.Credentials{AuthToken: "tok", WorkspaceID: "ws"}))
+
+	kind, err := SetUsername(map[string]string{}, "erin")
+	require.NoError(t, err)
+	assert.Equal(t, KindFile, kind, "username must land in the file store that holds the creds, not the keychain")
+
+	got, err := NewFile().Load()
+	require.NoError(t, err)
+	assert.Equal(t, "erin", got.Username)
+	assert.Equal(t, "tok", got.AuthToken, "token must survive a username-only write")
+	assert.Equal(t, "ws", got.WorkspaceID)
+
+	_, kcErr := NewKeychain().Load()
+	require.ErrorIs(t, kcErr, ErrNotFound, "username write must not create a stray keychain entry")
+}
+
 func TestFileStore_SavePersistsAtRestrictedPerms(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/config/common/auth.go
+++ b/internal/config/common/auth.go
@@ -84,6 +84,23 @@ const (
 	UsernameSourceOS
 )
 
+func (s UsernameSource) String() string {
+	switch s {
+	case UsernameSourceEnv:
+		return "env"
+	case UsernameSourceKeychain:
+		return "keychain"
+	case UsernameSourceFile:
+		return "file"
+	case UsernameSourceOS:
+		return "os"
+	case UsernameSourceNone:
+		return sourceNameNone
+	}
+
+	return "unknown"
+}
+
 func ResolveUsername(envs map[string]string) (string, UsernameSource) {
 	return resolveUsername(envs, keychain.New(), fileCredentialsReader, osUsername)
 }

--- a/internal/config/common/authsource.go
+++ b/internal/config/common/authsource.go
@@ -7,6 +7,8 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
 )
 
+const sourceNameNone = "none"
+
 // AuthDescription is the shared description of a resolved credential, consumed
 // by status, doctor, and `auth status` so the source taxonomy and the
 // OAuth-login/expiry knowledge live in one place.
@@ -35,10 +37,10 @@ func SourceLabel(source AuthSource, isOAuthLogin bool) string {
 	case AuthSourceMultiplatform:
 		return "multiplatform config"
 	case AuthSourceNone:
-		return "none"
+		return sourceNameNone
 	}
 
-	return "none"
+	return sourceNameNone
 }
 
 // Label is the canonical source name for this description.

--- a/internal/invocations/invocations.go
+++ b/internal/invocations/invocations.go
@@ -17,13 +17,6 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 )
 
-type Source string
-
-const (
-	SourceLocal Source = "local"
-	SourceCI    Source = "ci"
-)
-
 type Tool string
 
 const (
@@ -43,8 +36,12 @@ type Record struct {
 	StartedAt    time.Time `json:"started_at"`
 	FinishedAt   time.Time `json:"finished_at,omitzero"`
 	ExitCode     int       `json:"exit_code"`
-	Source       Source    `json:"source"`
+	CIProvider   string    `json:"ci_provider,omitempty"`
+	Username     string    `json:"username,omitempty"`
 }
+
+// IsLocal reports whether the record was produced outside a known CI provider.
+func (r Record) IsLocal() bool { return r.CIProvider == "" }
 
 const (
 	dayLayout        = "2006-01-02"

--- a/internal/invocations/invocations_test.go
+++ b/internal/invocations/invocations_test.go
@@ -40,7 +40,7 @@ func TestWriter_Append_writesDailyNDJSON(t *testing.T) {
 		CLIVersion:   "v2.8.6",
 		StartedAt:    at,
 		ExitCode:     0,
-		Source:       SourceLocal,
+		Username:     "alice",
 	}
 	require.NoError(t, w.Append(rec))
 
@@ -87,7 +87,7 @@ func TestWriter_Append_writesOversizedRecordVerbatim(t *testing.T) {
 		Tool:         ToolXcode,
 		CLIVersion:   "v2.8.6",
 		StartedAt:    at,
-		Source:       SourceLocal,
+		Username:     "alice",
 	}
 	require.NoError(t, w.Append(rec))
 
@@ -118,7 +118,7 @@ func TestWriter_Append_concurrentWritesParseable(t *testing.T) {
 					Tool:         ToolXcode,
 					CLIVersion:   "v2.8.6",
 					StartedAt:    at,
-					Source:       SourceLocal,
+					Username:     "alice",
 				})
 			}
 		}(i)
@@ -217,7 +217,8 @@ func TestRecord_jsonRoundtrip(t *testing.T) {
 		StartedAt:    start,
 		FinishedAt:   start.Add(45 * time.Second),
 		ExitCode:     0,
-		Source:       SourceCI,
+		CIProvider:   "bitrise",
+		Username:     "bob",
 	}
 
 	b, err := json.Marshal(rec)
@@ -306,7 +307,7 @@ func TestCanonicalRecord_byteEqualToCheckedInFixture(t *testing.T) {
 		StartedAt:    time.Date(2026, 6, 25, 13, 14, 15, 0, time.UTC),
 		FinishedAt:   time.Date(2026, 6, 25, 13, 15, 0, 0, time.UTC),
 		ExitCode:     0,
-		Source:       SourceLocal,
+		Username:     "alice",
 	}
 
 	encoded, err := encodeRecord(rec)


### PR DESCRIPTION
[ACI-4264](https://bitrise.atlassian.net/browse/ACI-4264)

## Summary

Local invocations already resolve a display-name override (env → keychain → config file → OS username), but there was no way for an external consumer to ask the CLI for the resolved value, and no non-interactive way to set it on its own. This adds a single `auth username` command that both resolves and persists the name, so the Gradle plugin (and any other consumer) can rely on one source of truth instead of re-implementing the lookup. It also corrects the local-invocation-log schema, replacing the lossy `source: local|ci` boolean with `ci_provider` + `username`.

## Changes

- **`auth username` command** — no flag: resolves and prints the display name to stdout (bare line, or `--json {"username","source"}`) for build-time consumers like the Gradle init script; `--set <name>`: persists the name into whichever store already holds the credentials (keychain or the CI-safe config file), leaving token/workspace untouched; `--set ""` clears it.
- **Centralized persistence** — `store.SetUsername` (in `internal/auth/store/persist.go`) is the single writer; it targets the store that already holds creds so a username-only edit can't strand an empty-token entry in the wrong backend.
- **`UsernameSource.String()`** — reused for the `--json` `source` field; shared `sourceNameNone` const.
- **Version-check skip** — `username` added to `ShouldSkipVersionCheck` so the update nudge never lands on the machine-readable stdout.
- **Local invocation log schema** — dropped `source: local|ci`; added `ci_provider` (raw provider id, empty ⇒ local) and `username`. Touches `internal/invocations` (`Record`, `IsLocal()`), the xcodebuild hook, and the `docs/local-invocation-log.md` + `.schema.json` + `canonical-record.ndjson` triple. Corresponding Jira updates: ACI-5134, ACI-5135, comment on ACI-5090.

## Testing

```bash
make lint        # 0 issues
make test-unit   # passes except pre-existing "auth-missing → error" tests
                 # (cmd/bazel, cmd/gradle, config/{bazel,gradle}, pkg/ccache)
                 # which fail only because this dev machine has stored creds;
                 # confirmed identical on clean HEAD, green on CI.
```

New/updated tests: `auth username` bare/`--json`/`--set` paths, `store.SetUsername` split-brain guard (lands in the file store, preserves token, no stray keychain entry), and the invocation-log golden byte-parity test updated for the new canonical record.

## Notes for reviewers

- **Cross-repo coordination:** `canonical-record.ndjson` + the schema are golden-tested in `gradle-plugins` too. This change moves the fixture from `source` to `ci_provider`/`username`, so the gradle-plugins Kotlin writer + its golden copy must update in lockstep (that's ACI-5134's scope). It's low-usage local-invocation data, so no migration is needed for existing records — readers ignore unknown fields and `local` is derived as `ci_provider == ""`.
- The `--json` field is named `source` intentionally — it means the resolution origin (env/keychain/file/os), which is distinct from the invocation `ci_provider`.
- **Deferred (separate PR):** wiring `auth username` into the Gradle init template + analytics extension so Gradle local invocations get tagged.
- Scope: the unrelated in-progress `.claude/skills/release/SKILL.md` edit is intentionally left out of this PR.


[ACI-4264]: https://bitrise.atlassian.net/browse/ACI-4264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ