### PR TITLE
refactor: -d always ORs into config/params DebugLogging across cmd/ + pkg/reactnative

### DIFF
--- a/cmd/common/activate_interactive.go
+++ b/cmd/common/activate_interactive.go
@@ -199,7 +199,7 @@ func runInteractiveCcache(ctx context.Context, logger log.Logger, envs map[strin
 
 func runInteractiveXcode(ctx context.Context, logger log.Logger, envs map[string]string, pushEnabled bool) error {
 	params := xcelerate.DefaultParams()
-	params.DebugLogging = IsDebugLogMode
+	params.DebugLogging = DebugEnabled(params.DebugLogging)
 	params.PushEnabled = pushEnabled
 
 	if err := xcelerate.Activate(

--- a/cmd/common/activate_interactive_test.go
+++ b/cmd/common/activate_interactive_test.go
@@ -63,3 +63,14 @@ func TestUsernamePersistable(t *testing.T) {
 	assert.True(t, usernamePersistable(configcommon.AuthSourceMultiplatform))
 	assert.False(t, usernamePersistable(configcommon.AuthSourceJWT))
 }
+
+func TestDebugFlag_ORsGlobal_ActivateInteractive(t *testing.T) {
+	t.Cleanup(func() { IsDebugLogMode = false })
+
+	IsDebugLogMode = true
+	params := struct{ DebugLogging bool }{DebugLogging: false}
+
+	params.DebugLogging = DebugEnabled(params.DebugLogging)
+
+	assert.True(t, params.DebugLogging, "global -d must OR into interactive params.DebugLogging")
+}

--- a/cmd/common/debug.go
+++ b/cmd/common/debug.go
@@ -1,0 +1,5 @@
+package common
+
+// DebugEnabled reports whether debug logging is on from the passed source (a
+// config or params field) OR the global -d/--debug CLI flag.
+func DebugEnabled(source bool) bool { return source || IsDebugLogMode }

--- a/cmd/common/debug_test.go
+++ b/cmd/common/debug_test.go
@@ -1,0 +1,32 @@
+//go:build unit
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDebugEnabled(t *testing.T) {
+	t.Cleanup(func() { IsDebugLogMode = false })
+
+	cases := []struct {
+		name   string
+		source bool
+		global bool
+		want   bool
+	}{
+		{"both off", false, false, false},
+		{"source on, global off", true, false, true},
+		{"source off, global on", false, true, true},
+		{"both on", true, true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			IsDebugLogMode = tc.global
+			assert.Equal(t, tc.want, DebugEnabled(tc.source))
+		})
+	}
+}

--- a/cmd/reactnative/run_cmd.go
+++ b/cmd/reactnative/run_cmd.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 	rnpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/reactnative"
 )
 
@@ -20,7 +21,8 @@ var runCmd = &cobra.Command{
 	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := rnpkg.NewRunner(rnpkg.RunnerParams{
-			ExecFn: defaultExecFn,
+			ExecFn:       defaultExecFn,
+			DebugLogging: common.DebugEnabled(false),
 		})
 
 		return r.Run(cmd.Context(), args, os.Getenv("BITRISE_INVOCATION_ID"), os.Environ())

--- a/cmd/xcode/activate_xcode.go
+++ b/cmd/xcode/activate_xcode.go
@@ -46,7 +46,7 @@ This command will:
 		logger.EnableDebugLog(common.IsDebugLogMode)
 		logger.TInfof(activateXcode)
 
-		activateXcodeParams.DebugLogging = common.IsDebugLogMode
+		activateXcodeParams.DebugLogging = common.DebugEnabled(activateXcodeParams.DebugLogging)
 		logger.Infof("Activate Xcode params: %+v", activateXcodeParams)
 
 		if err := xcelerate.Activate(

--- a/cmd/xcode/debug_flag_internal_test.go
+++ b/cmd/xcode/debug_flag_internal_test.go
@@ -1,0 +1,23 @@
+//go:build unit
+
+package xcode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
+)
+
+func TestDebugFlag_ORsGlobal_ActivateXcode(t *testing.T) {
+	t.Cleanup(func() { common.IsDebugLogMode = false })
+
+	common.IsDebugLogMode = true
+	params := xcelerate.Params{DebugLogging: false}
+
+	params.DebugLogging = common.DebugEnabled(params.DebugLogging)
+
+	assert.True(t, params.DebugLogging, "global -d must OR into activateXcodeParams.DebugLogging")
+}

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -23,8 +23,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/analytics/multiplatform"
-	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/invocations"
@@ -37,6 +38,13 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/pkg/common/childstats"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/llvm/session"
 )
+
+// mergeDebugFlag ORs the CLI -d/--debug global into the config-derived flag.
+func mergeDebugFlag(cfg xcelerate.Config) xcelerate.Config {
+	cfg.DebugLogging = common.DebugEnabled(cfg.DebugLogging)
+
+	return cfg
+}
 
 const (
 	startedProxy = "Started xcelerate_proxy pid = %d"
@@ -101,6 +109,8 @@ TBD`,
 			log.NewLogger().Errorf(ErrReadConfig, err)
 			config = xcelerate.DefaultConfig()
 		}
+
+		config = mergeDebugFlag(config)
 
 		xcelerateParams.OrigArgs = os.Args[1:]
 
@@ -202,7 +212,7 @@ TBD`,
 			defer cleanup()
 		}
 
-		metadata := common.NewMetadata(utils.AllEnvs(), func(cmd string, args ...string) (string, error) {
+		metadata := configcommon.NewMetadata(utils.AllEnvs(), func(cmd string, args ...string) (string, error) {
 			o, err := utils.DefaultCommandFunc()(cobraCmd.Context(), cmd, args...).CombinedOutput()
 
 			return string(o), err
@@ -300,7 +310,7 @@ type localInvocationLogger interface {
 // Run as its main entry point.
 type XcodebuildRunner struct {
 	Config             xcelerate.Config
-	Metadata           common.CacheConfigMetadata
+	Metadata           configcommon.CacheConfigMetadata
 	InvocationID       string
 	Logger             log.Logger
 	CacheLogger        log.Logger
@@ -614,13 +624,13 @@ func getHitRateFromSessionAndRunStats(ctx context.Context,
 // 1. BITRISE_BUILD_CACHE_BENCHMARK_PHASE_XCODE env var (set during activation)
 // 2. ~/.local/state/xcelerate/benchmark/benchmark-phase-xcode.json (file fallback)
 func resolveBenchmarkPhase(logger log.Logger) string {
-	if phase := os.Getenv(common.BenchmarkPhaseEnvVar(common.BuildToolXcode)); phase != "" {
+	if phase := os.Getenv(configcommon.BenchmarkPhaseEnvVar(configcommon.BuildToolXcode)); phase != "" {
 		logger.Debugf("Benchmark phase from env: %s", phase)
 
 		return phase
 	}
 
-	if phase := common.ReadBenchmarkPhaseFile(common.BuildToolXcode, logger); phase != "" {
+	if phase := configcommon.ReadBenchmarkPhaseFile(configcommon.BuildToolXcode, logger); phase != "" {
 		logger.Debugf("Benchmark phase from file: %s", phase)
 
 		return phase

--- a/cmd/xcode/xcodebuild_internal_test.go
+++ b/cmd/xcode/xcodebuild_internal_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	cmdcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/analytics/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/xcelerate"
@@ -411,3 +412,13 @@ func Test_Run_BuildAction_StillEmitsAnalyticsAndSession(t *testing.T) {
 	assert.NoError(t, err, "handled-invocation marker must be written on the build path")
 }
 
+func TestDebugFlag_ORsGlobal_Xcodebuild(t *testing.T) {
+	t.Cleanup(func() { cmdcommon.IsDebugLogMode = false })
+
+	cmdcommon.IsDebugLogMode = true
+	cfg := xcelerate.Config{DebugLogging: false}
+
+	merged := mergeDebugFlag(cfg)
+
+	assert.True(t, merged.DebugLogging, "global -d must OR into config.DebugLogging")
+}

--- a/pkg/reactnative/runner.go
+++ b/pkg/reactnative/runner.go
@@ -41,6 +41,8 @@ type RunnerParams struct {
 	OsProxy utils.OsProxy
 	// DecoderFactory overrides the default decoder factory. If nil, utils.DefaultDecoderFactory{} is used.
 	DecoderFactory utils.DecoderFactory
+	// DebugLogging ORs with the on-disk multiplatform config's DebugLogging.
+	DebugLogging bool
 }
 
 //go:generate moq -stub -out post_run_runner_mock_test.go -pkg reactnative . postRunRunner
@@ -81,15 +83,7 @@ func NewRunner(params RunnerParams) *Runner {
 
 	logger := params.Logger
 	if logger == nil {
-		// Honour DebugLogging from the multiplatform analytics config so
-		// `activate react-native --debug` propagates to the runner and to any
-		// component (e.g. the analytics client) that uses this logger.
-		debug := false
-		if cfg, err := multiplatformconfig.ReadConfig(osProxy, decoderFactory); err == nil {
-			debug = cfg.DebugLogging
-		}
-
-		logger = log.NewLogger(log.WithDebugLog(debug))
+		logger = log.NewLogger(log.WithDebugLog(resolveDebugLogging(params.DebugLogging, osProxy, decoderFactory)))
 	}
 
 	var ccacheConfig *ccacheconfig.Config
@@ -267,4 +261,14 @@ func (r *Runner) zeroCcacheStats(ctx context.Context) {
 	if _, _, err := (exec.ExecRunner{}).RunCheck(ctx, path, "-z"); err != nil {
 		r.logger.TWarnf("Failed to reset ccache stats: %v", err)
 	}
+}
+
+// resolveDebugLogging ORs params.DebugLogging with the on-disk multiplatform config's DebugLogging.
+func resolveDebugLogging(paramsDebug bool, osProxy utils.OsProxy, decoderFactory utils.DecoderFactory) bool {
+	debug := paramsDebug
+	if cfg, err := multiplatformconfig.ReadConfig(osProxy, decoderFactory); err == nil {
+		debug = debug || cfg.DebugLogging
+	}
+
+	return debug
 }

--- a/pkg/reactnative/runner_test.go
+++ b/pkg/reactnative/runner_test.go
@@ -1,0 +1,61 @@
+//go:build unit
+
+package reactnative
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+)
+
+func writeMultiplatformConfig(t *testing.T, home string, debug bool) {
+	t.Helper()
+	dir := filepath.Join(home, ".bitrise/analytics/multiplatform")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	body := `{"debugLogging":false}`
+	if debug {
+		body = `{"debugLogging":true}`
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte(body), 0o644))
+}
+
+func TestResolveDebugLogging(t *testing.T) {
+	osProxy := utils.DefaultOsProxy{}
+	decoderFactory := utils.DefaultDecoderFactory{}
+
+	t.Run("params on, disk off", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		writeMultiplatformConfig(t, home, false)
+
+		assert.True(t, resolveDebugLogging(true, osProxy, decoderFactory), "params.DebugLogging must win when disk is off")
+	})
+
+	t.Run("params off, disk on", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		writeMultiplatformConfig(t, home, true)
+
+		assert.True(t, resolveDebugLogging(false, osProxy, decoderFactory), "disk DebugLogging must win when params is off")
+	})
+
+	t.Run("both off", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		writeMultiplatformConfig(t, home, false)
+
+		assert.False(t, resolveDebugLogging(false, osProxy, decoderFactory))
+	})
+
+	t.Run("params on, no disk config", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		assert.True(t, resolveDebugLogging(true, osProxy, decoderFactory), "missing disk config must not drop params.DebugLogging")
+	})
+}


### PR DESCRIPTION
## Summary

CLI \`-d\`/\`--debug\` (global \`cmd/common.IsDebugLogMode\`) is inconsistently honored today: several sites overwrite a config/params-derived \`DebugLogging\` bool with the global instead of ORing them, and \`pkg/reactnative/runner.go\` has no way for its \`cmd/\` caller to inject the global at all.

This PR introduces \`common.DebugEnabled(source bool) bool\` and ORs the global into every point where a config- or params-derived \`DebugLogging\` bool crosses into \`pkg/\`. Adds a \`DebugLogging\` field to \`pkg/reactnative.RunnerParams\` so the CLI global flows through without dropping the disk-derived value.

## Touched files

| File | Change |
| --- | --- |
| \`cmd/common/debug.go\` (new) | \`DebugEnabled(source) = source \|\| IsDebugLogMode\`; zero imports |
| \`cmd/common/debug_test.go\` (new) | 4-case table test |
| \`cmd/common/activate_interactive.go\` | OR into \`runInteractiveXcode\` params |
| \`cmd/common/activate_interactive_test.go\` | subtest asserting OR |
| \`cmd/xcode/xcodebuild.go\` | \`mergeDebugFlag\` merges config after read; import for \`internal/config/common\` aliased to \`configcommon\` |
| \`cmd/xcode/activate_xcode.go\` | OR into \`activateXcodeParams.DebugLogging\` |
| \`cmd/xcode/xcodebuild_internal_test.go\` | \`TestDebugFlag_ORsGlobal_Xcodebuild\` on \`mergeDebugFlag\` |
| \`cmd/xcode/debug_flag_internal_test.go\` (new) | \`TestDebugFlag_ORsGlobal_ActivateXcode\` |
| \`cmd/reactnative/run_cmd.go\` | passes \`DebugEnabled(false)\` into \`RunnerParams\` |
| \`pkg/reactnative/runner.go\` | adds \`RunnerParams.DebugLogging\` field + \`resolveDebugLogging\` helper ORing params with disk config |
| \`pkg/reactnative/runner_test.go\` (new) | 4-case \`TestResolveDebugLogging\` |

## Layering

- \`cmd/common/debug.go\` has zero imports (stdlib + package only).
- \`pkg/reactnative\` still does not import \`cmd/\`. The CLI global crosses the boundary by being passed in through \`RunnerParams.DebugLogging\` from \`cmd/reactnative/run_cmd.go\`.
- Existing disk-config-debug propagation in the runner is preserved (additive OR, not a replacement).

## Test plan

- [x] \`go test -tags unit -race ./cmd/common/... ./cmd/xcode/... ./cmd/reactnative/... ./pkg/reactnative/...\` — all pass
- [x] \`make lint\` — 0 issues
- [ ] CI green

## Notes

- Pre-existing test failures on \`main\` unrelated to this refactor: \`cmd/bazel\` \`Test_enableForBazelCmdFn\`, \`cmd/gradle\` \`Test_enableForGradleCmdFn\`, \`pkg/ccache\` \`TestActivator_Activate/returns_error_when_auth_config_is_missing\`, and the enrichment watcher/retrier flakes.
- \`pkg/reactnative\` gains a small public API surface (one \`DebugLogging bool\` field on \`RunnerParams\`); no behavior change other than the OR-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)