### PR TITLE
docs: fix RN step steplib-id in release skill mapping

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -154,14 +154,14 @@ Create GitHub releases for whichever of the five step repos the user actually wa
 
 After the step releases, PRs appear in `bitrise-io/bitrise-steplib` for each released step. They may need a rebase.
 
-⚠ **steplib PR titles use the step's steplib ID, NOT its GitHub repo name — and the Gradle step's two names differ.** The steplib PR title is `<steplib-id>-<version>`. For most steps the id matches the repo, but the Gradle step's repo is `bitrise-step-activate-gradle-remote-cache` while its steplib id is **`activate-build-cache-for-gradle`** — so its steplib PR is titled `activate-build-cache-for-gradle-<version>` (e.g. `activate-build-cache-for-gradle-2.20.16`), not `activate-gradle-remote-cache-…`. If you search/poll for the wrong name the PR looks "missing" when it is in fact open. The five repo → steplib-id mappings:
+⚠ **steplib PR titles use the step's steplib ID, NOT its GitHub repo name — and TWO steps' names differ.** The steplib PR title is `<steplib-id>-<version>`. For most steps the id matches the repo, but two do NOT: the Gradle step's repo is `bitrise-step-activate-gradle-remote-cache` while its steplib id is **`activate-build-cache-for-gradle`**, and the React Native step's repo is `bitrise-step-activate-react-native-features` while its steplib id is **`activate-build-cache-for-react-native`**. So their steplib PRs are titled `activate-build-cache-for-gradle-<version>` and `activate-build-cache-for-react-native-<version>` — NOT `activate-gradle-remote-cache-…` / `activate-react-native-features-…`. If you search/poll for the wrong name the PR looks "missing" when it is in fact open (this cost ~40 min on the v3.2.2 release). To get a step's true steplib id, read the `Step id found:` line in its `release` build log (the `step-id-finder` step). The five repo → steplib-id mappings:
 
 | GitHub repo | steplib PR id |
 |---|---|
 | `bitrise-step-activate-gradle-remote-cache` | **`activate-build-cache-for-gradle`** |
 | `bitrise-step-activate-build-cache-for-xcode` | `activate-build-cache-for-xcode` |
 | `bitrise-step-activate-gradle-mirrors` | `activate-gradle-mirrors` |
-| `bitrise-step-activate-react-native-features` | `activate-react-native-features` |
+| `bitrise-step-activate-react-native-features` | **`activate-build-cache-for-react-native`** |
 | `bitrise-step-activate-gradle-features` | `activate-gradle-features` |
 
 **Merge each steplib PR as soon as it is individually MERGEABLE — do not batch-wait for all of them.** They appear and become mergeable at different times; gating on "all N present" stalls the whole release behind the slowest one (and behind any name-matching mistake above).


### PR DESCRIPTION
## Summary

The `/release` skill's steplib repo → steplib-id mapping had the wrong id for the React Native step. Its steplib PR is titled `activate-build-cache-for-react-native-<version>`, **not** `activate-react-native-features-<version>`. During the v3.2.2 release, polling for the wrong title made the RN steplib PR (`#5042`) look missing for ~40 min when it was in fact open and mergeable the whole time.

## Changes

- Correct the RN row in the repo → steplib-id table: `activate-react-native-features` → **`activate-build-cache-for-react-native`**.
- Generalize the ⚠ warning: **two** steps (Gradle + RN), not just Gradle, have a steplib-id that differs from the repo name.
- Add the reliable way to get a step's true steplib id: the `Step id found:` line in the step repo's `release` build log (`step-id-finder` step).

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)