### PR TITLE
fix: SSW-3090 make gradle-mirrors init script Isolated-Projects-compatible

### DIFF
--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -81,7 +81,8 @@ func TestActivate(t *testing.T) {
 				`log("prepending pluginManagement mirror https://repository-manager.services.bitrise.io:8090/maven/gradle-plugins")`,
 				`val loggedReplacements = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()`,
 				`if (loggedReplacements.add("${getName()}|${getUrl()}|$mirrorUrl"))`,
-				// Core: robolectric android-all redirect set unconditionally as part of the mirror install
+				// Core: robolectric android-all redirect set unconditionally as part of the mirror install,
+				// configured per project so it stays Isolated-Projects-compatible
 				`log("setting robolectric.dependency.repo.url=\"https://repository-manager.services.bitrise.io:8090/maven/central\" on all Test tasks")`,
 				`val roboProbes = System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false"`,
 				`tasks.withType(Test::class.java).configureEach {`,
@@ -94,7 +95,7 @@ func TestActivate(t *testing.T) {
 				`events("failed")`,
 				// Robolectric-specific classpath probe
 				`object RobolectricDiagnostics {`,
-				`test.doFirst { emitClasspathProbe(test, cliVersion) }`,
+				`test.doFirst { emitClasspathProbe(this as Test, cliVersion) }`,
 				// Classpath fingerprint (noncompatWidthPixels field check + bytecode-agent inventory, robolectric#9630)
 				`val hasField = String(bytes, Charsets.ISO_8859_1).contains("noncompatWidthPixels")`,
 				`"${jar.name}(${jar.length()},noncompatWidthPixels:$field)"`,
@@ -119,6 +120,10 @@ func TestActivate(t *testing.T) {
 				"getJavaLauncher",
 				"BITRISE_ROBOLECTRIC_VERBOSE_LOGGING",
 				"finalizedBy",
+				// Cross-project access — breaks Gradle Isolated Projects
+				"allprojects",
+				"subprojects",
+				"getRootProject()",
 			},
 		},
 		{

--- a/internal/config/gradle/mirrors/activate_test.go
+++ b/internal/config/gradle/mirrors/activate_test.go
@@ -83,10 +83,13 @@ func TestActivate(t *testing.T) {
 				`if (loggedReplacements.add("${getName()}|${getUrl()}|$mirrorUrl"))`,
 				// Core: robolectric android-all redirect set unconditionally as part of the mirror install,
 				// configured per project so it stays Isolated-Projects-compatible
-				`log("setting robolectric.dependency.repo.url=\"https://repository-manager.services.bitrise.io:8090/maven/central\" on all Test tasks")`,
-				`val roboProbes = System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false"`,
+				`log("registering robolectric.dependency.repo.url=\"https://repository-manager.services.bitrise.io:8090/maven/central\" on Test tasks, per project")`,
+				// Suffixed per mirror: two UseAsRobolectricRepo entries would otherwise emit conflicting
+				// declarations in the same scope and the init script would not compile
+				`val roboProbesCentral = System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false"`,
 				`tasks.withType(Test::class.java).configureEach {`,
 				`systemProperty("robolectric.dependency.repo.url", "https://repository-manager.services.bitrise.io:8090/maven/central")`,
+				`if (roboProbesCentral) {`,
 				`TestFailureLogging.enable(this)`,
 				`RobolectricDiagnostics.probe(this, "v0.0.0-test")`,
 				// Generic FULL-on-FAILED logging extracted into its own object

--- a/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -68,28 +68,29 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
                 log("beforeProject(${getPath()}) fired, configuring buildscript repositories")
             }
             configureMirror.execute(getBuildscript().getRepositories())
+            {{- range .Mirrors }}{{ if .UseAsRobolectricRepo }}
+            // Redirect Robolectric's android-all download to the mirror on every Test task. Each project
+            // configures its own tasks: reaching across projects from the root breaks Isolated Projects.
+            // Registered here rather than in afterProject so a project that sets the property itself is
+            // applied last and still wins.
+            if (getParent() == null) {
+                log("registering robolectric.dependency.repo.url=\"{{ .MirrorURL }}\" on Test tasks, per project")
+            }
+            val roboProbes{{ .ID }} = System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false"
+            tasks.withType(Test::class.java).configureEach {
+                systemProperty("robolectric.dependency.repo.url", "{{ .MirrorURL }}")
+                if (roboProbes{{ .ID }}) {
+                    TestFailureLogging.enable(this)
+                    RobolectricDiagnostics.probe(this, "{{ $.CLIVersion }}")
+                }
+            }
+            {{- end }}{{ end }}
         })
         gradle.afterProject(Action {
             if (getParent() == null) {
                 log("afterProject(${getPath()}) fired, configuring project repositories")
             }
             configureMirror.execute(getRepositories())
-            {{- range .Mirrors }}{{ if .UseAsRobolectricRepo }}
-            // Redirect Robolectric's android-all download to the mirror on every Test task. afterProject
-            // fires per project, so each one configures its own tasks — reaching across projects from the
-            // root would break Gradle Isolated Projects.
-            if (getParent() == null) {
-                log("setting robolectric.dependency.repo.url=\"{{ .MirrorURL }}\" on all Test tasks")
-            }
-            val roboProbes = System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false"
-            tasks.withType(Test::class.java).configureEach {
-                systemProperty("robolectric.dependency.repo.url", "{{ .MirrorURL }}")
-                if (roboProbes) {
-                    TestFailureLogging.enable(this)
-                    RobolectricDiagnostics.probe(this, "{{ $.CLIVersion }}")
-                }
-            }
-            {{- end }}{{ end }}
         })
     }
 }

--- a/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -75,18 +75,18 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
             }
             configureMirror.execute(getRepositories())
             {{- range .Mirrors }}{{ if .UseAsRobolectricRepo }}
-            // Redirect Robolectric's android-all download to the mirror on every Test task (root-only, once).
+            // Redirect Robolectric's android-all download to the mirror on every Test task. afterProject
+            // fires per project, so each one configures its own tasks — reaching across projects from the
+            // root would break Gradle Isolated Projects.
             if (getParent() == null) {
-                val roboProbes = System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false"
                 log("setting robolectric.dependency.repo.url=\"{{ .MirrorURL }}\" on all Test tasks")
-                getRootProject().allprojects {
-                    tasks.withType(Test::class.java).configureEach {
-                        systemProperty("robolectric.dependency.repo.url", "{{ .MirrorURL }}")
-                        if (roboProbes) {
-                            TestFailureLogging.enable(this)
-                            RobolectricDiagnostics.probe(this, "{{ $.CLIVersion }}")
-                        }
-                    }
+            }
+            val roboProbes = System.getenv("BITRISE_ROBOLECTRIC_JAR_AUDIT") != "false"
+            tasks.withType(Test::class.java).configureEach {
+                systemProperty("robolectric.dependency.repo.url", "{{ .MirrorURL }}")
+                if (roboProbes) {
+                    TestFailureLogging.enable(this)
+                    RobolectricDiagnostics.probe(this, "{{ $.CLIVersion }}")
                 }
             }
             {{- end }}{{ end }}
@@ -112,7 +112,9 @@ object TestFailureLogging {
 // fail a customer build.
 object RobolectricDiagnostics {
     fun probe(test: Test, cliVersion: String) {
-        test.doFirst { emitClasspathProbe(test, cliVersion) }
+        // Take the task from the action receiver: capturing `test` would put a Task in a task action,
+        // which the configuration cache cannot serialize.
+        test.doFirst { emitClasspathProbe(this as Test, cliVersion) }
     }
 
     // A stub android.jar / mockable-android MISSING noncompatWidthPixels shadows android-all's instrumented


### PR DESCRIPTION
## Summary

[SSW-3090](https://bitrise.atlassian.net/browse/SSW-3090) — Adastra s.r.o. enabled Gradle's Isolated Projects (`org.gradle.unsafe.isolated-projects=true`) and every build fails at configuration time:

```
Plugin class 'Bitrise_gradle_mirrors_init_gradle$InternalRepositoryPlugin':
Project ':' cannot access 'Project.tasks' functionality on subprojects via 'allprojects'
Plugin class 'Bitrise_gradle_mirrors_init_gradle$InternalRepositoryPlugin':
Project ':build-logic' cannot access 'Project.tasks' functionality on subprojects via 'allprojects'
```

The Robolectric block in `gradle.afterProject` reached into every project's `tasks` via `getRootProject().allprojects`. It is gated on `UseAsRobolectricRepo`, set only on the `mavencentral` mirror — which is on by default, so any Isolated Projects build hits it. This was the only `allprojects`/`subprojects` usage in the repo; the build-cache init script uses `rootProject { }` only and is unaffected. Note the script also ships via preboot, so the blast radius is not limited to workflows running the Activate Gradle Mirrors step.

## Changes

Both in `asset/gradle-mirrors.init.gradle.kts.gotemplate`:

- **Register the Robolectric redirect per project, in `beforeProject`.** Drops the `getRootProject().allprojects { }` wrapper, which is the Isolated Projects violation. `configureEach` stays lazy, so coverage is unchanged.

  `beforeProject` rather than `afterProject` is deliberate, and it is the non-obvious part of this PR. `configureEach` actions run in registration order, so whoever registers last wins. The old `allprojects`-from-root registration happened *before* subproject build scripts were read, so a project setting `robolectric.dependency.repo.url` itself won. Moving to each project's own `afterProject` would invert that and make us the last writer — silently overriding the escape hatch we published on [SSW-3019](https://bitrise.atlassian.net/browse/SSW-3019):

  ```kotlin
  tasks.withType<Test>().configureEach {
      systemProperty("robolectric.dependency.repo.url", "https://repo1.maven.org/maven2")
  }
  ```

  `beforeProject` registers ahead of the build script, so project config wins again — now consistently, including the root project, which the old code did not manage.

- **Suffix `roboProbes` per mirror** (`roboProbes{{ .ID }}`), matching the existing `canBeMirrored{{ .ID }}` / `useMirror{{ .ID }}` convention. Only `mavencentral` sets `UseAsRobolectricRepo` today, so one copy is emitted; a second flagged entry would otherwise emit two `val roboProbes` in one scope, fail to compile, and break every Gradle build on the machine.

- **Take the `Test` task from the `doFirst` receiver** instead of capturing it. `RobolectricDiagnostics.probe` put a `Task` reference inside its own task action; Isolated Projects implies the configuration cache, so that would have been the next failure once the `allprojects` one cleared.

Plus a log reword (the root-only line described work that now happens per project) and ASCII-only in the template.

`activate_test.go` — update the pinned assertions and add `allprojects` / `subprojects` / `getRootProject()` to `expectNotContain` as a regression guard.

## Verification

Multi-module repro with a `build-logic` included build, `org.gradle.unsafe.isolated-projects=true`, Gradle 8.14.5 / JDK 21. Rendered with the full `KnownMirrors` set.

| Check | Result |
| --- | --- |
| Pre-fix script | reproduces the customer error verbatim |
| Post-fix, probes on, no override | mirror applies, no IP error, config cache **stored** |
| Re-run | `Reusing configuration cache.` |
| SSW-3019 escape hatch present | resolves to `repo1.maven.org` — project config wins |
| `BITRISE_MAVENCENTRAL_PROXY_ENABLED=false` | script no-ops, build green |
| `BITRISE_ROBOLECTRIC_JAR_AUDIT=false` | green |
| Static | 0 non-ASCII, 0 `allprojects`/`getRootProject()`, exactly 1 `roboProbes` decl |

`make lint` → 0 issues. Full `make test-unit` green except `internal/xcelerate/enrichment` and `pkg/ccache`, which fail identically on clean `main`.

## Notes for the reviewer

See also the [follow-up comment](https://github.com/bitrise-io/bitrise-build-cache-cli/pull/442#issuecomment-5089912615) on retiring `RobolectricDiagnostics` and on the root-project `testLogging` precedence shift.

Worth a separate ticket: migrating `beforeProject`/`afterProject` to the isolated `gradle.lifecycle.*` API would be fully IP-clean, but those actions cannot capture `log()`, the `configureMirror`/`useMirror` `Action`s, or the `loggedReplacements` dedupe set — a rewrite of the whole script plus a Gradle 8.8 floor. Per [gradle/gradle#30075](https://github.com/gradle/gradle/issues/30075) the current hooks are "not inherently incompatible with IP", so there is no correctness pressure to do it now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SSW-3090]: https://bitrise.atlassian.net/browse/SSW-3090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SSW-3019]: https://bitrise.atlassian.net/browse/SSW-3019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ