### PR TITLE
feat: xcelerate wrapper sets COMPILATION_CACHE_ENABLE_CACHING master toggle

### DIFF
--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -22,7 +22,13 @@ type XcodeArgs interface {
 	UserOtherCFlags() string
 }
 
+// Xcode 26 gates the compile-cache plugin behind the master toggle
+// COMPILATION_CACHE_ENABLE_CACHING. Without it, SwiftBuild resolves the
+// individual COMPILATION_CACHE_* keys but never emits -cache-compile-job on
+// swiftc argv, so the plugin never loads and the remote CAS stays dark for
+// projects whose target defaults don't already have caching on.
 var CacheArgs = map[string]string{
+	"COMPILATION_CACHE_ENABLE_CACHING":              "YES",
 	"COMPILATION_CACHE_ENABLE_PLUGIN":               "YES",
 	"COMPILATION_CACHE_ENABLE_INTEGRATED_QUERIES":   "YES",
 	"COMPILATION_CACHE_ENABLE_DETACHED_KEY_QUERIES": "YES",


### PR DESCRIPTION
## Summary

- Add `COMPILATION_CACHE_ENABLE_CACHING = YES` to `CacheArgs`. Xcode 26 gates the compile-cache plugin behind this master toggle; without it, SwiftBuild resolves the nine other `COMPILATION_CACHE_*` keys we already pass but never emits `-cache-compile-job` on swiftc argv, so the plugin never loads and remote CAS stays dark for any project whose target-level defaults don't happen to have caching on.
- Comment above the map explains the *why*.

## Verification

Cold-build IceCubesApp through the wrapper:

```
[Bitrise Analytics] Proxy blob stats: hits: 4567 (550 MB) / total: 5350 (85.36%). Uploaded blobs: 6289 (491 MB)
[Bitrise Analytics] Proxy KV stats: hits: 1765 / total: 2524 (69.93%). Uploaded KV blobs: 866 kB
[Bitrise Analytics] Xcode task stats: hits: 1113 / total: 1896 (58.70%)
```

Before this change on the same project the wrapper produced zero proxy traffic (the plugin loaded locally but never opened the socket).

## Test plan

- [ ] `make lint`
- [ ] `make test-unit`
- [ ] cache-xcode-test CI workflow (Bitrise), specifically the assertion that the proxy sees real `Upload xcelerate-cas-*` lines during a wrapper-driven cold build

🤖 Generated with [Claude Code](https://claude.com/claude-code)