### PR TITLE
PoC: xcode-app CAS config injector — Xcode.app IDE remote CAS via .cas-config watch

### DIFF
--- a/cmd/xcode_app_casinject/casinject.go
+++ b/cmd/xcode_app_casinject/casinject.go
@@ -1,0 +1,21 @@
+package xcode_app_casinject
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+)
+
+//nolint:gochecknoglobals
+var rootCmd = &cobra.Command{
+	Use:   "xcode-app-casinject",
+	Short: "Inject RemoteService into Xcode.app .cas-config files (PoC)",
+	Long: "PoC: watch DerivedData for .cas-config files written by Xcode.app IDE builds " +
+		"and inject RemoteService so the ToolchainCASPlugin opens the xcelerate proxy socket. " +
+		"Xcode 26 IDE drops COMPILATION_CACHE_REMOTE_SERVICE_PATH before serializing .cas-config, " +
+		"so patching post-write is the only way to engage remote CAS from the IDE build path.",
+}
+
+func init() {
+	common.RootCmd.AddCommand(rootCmd)
+}

--- a/cmd/xcode_app_casinject/watch.go
+++ b/cmd/xcode_app_casinject/watch.go
@@ -1,0 +1,116 @@
+package xcode_app_casinject
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	xcelerateconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+	injector "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/xcode_app_casinject"
+)
+
+//nolint:gochecknoglobals
+var (
+	watchRoots              []string
+	watchSocketPath         string
+	watchPoll               time.Duration
+	watchAllowMissingSocket bool
+)
+
+//nolint:gochecknoglobals
+var watchCmd = &cobra.Command{
+	Use:          "watch",
+	Short:        "Watch DerivedData for .cas-config files and inject RemoteService",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+
+		roots, err := resolveRoots(watchRoots)
+		if err != nil {
+			return err
+		}
+
+		socketPath := watchSocketPath
+		if socketPath == "" {
+			socketPath = xcelerateconfig.ResolveProxySocketPath("", envsMap(), utils.DefaultOsProxy{})
+		}
+		if err := injector.ValidateSocket(socketPath); err != nil {
+			if !errors.Is(err, injector.ErrSocketMissing) {
+				return err //nolint:wrapcheck
+			}
+			if !watchAllowMissingSocket {
+				return fmt.Errorf("%w — start the xcelerate proxy first, or pass --allow-missing-socket", err)
+			}
+			logger.Warnf("proxy socket missing at %s — continuing (--allow-missing-socket)", socketPath)
+		}
+
+		w, err := injector.NewWatcher(injector.WatchParams{
+			Roots:        roots,
+			SocketPath:   socketPath,
+			Logger:       logger,
+			PollInterval: watchPoll,
+		})
+		if err != nil {
+			return fmt.Errorf("watcher: %w", err)
+		}
+
+		logger.Infof("watching %d roots for .cas-config; socket=%s poll=%s", len(roots), socketPath, watchPoll)
+
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
+		if err := w.Run(ctx); err != nil {
+			return fmt.Errorf("watch: %w", err)
+		}
+
+		return nil
+	},
+}
+
+func resolveRoots(explicit []string) ([]string, error) {
+	if len(explicit) > 0 {
+		return explicit, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("home dir: %w", err)
+	}
+
+	return []string{filepath.Join(home, "Library", "Developer", "Xcode", "DerivedData")}, nil
+}
+
+func envsMap() map[string]string {
+	out := map[string]string{}
+	for _, e := range os.Environ() {
+		for i := range len(e) {
+			if e[i] == '=' {
+				out[e[:i]] = e[i+1:]
+
+				break
+			}
+		}
+	}
+
+	return out
+}
+
+func init() {
+	watchCmd.Flags().StringSliceVar(&watchRoots, "root", nil,
+		"DerivedData roots to watch recursively (defaults to ~/Library/Developer/Xcode/DerivedData)")
+	watchCmd.Flags().StringVar(&watchSocketPath, "socket", "",
+		"xcelerate proxy socket path (defaults to xcelerate config resolution)")
+	watchCmd.Flags().DurationVar(&watchPoll, "poll-interval", 2*time.Second,
+		"periodic rescan interval for late-created directories")
+	watchCmd.Flags().BoolVar(&watchAllowMissingSocket, "allow-missing-socket", false,
+		"start watcher even if the proxy socket does not exist yet")
+	rootCmd.AddCommand(watchCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/internal/xcode_app_casinject/inject.go
+++ b/internal/xcode_app_casinject/inject.go
@@ -1,0 +1,139 @@
+package xcode_app_casinject
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const CasConfigName = ".cas-config"
+
+type remoteService struct {
+	Path string `json:"Path"`
+}
+
+// InjectFile rewrites .cas-config at path so RemoteService.Path == socketPath.
+// Returns (rewritten, error). rewritten=false means the file already had the
+// desired RemoteService (idempotent no-op).
+func InjectFile(path, socketPath string) (bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	patched, changed, err := patchCasConfig(raw, socketPath)
+	if err != nil {
+		return false, fmt.Errorf("patch %s: %w", path, err)
+	}
+	if !changed {
+		return false, nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	if err := atomicWrite(path, patched, info.Mode().Perm()); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func patchCasConfig(raw []byte, socketPath string) ([]byte, bool, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, false, fmt.Errorf("unmarshal: %w", err)
+	}
+
+	if existing, ok := obj["RemoteService"]; ok {
+		var rs remoteService
+		if err := json.Unmarshal(existing, &rs); err == nil && rs.Path == socketPath {
+			return nil, false, nil
+		}
+	}
+
+	rsBytes, err := json.Marshal(remoteService{Path: socketPath})
+	if err != nil {
+		return nil, false, fmt.Errorf("marshal remote-service: %w", err)
+	}
+	obj["RemoteService"] = rsBytes
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(obj); err != nil {
+		return nil, false, fmt.Errorf("encode: %w", err)
+	}
+
+	return bytes.TrimRight(buf.Bytes(), "\n"), true, nil
+}
+
+func atomicWrite(target string, data []byte, mode fs.FileMode) error {
+	dir := filepath.Dir(target)
+	tmp, err := os.CreateTemp(dir, ".cas-config.tmp-*")
+	if err != nil {
+		return fmt.Errorf("tempfile: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	cleanup := func() {
+		_ = os.Remove(tmpPath)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+
+		return fmt.Errorf("write: %w", err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		cleanup()
+
+		return fmt.Errorf("chmod: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+
+		return fmt.Errorf("close: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, target); err != nil {
+		cleanup()
+
+		return fmt.Errorf("rename: %w", err)
+	}
+
+	return nil
+}
+
+// IsCasConfigPath returns true when the path's basename is ".cas-config".
+func IsCasConfigPath(p string) bool {
+	return filepath.Base(p) == CasConfigName
+}
+
+// ErrSocketMissing is returned by ValidateSocket when the socket does not exist.
+var ErrSocketMissing = errors.New("proxy socket not found")
+
+// ValidateSocket verifies the socket path is a Unix socket. Cheap sanity check
+// before we start rewriting build files with it.
+func ValidateSocket(path string) error {
+	st, err := os.Stat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("%w: %s", ErrSocketMissing, path)
+	}
+	if err != nil {
+		return fmt.Errorf("stat socket: %w", err)
+	}
+	if st.Mode()&fs.ModeSocket == 0 {
+		return fmt.Errorf("not a unix socket: %s", path)
+	}
+
+	return nil
+}

--- a/internal/xcode_app_casinject/inject_test.go
+++ b/internal/xcode_app_casinject/inject_test.go
@@ -1,0 +1,97 @@
+//go:build unit
+
+package xcode_app_casinject
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const socket = "/tmp/xcelerate-proxy.sock"
+
+func writeCasConfig(t *testing.T, dir string, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, ".cas-config")
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o644))
+
+	return p
+}
+
+func TestInjectFile_AddsRemoteServiceWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	p := writeCasConfig(t, dir, `{"CASPath":"/some/path"}`)
+
+	changed, err := InjectFile(p, socket)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	raw, err := os.ReadFile(p)
+	require.NoError(t, err)
+
+	var obj map[string]any
+	require.NoError(t, json.Unmarshal(raw, &obj))
+	require.Equal(t, "/some/path", obj["CASPath"])
+
+	rs, ok := obj["RemoteService"].(map[string]any)
+	require.True(t, ok, "RemoteService object missing: %s", string(raw))
+	require.Equal(t, socket, rs["Path"])
+}
+
+func TestInjectFile_IdempotentWhenSocketMatches(t *testing.T) {
+	dir := t.TempDir()
+	p := writeCasConfig(t, dir, `{"CASPath":"/x","RemoteService":{"Path":"`+socket+`"}}`)
+
+	changed, err := InjectFile(p, socket)
+	require.NoError(t, err)
+	require.False(t, changed)
+}
+
+func TestInjectFile_ReplacesDifferentRemoteService(t *testing.T) {
+	dir := t.TempDir()
+	p := writeCasConfig(t, dir, `{"CASPath":"/x","RemoteService":{"Path":"/old.sock"}}`)
+
+	changed, err := InjectFile(p, socket)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	raw, err := os.ReadFile(p)
+	require.NoError(t, err)
+
+	var obj map[string]any
+	require.NoError(t, json.Unmarshal(raw, &obj))
+	rs := obj["RemoteService"].(map[string]any) //nolint:forcetypeassert
+	require.Equal(t, socket, rs["Path"])
+}
+
+func TestInjectFile_PreservesExtraKeys(t *testing.T) {
+	dir := t.TempDir()
+	p := writeCasConfig(t, dir, `{"CASPath":"/x","Extra":"keep","N":42}`)
+
+	_, err := InjectFile(p, socket)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(p)
+	require.NoError(t, err)
+
+	var obj map[string]any
+	require.NoError(t, json.Unmarshal(raw, &obj))
+	require.Equal(t, "keep", obj["Extra"])
+	require.EqualValues(t, 42, obj["N"])
+}
+
+func TestInjectFile_MalformedJSONReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	p := writeCasConfig(t, dir, `{not json`)
+
+	_, err := InjectFile(p, socket)
+	require.Error(t, err)
+}
+
+func TestIsCasConfigPath(t *testing.T) {
+	require.True(t, IsCasConfigPath("/a/b/.cas-config"))
+	require.False(t, IsCasConfigPath("/a/b/other.json"))
+}

--- a/internal/xcode_app_casinject/watcher.go
+++ b/internal/xcode_app_casinject/watcher.go
@@ -1,0 +1,233 @@
+package xcode_app_casinject
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Logger keeps the package free of the project's logger interface so we can
+// unit-test with a simple stub.
+type Logger interface {
+	Infof(format string, args ...any)
+	Debugf(format string, args ...any)
+	Warnf(format string, args ...any)
+	Errorf(format string, args ...any)
+}
+
+type WatchParams struct {
+	// Roots to watch recursively. Typically DerivedData/<Project>*.
+	Roots []string
+	// SocketPath to inject as RemoteService.Path.
+	SocketPath string
+	// Logger receives lifecycle + per-file logs.
+	Logger Logger
+	// PollInterval scans Roots for new subdirectories to add watches to.
+	// fsnotify does not recurse; new Intermediates.noindex/... paths get
+	// caught by both directory-create events AND the poll fallback.
+	PollInterval time.Duration
+}
+
+type Watcher struct {
+	params WatchParams
+	fsw    *fsnotify.Watcher
+
+	mu      sync.Mutex
+	watched map[string]struct{}
+
+	stats stats
+}
+
+type stats struct {
+	discovered int
+	injected   int
+	skipped    int
+	errored    int
+}
+
+func NewWatcher(p WatchParams) (*Watcher, error) {
+	if len(p.Roots) == 0 {
+		return nil, errors.New("no roots to watch")
+	}
+	if p.SocketPath == "" {
+		return nil, errors.New("empty socket path")
+	}
+	if p.PollInterval <= 0 {
+		p.PollInterval = 2 * time.Second
+	}
+
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("new fsnotify watcher: %w", err)
+	}
+
+	return &Watcher{
+		params:  p,
+		fsw:     fsw,
+		watched: map[string]struct{}{},
+	}, nil
+}
+
+// Run drives the injection loop until ctx is cancelled.
+//
+// Bootstrap: before entering the select, every root is walked and any existing
+// directory is registered with fsnotify while any existing .cas-config is
+// injected immediately. This closes the race where DerivedData already
+// contains a config by the time the watcher starts.
+//
+// Self-echo idempotency: rewriting a .cas-config produces a Write event that
+// re-enters handleEvent. InjectFile compares the desired RemoteService.Path
+// against the file's current value and returns changed=false when they match,
+// so the second pass is a stat + read + compare with no filesystem write. New
+// events therefore stop propagating after the first successful injection.
+//
+// Recursive add semantics: fsnotify on macOS (FSEvents) does not recurse into
+// subdirectories created after Add. Two mechanisms compensate: directory
+// Create events call addRecursive on the new subtree, and the poll ticker
+// re-walks every root so late-arriving trees (SourcePackages, XCBuildData,
+// Intermediates.noindex/...) are eventually picked up even if the Create was
+// missed.
+func (w *Watcher) Run(ctx context.Context) error {
+	defer w.fsw.Close()
+
+	for _, root := range w.params.Roots {
+		w.addRecursive(root)
+	}
+
+	ticker := time.NewTicker(w.params.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.params.Logger.Infof("watcher stopping: discovered=%d injected=%d skipped=%d errored=%d",
+				w.stats.discovered, w.stats.injected, w.stats.skipped, w.stats.errored)
+
+			return nil
+
+		case ev, ok := <-w.fsw.Events:
+			if !ok {
+				return errors.New("fsnotify events channel closed")
+			}
+			w.handleEvent(ev)
+
+		case err, ok := <-w.fsw.Errors:
+			if !ok {
+				return errors.New("fsnotify errors channel closed")
+			}
+			w.params.Logger.Warnf("fsnotify error: %v", err)
+
+		case <-ticker.C:
+			for _, root := range w.params.Roots {
+				w.addRecursive(root)
+			}
+		}
+	}
+}
+
+func (w *Watcher) handleEvent(ev fsnotify.Event) {
+	w.params.Logger.Debugf("fsnotify event: op=%s path=%s", ev.Op.String(), ev.Name)
+
+	// fsnotify bundles bits: a single event may carry Create|Write. Handle
+	// them independently instead of with a switch so both fire when needed.
+	if ev.Op.Has(fsnotify.Create) {
+		info, err := os.Lstat(ev.Name)
+		if err == nil {
+			if info.IsDir() {
+				w.addRecursive(ev.Name)
+			} else if IsCasConfigPath(ev.Name) {
+				w.tryInject(ev.Name)
+			}
+		}
+	}
+
+	if ev.Op.Has(fsnotify.Write) && IsCasConfigPath(ev.Name) {
+		w.tryInject(ev.Name)
+	}
+}
+
+func (w *Watcher) tryInject(path string) {
+	w.stats.discovered++
+
+	changed, err := InjectFile(path, w.params.SocketPath)
+	if err != nil {
+		w.stats.errored++
+		w.params.Logger.Errorf("inject %s: %v", path, err)
+
+		return
+	}
+	if !changed {
+		w.stats.skipped++
+		w.params.Logger.Debugf("skip (already patched): %s", path)
+
+		return
+	}
+
+	w.stats.injected++
+
+	now := time.Now()
+	if info, statErr := os.Stat(path); statErr == nil {
+		w.params.Logger.Infof("injected RemoteService into %s (modtime=%s injected_at=%s)",
+			path, info.ModTime().Format(time.RFC3339Nano), now.Format(time.RFC3339Nano))
+	} else {
+		w.params.Logger.Infof("injected RemoteService into %s (injected_at=%s; stat failed: %v)",
+			path, now.Format(time.RFC3339Nano), statErr)
+	}
+}
+
+func (w *Watcher) addRecursive(root string) {
+	_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+
+			return nil
+		}
+		if !d.IsDir() {
+			if IsCasConfigPath(p) {
+				w.tryInject(p)
+			}
+
+			return nil
+		}
+		// Skip well-known noisy DerivedData subtrees that never contain
+		// .cas-config. Each entry saves both an fsnotify Add and a
+		// recurring poll-scan traversal.
+		switch filepath.Base(p) {
+		case "ModuleCache.noindex",
+			"SDKStatCaches.noindex",
+			"Index.noindex",
+			"Logs",
+			"SourcePackages",
+			"XCBuildData":
+			return filepath.SkipDir
+		}
+		w.addDir(p)
+
+		return nil
+	})
+}
+
+func (w *Watcher) addDir(dir string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if _, ok := w.watched[dir]; ok {
+		return
+	}
+	if err := w.fsw.Add(dir); err != nil {
+		w.params.Logger.Debugf("watch add %s: %v", dir, err)
+
+		return
+	}
+	w.watched[dir] = struct{}{}
+	w.params.Logger.Debugf("watching %s", dir)
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/reactnative"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/update"
 	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/xcode"
+	_ "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/xcode_app_casinject"
 )
 
 func main() {


### PR DESCRIPTION
## Summary

Proof-of-concept subcommand \`bitrise-build-cache xcode-app-casinject watch\` that watches \`~/Library/Developer/Xcode/DerivedData\` for \`.cas-config\` files written by Xcode.app IDE builds and injects \`RemoteService.Path\` so the ToolchainCASPlugin opens the xcelerate proxy socket.

## Background

Xcode 26 IDE (Xcode.app) drops \`COMPILATION_CACHE_REMOTE_SERVICE_PATH\` before serialising \`.cas-config\`, so the CLI cannot rely on env-var injection to engage remote CAS from the IDE build path. Patching post-write is the only route. Findings recorded in commit d3cbc2c (\`docs: correct xcode-app IDE remote-CAS claims on macOS 26+\`).

## Package layout

- \`internal/xcode_app_casinject/inject.go\` — atomic \`.cas-config\` rewrite, idempotent when the file already carries the desired \`RemoteService.Path\`
- \`internal/xcode_app_casinject/watcher.go\` — fsnotify + poll-fallback loop, recursive add on \`Create\`, bootstrap scan of pre-existing configs
- \`cmd/xcode_app_casinject/\` — thin cobra wiring, defaults to \`~/Library/Developer/Xcode/DerivedData\` and the xcelerate-resolved socket path
- fsnotify dep added to go.mod

## Watcher tuning (planner-approved deltas)

- Prune \`ModuleCache.noindex\`, \`SDKStatCaches.noindex\`, \`Index.noindex\`, \`Logs\`, \`SourcePackages\`, \`XCBuildData\` from recursive walks — none of these ever contain \`.cas-config\` and they bloat both fsnotify Add count and poll-scan traversal cost
- Debug-log fsnotify Op string per event
- Log modtime + inject timestamp (RFC3339Nano) on successful writes for correlation with build logs
- Handle \`Create\` and \`Write\` as independent bits — fsnotify batches both bits into a single event on macOS FSEvents, and the previous \`switch\` only fired the first arm (latent bug)
- Docstring on \`Watcher.Run\` documenting bootstrap scan, self-echo idempotency (\`patchCasConfig\` returns \`changed=false\` when \`RemoteService.Path\` already matches), and the recursive-add double-safety (\`Create\` event + periodic poll)

## Verification

- \`make lint\` — 0 issues
- \`go test -tags unit -race ./internal/xcode_app_casinject/...\` — PASS
- \`make test-unit\` — PASS for all packages except one pre-existing failure in \`pkg/ccache\` (\`TestActivator_Activate/returns_error_when_auth_config_is_missing\`) that also fails on \`main\`, unrelated to this change

## Manual E2E test plan

- [ ] Start xcelerate proxy locally: \`bitrise-build-cache xcelerate proxy start\` (or \`make run-xcelerate-proxy\`)
- [ ] In a second shell, run the watcher against a scratch DerivedData: \`bitrise-build-cache --debug xcode-app-casinject watch --root /tmp/derived --allow-missing-socket\`
- [ ] Touch a \`.cas-config\` in a subdirectory of \`/tmp/derived\`: \`mkdir -p /tmp/derived/Foo/Build/Intermediates.noindex && printf '{"CASPath":"/tmp/x"}' > /tmp/derived/Foo/Build/Intermediates.noindex/.cas-config\`
- [ ] Verify watcher log shows \`fsnotify event: op=CREATE\` then \`injected RemoteService into ... (modtime=... injected_at=...)\`
- [ ] Verify file now contains \`"RemoteService": {"Path": "<socket>"}\`
- [ ] Rewrite the same file with the same \`RemoteService.Path\` — watcher should log \`skip (already patched)\` at debug level (no re-write, self-echo idempotency)
- [ ] Real Xcode.app build against a project of choice — confirm \`.cas-config\` files under DerivedData are patched before the ToolchainCASPlugin opens them; check the proxy log for CAS hits/misses
- [ ] Kill watcher (Ctrl-C) — should log \`watcher stopping: discovered=N injected=N skipped=N errored=N\`

## Status

Draft. Do not merge — this is a PoC scaffold. Follow-up tickets to file once the E2E validates the approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)