### PR TITLE
post-walkthrough fixes: doctor overall field, log noise, watcher filter, scheme PATH

### DIFF
--- a/docs/xcode-scheme-self-check.md
+++ b/docs/xcode-scheme-self-check.md
@@ -36,7 +36,7 @@ set -eu
 LOG="${TMPDIR:-/tmp}/bitrise-build-cache-doctor.log"
 
 # Xcode strips PATH down to a minimal set. Extend to common CLI install dirs.
-export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+export PATH="$HOME/.bitrise/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
 if ! command -v bitrise-build-cache >/dev/null 2>&1; then
     # CLI not installed — nothing to check. Silent no-op.

--- a/internal/config/common/expiry_aware_resolver.go
+++ b/internal/config/common/expiry_aware_resolver.go
@@ -50,7 +50,7 @@ func (r *ExpiryAwareResolver) Get() CacheAuthConfig {
 	pat, wsid, err := r.refreshFn(r.ctx)
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Warnf("ExpiryAwareResolver: refreshFn failed, serving previous credentials: %s", err)
+			r.logger.Debugf("ExpiryAwareResolver: refreshFn failed, serving previous credentials: %s", err)
 		}
 
 		return cfg

--- a/internal/config/common/expiry_aware_resolver_test.go
+++ b/internal/config/common/expiry_aware_resolver_test.go
@@ -56,7 +56,7 @@ func TestExpiryAwareResolver_RefreshFnError_FallsBackToPlainResolve(t *testing.T
 	}
 
 	var out bytes.Buffer
-	logger := log.NewLogger(log.WithOutput(&out))
+	logger := log.NewLogger(log.WithOutput(&out), log.WithDebugLog(true))
 
 	r := newExpiryAwareResolver(context.Background(), map[string]string{}, refresh, resolve, logger)
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -42,6 +42,7 @@ type Check struct {
 type Report struct {
 	Items   []ReportItem `json:"items"`
 	Version string       `json:"cli_version"`
+	Overall State        `json:"overall"`
 }
 
 type ReportItem struct {
@@ -51,9 +52,9 @@ type ReportItem struct {
 	FixError  string  `json:"fix_error,omitempty"`
 }
 
-func (r Report) Overall() State {
+func computeOverall(items []ReportItem) State {
 	worst := StateOK
-	for _, it := range r.Items {
+	for _, it := range items {
 		switch it.Result.State {
 		case StateError:
 			return StateError
@@ -158,7 +159,7 @@ func (d *Doctor) Run(ctx context.Context, opts Options) Report {
 		items = append(items, item)
 	}
 
-	return Report{Items: items, Version: d.CLIVersion}
+	return Report{Items: items, Version: d.CLIVersion, Overall: computeOverall(items)}
 }
 
 func (d *Doctor) checks(opts Options) []Check {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -92,7 +92,7 @@ func TestReport_Overall(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, Report{Items: tt.items}.Overall())
+			assert.Equal(t, tt.want, computeOverall(tt.items))
 		})
 	}
 }

--- a/internal/xcelerate/enrichment/enricher.go
+++ b/internal/xcelerate/enrichment/enricher.go
@@ -55,6 +55,12 @@ func (e *Enricher) Enrich(entry ManifestEntry) {
 		}
 	}
 
+	if entry.Command() == CommandUnknown {
+		logger.Debugf("Enrichment PUT skipped for manifest %s: side-effect (sig=%q scheme=%q)", entry.UUID, entry.Signature, entry.SchemeName)
+
+		return
+	}
+
 	invocationID, matched := Correlate(entry, pending)
 	if !matched {
 		invocationID = uuid.NewString()

--- a/internal/xcelerate/enrichment/enricher_test.go
+++ b/internal/xcelerate/enrichment/enricher_test.go
@@ -94,6 +94,46 @@ func TestEnricher_NoMatchMintsFreshID(t *testing.T) {
 	assert.False(t, captured.Success)
 }
 
+func TestEnricher_CommandUnknown_SkipsPUT(t *testing.T) {
+	dir := t.TempDir()
+	store := &enrichment.Store{Path: filepath.Join(dir, "pending.ndjson")}
+
+	base := time.Now()
+	require.NoError(t, store.Append(enrichment.PendingRecord{
+		InvocationID: "wrapper-id",
+		StartTime:    base,
+		Duration:     10_000,
+	}))
+
+	var puts int
+	mock := &InvocationPutterMock{
+		PutInvocationFunc: func(_ analytics.Invocation) error {
+			puts++
+
+			return nil
+		},
+	}
+
+	e := &enrichment.Enricher{Store: store, Client: mock}
+
+	for _, sig := range []string{"Resolve Packages", "Update Signing", "Sync Localizations"} {
+		e.Enrich(enrichment.ManifestEntry{
+			UUID:      "side-effect-" + sig,
+			Signature: sig,
+			Status:    "S",
+			Start:     base.Add(1 * time.Second),
+			Stop:      base.Add(2 * time.Second),
+		})
+	}
+
+	assert.Zero(t, puts, "side-effect manifests must not trigger PutInvocation")
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	assert.Len(t, loaded, 1, "side-effect early-return must not consume time-overlapping pending records")
+	assert.Equal(t, "wrapper-id", loaded[0].InvocationID)
+}
+
 func TestEnricher_PutFailure_DoesNotRemovePending(t *testing.T) {
 	dir := t.TempDir()
 	store := &enrichment.Store{Path: filepath.Join(dir, "pending.ndjson")}


### PR DESCRIPTION
## Summary

Five small fixes surfaced during a full manual-testing walkthrough of ACI-4337 epic on 2026-07-24.

## Changes

- **`internal/doctor/doctor.go`** — `Report` gains an `Overall` JSON field so `doctor --json | jq .overall` returns `"ok"` / `"warn"` / `"error"` instead of `null`. The `Overall()` method got refactored to `computeOverall(items)` to avoid the field-and-method name collision.
- **`internal/config/common/expiry_aware_resolver.go`** — `refreshFn` error path downgraded from `Warnf` to `Debugf`. On a manual `auth set` keychain entry (non-OAuth-managed), `oauth.EnsureFresh` returns `ErrNotLoggedIn` — the resolver correctly falls back to the plain `ResolveAuthConfig` cfg. Logging this on every RPC produced 10k+ warn lines per build.
- **`internal/xcelerate/enrichment/enricher.go`** — skip enrichment PUT when the manifest entry has `Command() == CommandUnknown`. Filters out side-effect manifests (Package resolve, Update Signing, Localization sync) that were emitting BE dashboard rows with empty scheme/cmd fields.
- **`docs/xcode-scheme-self-check.md`** — pre-action script's PATH extension gains `$HOME/.bitrise/bin`. `daemon install` writes the CLI there; the recipe was missing it, so the pre-action silently exited 0 as "CLI not installed" on the very machines that had it via the daemon path.

## Test plan

- [x] `make lint` clean
- [x] `go test -tags unit -race ./...` — touched packages green; pre-existing enrichment flakes unchanged
- [x] Full manual walkthrough (see `docs/aci-4337-manual-testing-guide-2026-07-23.md`) confirmed each fix on-device

🤖 Generated with [Claude Code](https://claude.com/claude-code)