### PR TITLE
feat: ACI-5253 make SPM checkouts findable and consistent across every xcodebuild action

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1339,21 +1339,24 @@ workflows:
         inputs:
         - key: xcode-spm-e2e-{{ .OS }}-{{ .Arch }}-{{ .Branch }}
     - script:
-        title: 'ACI-5253: rebuild and assert SPM downloaded nothing'
+        title: 'ACI-5253: assert SPM resolves offline from the restored checkouts'
         inputs:
         - content: |-
-            set -eo pipefail
+            set -exo pipefail
 
-            xcodebuild build \
+            # Discovered rather than recomputed, so the test does not restate the workspace-sha rule.
+            spm_dir=$(echo "${BITRISE_XCODE_DERIVED_DATA_PATH:?}"/*/SourcePackages)
+            [ -d "$spm_dir" ] || { echo "restore left no SourcePackages under $BITRISE_XCODE_DERIVED_DATA_PATH"; exit 1; }
+
+            # -resolvePackageDependencies is a query action, so the wrapper does not point it at the
+            # managed DerivedData for us.
+            xcodebuild -resolvePackageDependencies \
               -workspace ComposableArchitecture.xcworkspace \
               -scheme ComposableArchitecture \
-              -destination "generic/platform=iOS" \
-              -skipMacroValidation 2> wrapper-warm.log | tee xcodebuild-warm.log | xcpretty
-
-            cp wrapper-warm.log xcodebuild-warm.log "$BITRISE_DEPLOY_DIR"
+              -clonedSourcePackagesDirPath "$spm_dir" 2>&1 | tee "$BITRISE_DEPLOY_DIR/spm-resolve.log"
 
             # A "Fetching from" line means the cache steps archived a dir the build never reads.
-            if grep -n 'Fetching from' xcodebuild-warm.log; then
+            if grep -n 'Fetching from' "$BITRISE_DEPLOY_DIR/spm-resolve.log"; then
               echo "SPM re-fetched packages despite the restored checkouts"
               exit 1
             fi

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1230,6 +1230,23 @@ workflows:
               ../bitrise-build-cache-cli -d activate xcode \
                 --cache
     - script:
+        title: 'ACI-5253: assert activate exports the SPM checkout dir'
+        inputs:
+        - content: |-
+            set -exo pipefail
+
+            # Exported so cache steps have a stable path to target: the wrapper moves DerivedData
+            # under ~/.bitrise/cache, dragging SPM checkouts out of the default location with it.
+            expected="$HOME/.bitrise/cache/xcode-spm"
+            if [[ "$BITRISE_XCODE_SOURCE_PACKAGES_PATH" != "$expected" ]]; then
+              echo "BITRISE_XCODE_SOURCE_PACKAGES_PATH=$BITRISE_XCODE_SOURCE_PACKAGES_PATH, want $expected"
+              exit 1
+            fi
+    - restore-cache:
+        title: 'ACI-5253: restore SPM checkouts'
+        inputs:
+        - key: xcode-spm-e2e-{{ .OS }}-{{ .Arch }}-{{ .Branch }}
+    - script:
         title: build app
         inputs:
           - content: |-
@@ -1323,6 +1340,55 @@ workflows:
             set -exo pipefail
 
             ../scripts/check_pattern.sh "$BITRISE_DEPLOY_DIR/xcodebuild.log" 'CompilationCacheMetrics'
+    - script:
+        title: 'ACI-5253: assert SPM checkouts landed in the exported dir'
+        inputs:
+        - content: |-
+            set -exo pipefail
+
+            grep -q -- '-clonedSourcePackagesDirPath' "$BITRISE_DEPLOY_DIR/wrapper.log" \
+              || { echo "wrapper did not pass -clonedSourcePackagesDirPath to xcodebuild"; exit 1; }
+
+            checkouts="$BITRISE_XCODE_SOURCE_PACKAGES_PATH/checkouts"
+            [[ -d "$checkouts" ]] || { echo "no checkouts under $BITRISE_XCODE_SOURCE_PACKAGES_PATH"; exit 1; }
+            [[ -n "$(ls -A "$checkouts")" ]] || { echo "$checkouts is empty"; exit 1; }
+            echo "Relocated SPM checkouts: $(ls -A "$checkouts" | wc -l) package(s)"
+
+            # The bug this guards: checkouts staying in the default DerivedData location, where the
+            # wrapper's -derivedDataPath means the build never reads them and cache steps archive
+            # a directory that is never used.
+            stale=$(find "$HOME/Library/Developer/Xcode/DerivedData" -maxdepth 3 -type d -name checkouts 2>/dev/null | head -1)
+            if [[ -n "$stale" && -n "$(ls -A "$stale" 2>/dev/null)" ]]; then
+              echo "SPM checkouts also present in the default DerivedData location: $stale"
+              exit 1
+            fi
+    - save-cache:
+        title: 'ACI-5253: save SPM checkouts from the exported dir'
+        inputs:
+        - key: xcode-spm-e2e-{{ .OS }}-{{ .Arch }}-{{ .Branch }}
+        - paths: $BITRISE_XCODE_SOURCE_PACKAGES_PATH
+    - script:
+        title: 'ACI-5253: drop the checkouts so the restore below has to repopulate them'
+        inputs:
+        - content: |-
+            set -exo pipefail
+            rm -rf "$BITRISE_XCODE_SOURCE_PACKAGES_PATH"
+    - restore-cache:
+        title: 'ACI-5253: restore SPM checkouts round-trip'
+        inputs:
+        - key: xcode-spm-e2e-{{ .OS }}-{{ .Arch }}-{{ .Branch }}
+    - script:
+        title: 'ACI-5253: assert the round-trip repopulated the exported dir'
+        inputs:
+        - content: |-
+            set -exo pipefail
+
+            # Proves the exported path is usable verbatim by the generic cache steps, and that
+            # restore replays the archive to the location the next build will actually read.
+            checkouts="$BITRISE_XCODE_SOURCE_PACKAGES_PATH/checkouts"
+            [[ -d "$checkouts" && -n "$(ls -A "$checkouts")" ]] \
+              || { echo "restore did not repopulate $checkouts"; exit 1; }
+            echo "Round-trip restored $(ls -A "$checkouts" | wc -l) package(s)"
     - deploy-to-bitrise-io: {}
 
   e2e-xcode-cas-key-stable:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1348,9 +1348,7 @@ workflows:
             spm_dir=$(echo "${BITRISE_XCODE_DERIVED_DATA_PATH:?}"/*/SourcePackages)
             [ -d "$spm_dir" ] || { echo "restore left no SourcePackages under $BITRISE_XCODE_DERIVED_DATA_PATH"; exit 1; }
 
-            # No -clonedSourcePackagesDirPath on purpose: the wrapper injects it for resolving query
-            # actions, so this also covers that injection. Without it the resolve would read the
-            # default DerivedData, find nothing and re-fetch.
+            # No -clonedSourcePackagesDirPath: the wrapper injects it, so this covers that too.
             xcodebuild -resolvePackageDependencies \
               -workspace ComposableArchitecture.xcworkspace \
               -scheme ComposableArchitecture 2>&1 | tee "$BITRISE_DEPLOY_DIR/spm-resolve.log"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1230,23 +1230,6 @@ workflows:
               ../bitrise-build-cache-cli -d activate xcode \
                 --cache
     - script:
-        title: 'ACI-5253: assert activate exports the SPM checkout dir'
-        inputs:
-        - content: |-
-            set -exo pipefail
-
-            # Exported so cache steps have a stable path to target: the wrapper moves DerivedData
-            # under ~/.bitrise/cache, dragging SPM checkouts out of the default location with it.
-            expected="$HOME/.bitrise/cache/xcode-spm"
-            if [[ "$BITRISE_XCODE_SOURCE_PACKAGES_PATH" != "$expected" ]]; then
-              echo "BITRISE_XCODE_SOURCE_PACKAGES_PATH=$BITRISE_XCODE_SOURCE_PACKAGES_PATH, want $expected"
-              exit 1
-            fi
-    - restore-cache:
-        title: 'ACI-5253: restore SPM checkouts'
-        inputs:
-        - key: xcode-spm-e2e-{{ .OS }}-{{ .Arch }}-{{ .Branch }}
-    - script:
         title: build app
         inputs:
           - content: |-
@@ -1340,55 +1323,40 @@ workflows:
             set -exo pipefail
 
             ../scripts/check_pattern.sh "$BITRISE_DEPLOY_DIR/xcodebuild.log" 'CompilationCacheMetrics'
-    - script:
-        title: 'ACI-5253: assert SPM checkouts landed in the exported dir'
-        inputs:
-        - content: |-
-            set -exo pipefail
-
-            grep -q -- '-clonedSourcePackagesDirPath' "$BITRISE_DEPLOY_DIR/wrapper.log" \
-              || { echo "wrapper did not pass -clonedSourcePackagesDirPath to xcodebuild"; exit 1; }
-
-            checkouts="$BITRISE_XCODE_SOURCE_PACKAGES_PATH/checkouts"
-            [[ -d "$checkouts" ]] || { echo "no checkouts under $BITRISE_XCODE_SOURCE_PACKAGES_PATH"; exit 1; }
-            [[ -n "$(ls -A "$checkouts")" ]] || { echo "$checkouts is empty"; exit 1; }
-            echo "Relocated SPM checkouts: $(ls -A "$checkouts" | wc -l) package(s)"
-
-            # The bug this guards: checkouts staying in the default DerivedData location, where the
-            # wrapper's -derivedDataPath means the build never reads them and cache steps archive
-            # a directory that is never used.
-            stale=$(find "$HOME/Library/Developer/Xcode/DerivedData" -maxdepth 3 -type d -name checkouts 2>/dev/null | head -1)
-            if [[ -n "$stale" && -n "$(ls -A "$stale" 2>/dev/null)" ]]; then
-              echo "SPM checkouts also present in the default DerivedData location: $stale"
-              exit 1
-            fi
     - save-cache:
-        title: 'ACI-5253: save SPM checkouts from the exported dir'
+        title: 'ACI-5253: save the SPM checkouts the build actually used'
         inputs:
         - key: xcode-spm-e2e-{{ .OS }}-{{ .Arch }}-{{ .Branch }}
         - paths: $BITRISE_XCODE_SOURCE_PACKAGES_PATH
     - script:
-        title: 'ACI-5253: drop the checkouts so the restore below has to repopulate them'
+        title: 'ACI-5253: drop the checkouts so the restore has to repopulate them'
         inputs:
         - content: |-
             set -exo pipefail
-            rm -rf "$BITRISE_XCODE_SOURCE_PACKAGES_PATH"
+            rm -rf "${BITRISE_XCODE_SOURCE_PACKAGES_PATH:?activate must export the SPM checkout dir}"
     - restore-cache:
-        title: 'ACI-5253: restore SPM checkouts round-trip'
+        title: 'ACI-5253: restore the SPM checkouts'
         inputs:
         - key: xcode-spm-e2e-{{ .OS }}-{{ .Arch }}-{{ .Branch }}
     - script:
-        title: 'ACI-5253: assert the round-trip repopulated the exported dir'
+        title: 'ACI-5253: rebuild and assert SPM downloaded nothing'
         inputs:
         - content: |-
-            set -exo pipefail
+            set -eo pipefail
 
-            # Proves the exported path is usable verbatim by the generic cache steps, and that
-            # restore replays the archive to the location the next build will actually read.
-            checkouts="$BITRISE_XCODE_SOURCE_PACKAGES_PATH/checkouts"
-            [[ -d "$checkouts" && -n "$(ls -A "$checkouts")" ]] \
-              || { echo "restore did not repopulate $checkouts"; exit 1; }
-            echo "Round-trip restored $(ls -A "$checkouts" | wc -l) package(s)"
+            xcodebuild build \
+              -workspace ComposableArchitecture.xcworkspace \
+              -scheme ComposableArchitecture \
+              -destination "generic/platform=iOS" \
+              -skipMacroValidation 2> wrapper-warm.log | tee xcodebuild-warm.log | xcpretty
+
+            cp wrapper-warm.log xcodebuild-warm.log "$BITRISE_DEPLOY_DIR"
+
+            # A "Fetching from" line means the cache steps archived a dir the build never reads.
+            if grep -n 'Fetching from' xcodebuild-warm.log; then
+              echo "SPM re-fetched packages despite the restored checkouts"
+              exit 1
+            fi
     - deploy-to-bitrise-io: {}
 
   e2e-xcode-cas-key-stable:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1327,13 +1327,14 @@ workflows:
         title: 'ACI-5253: save the SPM checkouts the build actually used'
         inputs:
         - key: xcode-spm-e2e-{{ .OS }}-{{ .Arch }}-{{ .Branch }}
-        - paths: $BITRISE_XCODE_SOURCE_PACKAGES_PATH
+        - paths: $BITRISE_XCODE_DERIVED_DATA_PATH/SourcePackages
     - script:
         title: 'ACI-5253: drop the checkouts so the restore has to repopulate them'
         inputs:
         - content: |-
             set -exo pipefail
-            rm -rf "${BITRISE_XCODE_SOURCE_PACKAGES_PATH:?activate must export the SPM checkout dir}"
+            # shellcheck disable=SC2086 # the exported value is a glob and must expand
+            rm -rf ${BITRISE_XCODE_DERIVED_DATA_PATH:?activate must export the DerivedData glob}/SourcePackages
     - restore-cache:
         title: 'ACI-5253: restore the SPM checkouts'
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1348,12 +1348,12 @@ workflows:
             spm_dir=$(echo "${BITRISE_XCODE_DERIVED_DATA_PATH:?}"/*/SourcePackages)
             [ -d "$spm_dir" ] || { echo "restore left no SourcePackages under $BITRISE_XCODE_DERIVED_DATA_PATH"; exit 1; }
 
-            # -resolvePackageDependencies is a query action, so the wrapper does not point it at the
-            # managed DerivedData for us.
+            # No -clonedSourcePackagesDirPath on purpose: the wrapper injects it for resolving query
+            # actions, so this also covers that injection. Without it the resolve would read the
+            # default DerivedData, find nothing and re-fetch.
             xcodebuild -resolvePackageDependencies \
               -workspace ComposableArchitecture.xcworkspace \
-              -scheme ComposableArchitecture \
-              -clonedSourcePackagesDirPath "$spm_dir" 2>&1 | tee "$BITRISE_DEPLOY_DIR/spm-resolve.log"
+              -scheme ComposableArchitecture 2>&1 | tee "$BITRISE_DEPLOY_DIR/spm-resolve.log"
 
             # A "Fetching from" line means the cache steps archived a dir the build never reads.
             if grep -n 'Fetching from' "$BITRISE_DEPLOY_DIR/spm-resolve.log"; then

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1327,14 +1327,13 @@ workflows:
         title: 'ACI-5253: save the SPM checkouts the build actually used'
         inputs:
         - key: xcode-spm-e2e-{{ .OS }}-{{ .Arch }}-{{ .Branch }}
-        - paths: $BITRISE_XCODE_DERIVED_DATA_PATH/SourcePackages
+        - paths: $BITRISE_XCODE_DERIVED_DATA_PATH/*/SourcePackages
     - script:
         title: 'ACI-5253: drop the checkouts so the restore has to repopulate them'
         inputs:
         - content: |-
             set -exo pipefail
-            # shellcheck disable=SC2086 # the exported value is a glob and must expand
-            rm -rf ${BITRISE_XCODE_DERIVED_DATA_PATH:?activate must export the DerivedData glob}/SourcePackages
+            rm -rf "${BITRISE_XCODE_DERIVED_DATA_PATH:?activate must export the DerivedData root}"/*/SourcePackages
     - restore-cache:
         title: 'ACI-5253: restore the SPM checkouts'
         inputs:

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -814,8 +814,7 @@ func (c *XcodebuildRunner) fillManagedPrefixMapPaths(projectDir string, dd, ptd,
 		*ptd = p.XcodeManagedProjectTempDir(sha)
 		sources.ProjectTempDir = prefixMapSourceManaged
 	}
-	// Only relocate SPM checkouts when we also relocated DerivedData: with a user-supplied
-	// -derivedDataPath the checkouts already sit somewhere the user controls and can cache.
+	// A user-supplied -derivedDataPath already puts the checkouts somewhere they control.
 	if *spm == "" && sources.DerivedDataPath == prefixMapSourceManaged {
 		*spm = p.XcodeManagedSwiftPackagesDir()
 		sources.SwiftPackagesDir = prefixMapSourceManaged

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -718,6 +718,10 @@ func (c *XcodebuildRunner) assembleArgs() []string {
 		if ps.DerivedDataPath != "" && c.XcodeArgs.DerivedDataPath() == "" {
 			extraArgv = append(extraArgv, xcodeargs.DerivedDataPathFlag, ps.DerivedDataPath)
 		}
+
+		if ps.SwiftPackagesDir != "" && c.XcodeArgs.ClonedSourcePackagesDirPath() == "" {
+			extraArgv = append(extraArgv, xcodeargs.ClonedSourcePackagesDirPathFlag, ps.SwiftPackagesDir)
+		}
 	}
 
 	toPass := c.XcodeArgs.Args(additional)
@@ -741,10 +745,11 @@ const (
 // prefixMapSources records where each path in PrefixMapPaths came from so the
 // wrapper can log an origin trail. Values: argv, managed, auto, or "".
 type prefixMapSources struct {
-	Home            string
-	ProjectDir      string
-	DerivedDataPath string
-	ProjectTempDir  string
+	Home             string
+	ProjectDir       string
+	DerivedDataPath  string
+	ProjectTempDir   string
+	SwiftPackagesDir string
 }
 
 // resolvePrefixMapPaths determines the four absolute paths that feed the
@@ -765,28 +770,33 @@ func (c *XcodebuildRunner) resolvePrefixMapPaths() (xcodeargs.PrefixMapPaths, pr
 
 	dd := c.XcodeArgs.DerivedDataPath()
 	ptd := c.XcodeArgs.ProjectTempDir()
+	spm := c.XcodeArgs.ClonedSourcePackagesDirPath()
 	if dd != "" {
 		sources.DerivedDataPath = prefixMapSourceArgv
 	}
 	if ptd != "" {
 		sources.ProjectTempDir = prefixMapSourceArgv
 	}
+	if spm != "" {
+		sources.SwiftPackagesDir = prefixMapSourceArgv
+	}
 
-	c.fillManagedPrefixMapPaths(projectDir, &dd, &ptd, &sources)
+	c.fillManagedPrefixMapPaths(projectDir, &dd, &ptd, &spm, &sources)
 
 	return xcodeargs.PrefixMapPaths{
-		Home:            home,
-		ProjectDir:      projectDir,
-		DerivedDataPath: dd,
-		ProjectTempDir:  ptd,
+		Home:             home,
+		ProjectDir:       projectDir,
+		DerivedDataPath:  dd,
+		ProjectTempDir:   ptd,
+		SwiftPackagesDir: spm,
 	}, sources
 }
 
-// fillManagedPrefixMapPaths populates dd/ptd with wrapper-owned paths under
-// ~/.bitrise/cache/xcode-{dd,ptd}/<sha> when the user did not supply them and
+// fillManagedPrefixMapPaths populates dd/ptd/spm with wrapper-owned paths under
+// ~/.bitrise/cache/xcode-{dd,ptd,spm} when the user did not supply them and
 // managed fallback is enabled. No-op when NoManagedDD, when projectDir is
 // unknown, or when paths.Default() cannot resolve $HOME.
-func (c *XcodebuildRunner) fillManagedPrefixMapPaths(projectDir string, dd, ptd *string, sources *prefixMapSources) {
+func (c *XcodebuildRunner) fillManagedPrefixMapPaths(projectDir string, dd, ptd, spm *string, sources *prefixMapSources) {
 	if c.NoManagedDD || projectDir == "" {
 		return
 	}
@@ -804,15 +814,22 @@ func (c *XcodebuildRunner) fillManagedPrefixMapPaths(projectDir string, dd, ptd 
 		*ptd = p.XcodeManagedProjectTempDir(sha)
 		sources.ProjectTempDir = prefixMapSourceManaged
 	}
+	// Only relocate SPM checkouts when we also relocated DerivedData: with a user-supplied
+	// -derivedDataPath the checkouts already sit somewhere the user controls and can cache.
+	if *spm == "" && sources.DerivedDataPath == prefixMapSourceManaged {
+		*spm = p.XcodeManagedSwiftPackagesDir()
+		sources.SwiftPackagesDir = prefixMapSourceManaged
+	}
 }
 
 func (c *XcodebuildRunner) logPrefixMapSources(ps xcodeargs.PrefixMapPaths, s prefixMapSources) {
 	c.Logger.Debugf("Prefix map: %s", fmt.Sprintf(
-		"home=%s (%s), projectDir=%s (%s), derivedDataPath=%s (%s), projectTempDir=%s (%s)",
+		"home=%s (%s), projectDir=%s (%s), derivedDataPath=%s (%s), projectTempDir=%s (%s), swiftPackagesDir=%s (%s)",
 		ps.Home, s.Home,
 		ps.ProjectDir, s.ProjectDir,
 		ps.DerivedDataPath, s.DerivedDataPath,
 		ps.ProjectTempDir, s.ProjectTempDir,
+		ps.SwiftPackagesDir, s.SwiftPackagesDir,
 	))
 }
 

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -733,13 +733,8 @@ func (c *XcodebuildRunner) assembleArgs() []string {
 	return append(toPass, extraArgv...)
 }
 
-// sourcePackagesArgvForQueryAction points a package-resolving query action at the SPM checkout dir
-// the build itself uses. Without it `xcodebuild -list` and `-resolvePackageDependencies` fetch a
-// second copy of every package into the default DerivedData, which no build ever reads.
-//
-// This injects xcodebuild's own default location relative to the DerivedData in play, so no new
-// path reaches a compile command and compilation cache keys are untouched. -derivedDataPath is not
-// an option here: xcodebuild rejects it on these actions unless -scheme is also present.
+// sourcePackagesArgvForQueryAction points a resolving query action at the checkout dir the build
+// uses. The value is xcodebuild's own default there, so no new path reaches a compile command.
 func (c *XcodebuildRunner) sourcePackagesArgvForQueryAction() []string {
 	if !c.XcodeArgs.ResolvesPackages() || c.XcodeArgs.ClonedSourcePackagesDirPath() != "" {
 		return nil

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -718,10 +718,6 @@ func (c *XcodebuildRunner) assembleArgs() []string {
 		if ps.DerivedDataPath != "" && c.XcodeArgs.DerivedDataPath() == "" {
 			extraArgv = append(extraArgv, xcodeargs.DerivedDataPathFlag, ps.DerivedDataPath)
 		}
-
-		if ps.SwiftPackagesDir != "" && c.XcodeArgs.ClonedSourcePackagesDirPath() == "" {
-			extraArgv = append(extraArgv, xcodeargs.ClonedSourcePackagesDirPathFlag, ps.SwiftPackagesDir)
-		}
 	}
 
 	toPass := c.XcodeArgs.Args(additional)
@@ -745,11 +741,10 @@ const (
 // prefixMapSources records where each path in PrefixMapPaths came from so the
 // wrapper can log an origin trail. Values: argv, managed, auto, or "".
 type prefixMapSources struct {
-	Home             string
-	ProjectDir       string
-	DerivedDataPath  string
-	ProjectTempDir   string
-	SwiftPackagesDir string
+	Home            string
+	ProjectDir      string
+	DerivedDataPath string
+	ProjectTempDir  string
 }
 
 // resolvePrefixMapPaths determines the four absolute paths that feed the
@@ -770,33 +765,28 @@ func (c *XcodebuildRunner) resolvePrefixMapPaths() (xcodeargs.PrefixMapPaths, pr
 
 	dd := c.XcodeArgs.DerivedDataPath()
 	ptd := c.XcodeArgs.ProjectTempDir()
-	spm := c.XcodeArgs.ClonedSourcePackagesDirPath()
 	if dd != "" {
 		sources.DerivedDataPath = prefixMapSourceArgv
 	}
 	if ptd != "" {
 		sources.ProjectTempDir = prefixMapSourceArgv
 	}
-	if spm != "" {
-		sources.SwiftPackagesDir = prefixMapSourceArgv
-	}
 
-	c.fillManagedPrefixMapPaths(projectDir, &dd, &ptd, &spm, &sources)
+	c.fillManagedPrefixMapPaths(projectDir, &dd, &ptd, &sources)
 
 	return xcodeargs.PrefixMapPaths{
-		Home:             home,
-		ProjectDir:       projectDir,
-		DerivedDataPath:  dd,
-		ProjectTempDir:   ptd,
-		SwiftPackagesDir: spm,
+		Home:            home,
+		ProjectDir:      projectDir,
+		DerivedDataPath: dd,
+		ProjectTempDir:  ptd,
 	}, sources
 }
 
-// fillManagedPrefixMapPaths populates dd/ptd/spm with wrapper-owned paths under
-// ~/.bitrise/cache/xcode-{dd,ptd,spm} when the user did not supply them and
+// fillManagedPrefixMapPaths populates dd/ptd with wrapper-owned paths under
+// ~/.bitrise/cache/xcode-{dd,ptd}/<sha> when the user did not supply them and
 // managed fallback is enabled. No-op when NoManagedDD, when projectDir is
 // unknown, or when paths.Default() cannot resolve $HOME.
-func (c *XcodebuildRunner) fillManagedPrefixMapPaths(projectDir string, dd, ptd, spm *string, sources *prefixMapSources) {
+func (c *XcodebuildRunner) fillManagedPrefixMapPaths(projectDir string, dd, ptd *string, sources *prefixMapSources) {
 	if c.NoManagedDD || projectDir == "" {
 		return
 	}
@@ -814,21 +804,15 @@ func (c *XcodebuildRunner) fillManagedPrefixMapPaths(projectDir string, dd, ptd,
 		*ptd = p.XcodeManagedProjectTempDir(sha)
 		sources.ProjectTempDir = prefixMapSourceManaged
 	}
-	// A user-supplied -derivedDataPath already puts the checkouts somewhere they control.
-	if *spm == "" && sources.DerivedDataPath == prefixMapSourceManaged {
-		*spm = p.XcodeManagedSwiftPackagesDir(sha)
-		sources.SwiftPackagesDir = prefixMapSourceManaged
-	}
 }
 
 func (c *XcodebuildRunner) logPrefixMapSources(ps xcodeargs.PrefixMapPaths, s prefixMapSources) {
 	c.Logger.Debugf("Prefix map: %s", fmt.Sprintf(
-		"home=%s (%s), projectDir=%s (%s), derivedDataPath=%s (%s), projectTempDir=%s (%s), swiftPackagesDir=%s (%s)",
+		"home=%s (%s), projectDir=%s (%s), derivedDataPath=%s (%s), projectTempDir=%s (%s)",
 		ps.Home, s.Home,
 		ps.ProjectDir, s.ProjectDir,
 		ps.DerivedDataPath, s.DerivedDataPath,
 		ps.ProjectTempDir, s.ProjectTempDir,
-		ps.SwiftPackagesDir, s.SwiftPackagesDir,
 	))
 }
 

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"maps"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"syscall"
@@ -681,7 +682,7 @@ func (c *XcodebuildRunner) assembleArgs() []string {
 
 	// Query-only invocations (-list, -version, -showBuildSettings on its own, ...) reject -derivedDataPath and don't need cache wiring. Primary short-circuit is in Run() after assembleArgs returns; this branch is defensive.
 	if !c.XcodeArgs.HasBuildAction() {
-		return c.XcodeArgs.Args(additional)
+		return append(c.XcodeArgs.Args(additional), c.sourcePackagesArgvForQueryAction()...)
 	}
 
 	additional["COMPILATION_CACHE_REMOTE_SERVICE_PATH"] = c.Config.ProxySocketPath
@@ -730,6 +731,37 @@ func (c *XcodebuildRunner) assembleArgs() []string {
 	}
 
 	return append(toPass, extraArgv...)
+}
+
+// sourcePackagesArgvForQueryAction points a package-resolving query action at the SPM checkout dir
+// the build itself uses. Without it `xcodebuild -list` and `-resolvePackageDependencies` fetch a
+// second copy of every package into the default DerivedData, which no build ever reads.
+//
+// This injects xcodebuild's own default location relative to the DerivedData in play, so no new
+// path reaches a compile command and compilation cache keys are untouched. -derivedDataPath is not
+// an option here: xcodebuild rejects it on these actions unless -scheme is also present.
+func (c *XcodebuildRunner) sourcePackagesArgvForQueryAction() []string {
+	if !c.XcodeArgs.ResolvesPackages() || c.XcodeArgs.ClonedSourcePackagesDirPath() != "" {
+		return nil
+	}
+	if c.Config.BuildCacheSkipFlags || c.Config.DisablePrefixMapping || c.NoPrefixMap {
+		return nil
+	}
+
+	dd := c.XcodeArgs.DerivedDataPath()
+	if dd == "" {
+		projectDir := c.XcodeArgs.ProjectDir()
+		if c.NoManagedDD || projectDir == "" {
+			return nil
+		}
+		p := c.resolvePaths()
+		if p.Home == "" {
+			return nil
+		}
+		dd = p.XcodeManagedDerivedDataDir(workspaceSHA(projectDir))
+	}
+
+	return []string{xcodeargs.ClonedSourcePackagesDirPathFlag, filepath.Join(dd, "SourcePackages")}
 }
 
 const (

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -816,7 +816,7 @@ func (c *XcodebuildRunner) fillManagedPrefixMapPaths(projectDir string, dd, ptd,
 	}
 	// A user-supplied -derivedDataPath already puts the checkouts somewhere they control.
 	if *spm == "" && sources.DerivedDataPath == prefixMapSourceManaged {
-		*spm = p.XcodeManagedSwiftPackagesDir()
+		*spm = p.XcodeManagedSwiftPackagesDir(sha)
 		sources.SwiftPackagesDir = prefixMapSourceManaged
 	}
 }

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -680,7 +680,9 @@ func (c *XcodebuildRunner) assembleArgs() []string {
 		return c.XcodeArgs.Args(additional)
 	}
 
-	// Query-only invocations (-list, -version, -showBuildSettings on its own, ...) reject -derivedDataPath and don't need cache wiring. Primary short-circuit is in Run() after assembleArgs returns; this branch is defensive.
+	// Query-only invocations (-list, -version, -showBuildSettings, ...) reject -derivedDataPath and
+	// need no cache wiring, but they still take their argv from here. Run's short-circuit is separate:
+	// it skips session and analytics, not argument assembly.
 	if !c.XcodeArgs.HasBuildAction() {
 		return append(c.XcodeArgs.Args(additional), c.sourcePackagesArgvForQueryAction()...)
 	}

--- a/cmd/xcode/xcodebuild_test.go
+++ b/cmd/xcode/xcodebuild_test.go
@@ -321,6 +321,63 @@ func Test_assembleArgs_prefixMapInjection(t *testing.T) {
 		assert.Contains(t, other, "-fdepscan-prefix-map=/work/app=/^src")
 		assert.Contains(t, other, "/^dd")
 		assert.Contains(t, other, "/^obj")
+
+		// SPM checkouts follow the relocated DerivedData, so they get a stable managed dir too.
+		require.Contains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
+		spmIdx := indexOf(captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
+		require.Less(t, spmIdx+1, len(captured))
+		assert.Equal(t, "/h/.bitrise/cache/xcode-spm", captured[spmIdx+1],
+			"SPM dir must not be workspace-sha scoped")
+		assert.Contains(t, other, "-fdepscan-prefix-map=/h/.bitrise/cache/xcode-spm=/^spm")
+	})
+
+	t.Run("respects user-supplied clonedSourcePackagesDirPath (no injection)", func(t *testing.T) {
+		argsMock := &xcodeargsMocks.XcodeArgsMock{
+			HasBuildActionFunc:              func() bool { return true },
+			ArgsFunc:                        func(_ map[string]string) []string { return []string{"xcodebuild"} },
+			ProjectDirFunc:                  func() string { return "/work/app" },
+			DerivedDataPathFunc:             func() string { return "" },
+			ProjectTempDirFunc:              func() string { return "" },
+			ClonedSourcePackagesDirPathFunc: func() string { return "/user/spm" },
+			UserOtherCFlagsFunc:             func() string { return "" },
+			CommandFunc:                     func() string { return "xcodebuild" },
+			ShortCommandFunc:                func() string { return "xcodebuild" },
+		}
+		var captured []string
+		r := newRunnerWithArgs(xcelerate.Config{
+			BuildCacheEnabled: true,
+			ProxySocketPath:   "/tmp/proxy.sock",
+		}, argsMock, &captured)
+
+		_ = r.Run(context.Background())
+
+		assert.NotContains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag,
+			"user's -clonedSourcePackagesDirPath must be left alone")
+		other := findBuildSetting(captured, xcodeargs.OtherCFlagsKey)
+		assert.Contains(t, other, "-fdepscan-prefix-map=/user/spm=/^spm")
+	})
+
+	t.Run("does not relocate SPM when user supplies DerivedDataPath", func(t *testing.T) {
+		argsMock := &xcodeargsMocks.XcodeArgsMock{
+			HasBuildActionFunc:  func() bool { return true },
+			ArgsFunc:            func(_ map[string]string) []string { return []string{"xcodebuild"} },
+			ProjectDirFunc:      func() string { return "/work/app" },
+			DerivedDataPathFunc: func() string { return "/user/dd" },
+			ProjectTempDirFunc:  func() string { return "" },
+			UserOtherCFlagsFunc: func() string { return "" },
+			CommandFunc:         func() string { return "xcodebuild" },
+			ShortCommandFunc:    func() string { return "xcodebuild" },
+		}
+		var captured []string
+		r := newRunnerWithArgs(xcelerate.Config{
+			BuildCacheEnabled: true,
+			ProxySocketPath:   "/tmp/proxy.sock",
+		}, argsMock, &captured)
+
+		_ = r.Run(context.Background())
+
+		assert.NotContains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag,
+			"SPM checkouts already sit under the user's DerivedData")
 	})
 
 	t.Run("respects user-supplied DerivedDataPath (no injection)", func(t *testing.T) {

--- a/cmd/xcode/xcodebuild_test.go
+++ b/cmd/xcode/xcodebuild_test.go
@@ -4,6 +4,7 @@ package xcode_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -500,4 +501,84 @@ func Test_xcodebuildCmdFn_callsEndSessionAfterRun(t *testing.T) {
 	gotMs := calls[0].In.GetEndTimeUnixMs()
 	assert.GreaterOrEqual(t, gotMs, beforeMs, "EndTimeUnixMs must be captured at or after the wrapper started EndSession")
 	assert.LessOrEqual(t, gotMs, afterMs, "EndTimeUnixMs must be captured at or before the wrapper returned")
+}
+
+func Test_queryActionSourcePackages(t *testing.T) {
+	newRunner := func(argsMock *xcodeargsMocks.XcodeArgsMock, capturedArgs *[]string) *xcode.XcodebuildRunner {
+		return &xcode.XcodebuildRunner{
+			Config:       xcelerate.Config{BuildCacheEnabled: true, ProxySocketPath: "/tmp/p.sock"},
+			Metadata:     common.CacheConfigMetadata{},
+			InvocationID: uuid.NewString(),
+			Logger:       mockLogger,
+			CacheLogger:  mockLogger,
+			XcodeRunner: &mocks.XcodeRunnerMock{
+				RunFunc: func(_ context.Context, args []string) xcodeargs.RunStats {
+					*capturedArgs = append([]string(nil), args...)
+
+					return xcodeargs.RunStats{}
+				},
+			},
+			ProxySessionClient: &mocks.SessionClientMock{},
+			XcodeArgs:          argsMock,
+			Paths:              paths.FromHome("/h"),
+		}
+	}
+
+	newArgs := func(resolves bool, userSPM, userDD string) *xcodeargsMocks.XcodeArgsMock {
+		return &xcodeargsMocks.XcodeArgsMock{
+			HasBuildActionFunc:              func() bool { return false },
+			ResolvesPackagesFunc:            func() bool { return resolves },
+			ClonedSourcePackagesDirPathFunc: func() string { return userSPM },
+			DerivedDataPathFunc:             func() string { return userDD },
+			ProjectDirFunc:                  func() string { return "/work/app" },
+			ProjectTempDirFunc:              func() string { return "" },
+			UserOtherCFlagsFunc:             func() string { return "" },
+			ArgsFunc:                        func(_ map[string]string) []string { return []string{"xcodebuild"} },
+			CommandFunc:                     func() string { return "xcodebuild" },
+			ShortCommandFunc:                func() string { return "xcodebuild" },
+		}
+	}
+
+	t.Run("points a resolving query action at the managed checkout dir", func(t *testing.T) {
+		var captured []string
+		r := newRunner(newArgs(true, "", ""), &captured)
+
+		_ = r.Run(context.Background())
+
+		require.Contains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
+		idx := indexOf(captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
+		require.Less(t, idx+1, len(captured))
+		// xcodebuild's own default relative to the managed DerivedData, so no new path is introduced.
+		assert.Contains(t, captured[idx+1], "/h/.bitrise/cache/xcode-dd/")
+		assert.True(t, strings.HasSuffix(captured[idx+1], "/SourcePackages"), captured[idx+1])
+	})
+
+	t.Run("follows a user-supplied derivedDataPath", func(t *testing.T) {
+		var captured []string
+		r := newRunner(newArgs(true, "", "/user/dd"), &captured)
+
+		_ = r.Run(context.Background())
+
+		idx := indexOf(captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
+		require.GreaterOrEqual(t, idx, 0)
+		assert.Equal(t, "/user/dd/SourcePackages", captured[idx+1])
+	})
+
+	t.Run("leaves a user-supplied clonedSourcePackagesDirPath alone", func(t *testing.T) {
+		var captured []string
+		r := newRunner(newArgs(true, "/user/spm", ""), &captured)
+
+		_ = r.Run(context.Background())
+
+		assert.NotContains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
+	})
+
+	t.Run("no-op for query actions that do not resolve packages", func(t *testing.T) {
+		var captured []string
+		r := newRunner(newArgs(false, "", ""), &captured)
+
+		_ = r.Run(context.Background())
+
+		assert.NotContains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
+	})
 }

--- a/cmd/xcode/xcodebuild_test.go
+++ b/cmd/xcode/xcodebuild_test.go
@@ -326,9 +326,9 @@ func Test_assembleArgs_prefixMapInjection(t *testing.T) {
 		require.Contains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
 		spmIdx := indexOf(captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
 		require.Less(t, spmIdx+1, len(captured))
-		assert.Equal(t, "/h/.bitrise/cache/xcode-spm", captured[spmIdx+1],
-			"SPM dir must not be workspace-sha scoped")
-		assert.Contains(t, other, "-fdepscan-prefix-map=/h/.bitrise/cache/xcode-spm=/^spm")
+		assert.Contains(t, captured[spmIdx+1], "/h/.bitrise/cache/xcode-spm/")
+		// The sha is absorbed by the mapping, so two checkouts of one repo share a virtual path.
+		assert.Contains(t, other, "="+captured[spmIdx+1]+"=/^spm")
 	})
 
 	t.Run("respects user-supplied clonedSourcePackagesDirPath (no injection)", func(t *testing.T) {

--- a/cmd/xcode/xcodebuild_test.go
+++ b/cmd/xcode/xcodebuild_test.go
@@ -321,63 +321,6 @@ func Test_assembleArgs_prefixMapInjection(t *testing.T) {
 		assert.Contains(t, other, "-fdepscan-prefix-map=/work/app=/^src")
 		assert.Contains(t, other, "/^dd")
 		assert.Contains(t, other, "/^obj")
-
-		// SPM checkouts follow the relocated DerivedData, so they get a stable managed dir too.
-		require.Contains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
-		spmIdx := indexOf(captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
-		require.Less(t, spmIdx+1, len(captured))
-		assert.Contains(t, captured[spmIdx+1], "/h/.bitrise/cache/xcode-spm/")
-		// The sha is absorbed by the mapping, so two checkouts of one repo share a virtual path.
-		assert.Contains(t, other, "="+captured[spmIdx+1]+"=/^spm")
-	})
-
-	t.Run("respects user-supplied clonedSourcePackagesDirPath (no injection)", func(t *testing.T) {
-		argsMock := &xcodeargsMocks.XcodeArgsMock{
-			HasBuildActionFunc:              func() bool { return true },
-			ArgsFunc:                        func(_ map[string]string) []string { return []string{"xcodebuild"} },
-			ProjectDirFunc:                  func() string { return "/work/app" },
-			DerivedDataPathFunc:             func() string { return "" },
-			ProjectTempDirFunc:              func() string { return "" },
-			ClonedSourcePackagesDirPathFunc: func() string { return "/user/spm" },
-			UserOtherCFlagsFunc:             func() string { return "" },
-			CommandFunc:                     func() string { return "xcodebuild" },
-			ShortCommandFunc:                func() string { return "xcodebuild" },
-		}
-		var captured []string
-		r := newRunnerWithArgs(xcelerate.Config{
-			BuildCacheEnabled: true,
-			ProxySocketPath:   "/tmp/proxy.sock",
-		}, argsMock, &captured)
-
-		_ = r.Run(context.Background())
-
-		assert.NotContains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag,
-			"user's -clonedSourcePackagesDirPath must be left alone")
-		other := findBuildSetting(captured, xcodeargs.OtherCFlagsKey)
-		assert.Contains(t, other, "-fdepscan-prefix-map=/user/spm=/^spm")
-	})
-
-	t.Run("does not relocate SPM when user supplies DerivedDataPath", func(t *testing.T) {
-		argsMock := &xcodeargsMocks.XcodeArgsMock{
-			HasBuildActionFunc:  func() bool { return true },
-			ArgsFunc:            func(_ map[string]string) []string { return []string{"xcodebuild"} },
-			ProjectDirFunc:      func() string { return "/work/app" },
-			DerivedDataPathFunc: func() string { return "/user/dd" },
-			ProjectTempDirFunc:  func() string { return "" },
-			UserOtherCFlagsFunc: func() string { return "" },
-			CommandFunc:         func() string { return "xcodebuild" },
-			ShortCommandFunc:    func() string { return "xcodebuild" },
-		}
-		var captured []string
-		r := newRunnerWithArgs(xcelerate.Config{
-			BuildCacheEnabled: true,
-			ProxySocketPath:   "/tmp/proxy.sock",
-		}, argsMock, &captured)
-
-		_ = r.Run(context.Background())
-
-		assert.NotContains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag,
-			"SPM checkouts already sit under the user's DerivedData")
 	})
 
 	t.Run("respects user-supplied DerivedDataPath (no injection)", func(t *testing.T) {

--- a/cmd/xcode/xcodebuild_test.go
+++ b/cmd/xcode/xcodebuild_test.go
@@ -573,6 +573,28 @@ func Test_queryActionSourcePackages(t *testing.T) {
 		assert.NotContains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
 	})
 
+	t.Run("stays a query invocation: no session, no analytics, no cache settings", func(t *testing.T) {
+		var captured []string
+		var receivedAdditional map[string]string
+		argsMock := newArgs(true, "", "")
+		argsMock.ArgsFunc = func(additional map[string]string) []string {
+			receivedAdditional = additional
+
+			return []string{"xcodebuild"}
+		}
+		sessionMock := &mocks.SessionClientMock{}
+		r := newRunner(argsMock, &captured)
+		r.ProxySessionClient = sessionMock
+
+		_ = r.Run(context.Background())
+
+		// Injecting the checkout dir must not promote a query action into a reported build.
+		assert.Empty(t, sessionMock.SetSessionCalls(), "query invocations must not open a proxy session")
+		assert.Empty(t, sessionMock.EndSessionCalls(), "query invocations must not end a proxy session")
+		assert.Empty(t, receivedAdditional, "query invocations must get no cache build settings")
+		assert.NotContains(t, captured, "COMPILATION_CACHE_REMOTE_SERVICE_PATH")
+	})
+
 	t.Run("no-op for query actions that do not resolve packages", func(t *testing.T) {
 		var captured []string
 		r := newRunner(newArgs(false, "", ""), &captured)

--- a/cmd/xcode/xcodebuild_test.go
+++ b/cmd/xcode/xcodebuild_test.go
@@ -548,7 +548,6 @@ func Test_queryActionSourcePackages(t *testing.T) {
 		require.Contains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
 		idx := indexOf(captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
 		require.Less(t, idx+1, len(captured))
-		// xcodebuild's own default relative to the managed DerivedData, so no new path is introduced.
 		assert.Contains(t, captured[idx+1], "/h/.bitrise/cache/xcode-dd/")
 		assert.True(t, strings.HasSuffix(captured[idx+1], "/SourcePackages"), captured[idx+1])
 	})
@@ -588,7 +587,6 @@ func Test_queryActionSourcePackages(t *testing.T) {
 
 		_ = r.Run(context.Background())
 
-		// Injecting the checkout dir must not promote a query action into a reported build.
 		assert.Empty(t, sessionMock.SetSessionCalls(), "query invocations must not open a proxy session")
 		assert.Empty(t, sessionMock.EndSessionCalls(), "query invocations must not end a proxy session")
 		assert.Empty(t, receivedAdditional, "query invocations must get no cache build settings")

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -114,10 +114,8 @@ func Activate(
 	return nil
 }
 
-// exportSwiftPackagesPath publishes the SPM checkout dir the xcodebuild wrapper will pass as
-// -clonedSourcePackagesDirPath, so cache steps can target it. Without this the wrapper's
-// DerivedData relocation silently moves SPM checkouts out of whatever path a cache step was
-// configured with, and every build re-resolves its packages from origin.
+// exportSwiftPackagesPath publishes the SPM checkout dir the wrapper relocates to, so cache steps
+// have something to target instead of the default DerivedData path the build no longer uses.
 func exportSwiftPackagesPath(logger log.Logger, config Config, envs map[string]string) {
 	if !config.BuildCacheEnabled || config.BuildCacheSkipFlags || config.DisablePrefixMapping {
 		return

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -115,7 +115,7 @@ func Activate(
 }
 
 // exportDerivedDataPath publishes where the wrapper relocates DerivedData to, so cache steps can
-// target the SPM checkouts under it instead of the default location the build no longer uses.
+// target the SPM checkouts under it.
 func exportDerivedDataPath(logger log.Logger, config Config, envs map[string]string) {
 	if !config.BuildCacheEnabled || config.BuildCacheSkipFlags || config.DisablePrefixMapping {
 		return

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -106,7 +106,7 @@ func Activate(
 		return fmt.Errorf("failed to add xcelerate command: %w", err)
 	}
 
-	exportSwiftPackagesPath(logger, config, envs) //nolint:contextcheck // envman export inside is fire-and-forget, matching the wrapper-script export above
+	exportDerivedDataPath(logger, config, envs) //nolint:contextcheck // envman export inside is fire-and-forget, matching the wrapper-script export above
 
 	logger.TInfof(ActivateXcodeSuccessful)
 	logger.TInfof(AddXcelerateToPath)
@@ -114,21 +114,23 @@ func Activate(
 	return nil
 }
 
-// exportSwiftPackagesPath publishes the SPM checkout dir the wrapper relocates to, so cache steps
-// have something to target instead of the default DerivedData path the build no longer uses.
-func exportSwiftPackagesPath(logger log.Logger, config Config, envs map[string]string) {
+// exportDerivedDataPath publishes where the wrapper relocates DerivedData to, so cache steps can
+// target the SPM checkouts under it instead of the default location the build no longer uses.
+// Exported as a glob because the per-workspace sha is only known once the wrapper sees the
+// xcodebuild args, and it matches the shape the cache steps' own defaults already use.
+func exportDerivedDataPath(logger log.Logger, config Config, envs map[string]string) {
 	if !config.BuildCacheEnabled || config.BuildCacheSkipFlags || config.DisablePrefixMapping {
 		return
 	}
 
 	p, err := paths.Default()
 	if err != nil {
-		logger.Debugf("Skipping %s export: %v", EnvSwiftPackagesPath, err)
+		logger.Debugf("Skipping %s export: %v", EnvDerivedDataPath, err)
 
 		return
 	}
 
-	envexport.New(envs, logger).Export(EnvSwiftPackagesPath, p.XcodeManagedSwiftPackagesRoot())
+	envexport.New(envs, logger).Export(EnvDerivedDataPath, filepath.Join(p.XcodeManagedDerivedDataRoot(), "**"))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -128,7 +128,7 @@ func exportSwiftPackagesPath(logger log.Logger, config Config, envs map[string]s
 		return
 	}
 
-	envexport.New(envs, logger).Export(EnvSwiftPackagesPath, p.XcodeManagedSwiftPackagesDir())
+	envexport.New(envs, logger).Export(EnvSwiftPackagesPath, p.XcodeManagedSwiftPackagesRoot())
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -116,8 +116,6 @@ func Activate(
 
 // exportDerivedDataPath publishes where the wrapper relocates DerivedData to, so cache steps can
 // target the SPM checkouts under it instead of the default location the build no longer uses.
-// Exported as a glob because the per-workspace sha is only known once the wrapper sees the
-// xcodebuild args, and it matches the shape the cache steps' own defaults already use.
 func exportDerivedDataPath(logger log.Logger, config Config, envs map[string]string) {
 	if !config.BuildCacheEnabled || config.BuildCacheSkipFlags || config.DisablePrefixMapping {
 		return
@@ -130,7 +128,7 @@ func exportDerivedDataPath(logger log.Logger, config Config, envs map[string]str
 		return
 	}
 
-	envexport.New(envs, logger).Export(EnvDerivedDataPath, filepath.Join(p.XcodeManagedDerivedDataRoot(), "**"))
+	envexport.New(envs, logger).Export(EnvDerivedDataPath, p.XcodeManagedDerivedDataRoot())
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/config/xcelerate/activate.go
+++ b/internal/config/xcelerate/activate.go
@@ -18,6 +18,7 @@ import (
 	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/consts"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/envexport"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
@@ -105,10 +106,31 @@ func Activate(
 		return fmt.Errorf("failed to add xcelerate command: %w", err)
 	}
 
+	exportSwiftPackagesPath(logger, config, envs) //nolint:contextcheck // envman export inside is fire-and-forget, matching the wrapper-script export above
+
 	logger.TInfof(ActivateXcodeSuccessful)
 	logger.TInfof(AddXcelerateToPath)
 
 	return nil
+}
+
+// exportSwiftPackagesPath publishes the SPM checkout dir the xcodebuild wrapper will pass as
+// -clonedSourcePackagesDirPath, so cache steps can target it. Without this the wrapper's
+// DerivedData relocation silently moves SPM checkouts out of whatever path a cache step was
+// configured with, and every build re-resolves its packages from origin.
+func exportSwiftPackagesPath(logger log.Logger, config Config, envs map[string]string) {
+	if !config.BuildCacheEnabled || config.BuildCacheSkipFlags || config.DisablePrefixMapping {
+		return
+	}
+
+	p, err := paths.Default()
+	if err != nil {
+		logger.Debugf("Skipping %s export: %v", EnvSwiftPackagesPath, err)
+
+		return
+	}
+
+	envexport.New(envs, logger).Export(EnvSwiftPackagesPath, p.XcodeManagedSwiftPackagesDir())
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/config/xcelerate/paths.go
+++ b/internal/config/xcelerate/paths.go
@@ -44,9 +44,8 @@ func ConfigFile(osProxy utils.OsProxy) string {
 // EnvProxySocketPath overrides the default xcelerate proxy socket location when set.
 const EnvProxySocketPath = "BITRISE_XCELERATE_PROXY_SOCKET_PATH"
 
-// EnvDerivedDataPath is exported by `activate xcode` with the root the wrapper relocates
-// DerivedData under. Builds live at <root>/<workspace-sha>, so consumers glob for the workspaces
-// they want. Advisory only — the wrapper computes its own paths rather than reading this back.
+// EnvDerivedDataPath is exported by `activate xcode`; builds live at <root>/<workspace-sha>.
+// Advisory only — the wrapper computes its own paths rather than reading it back.
 const EnvDerivedDataPath = "BITRISE_XCODE_DERIVED_DATA_PATH"
 
 // EnvInactivityTimeout overrides the xcelerate proxy inactivity window that

--- a/internal/config/xcelerate/paths.go
+++ b/internal/config/xcelerate/paths.go
@@ -44,9 +44,8 @@ func ConfigFile(osProxy utils.OsProxy) string {
 // EnvProxySocketPath overrides the default xcelerate proxy socket location when set.
 const EnvProxySocketPath = "BITRISE_XCELERATE_PROXY_SOCKET_PATH"
 
-// EnvSwiftPackagesPath is exported by `activate xcode` with the SPM checkout dir the xcodebuild
-// wrapper passes as -clonedSourcePackagesDirPath. Read-only signal for cache steps; the wrapper
-// does not consult it.
+// EnvSwiftPackagesPath is exported by `activate xcode` for cache steps to target. Advisory only —
+// the wrapper computes the path itself rather than reading this back.
 const EnvSwiftPackagesPath = "BITRISE_XCODE_SOURCE_PACKAGES_PATH"
 
 // EnvInactivityTimeout overrides the xcelerate proxy inactivity window that

--- a/internal/config/xcelerate/paths.go
+++ b/internal/config/xcelerate/paths.go
@@ -44,9 +44,10 @@ func ConfigFile(osProxy utils.OsProxy) string {
 // EnvProxySocketPath overrides the default xcelerate proxy socket location when set.
 const EnvProxySocketPath = "BITRISE_XCELERATE_PROXY_SOCKET_PATH"
 
-// EnvSwiftPackagesPath is exported by `activate xcode` for cache steps to target. Advisory only —
-// the wrapper computes the path itself rather than reading this back.
-const EnvSwiftPackagesPath = "BITRISE_XCODE_SOURCE_PACKAGES_PATH"
+// EnvDerivedDataPath is exported by `activate xcode` with a glob over the DerivedData dirs the
+// wrapper relocates builds to, so cache steps can reach the SPM checkouts under them. Advisory
+// only — the wrapper computes its own paths rather than reading this back.
+const EnvDerivedDataPath = "BITRISE_XCODE_DERIVED_DATA_PATH"
 
 // EnvInactivityTimeout overrides the xcelerate proxy inactivity window that
 // triggers a slim invocation emit. Value is a time.ParseDuration string.

--- a/internal/config/xcelerate/paths.go
+++ b/internal/config/xcelerate/paths.go
@@ -44,6 +44,11 @@ func ConfigFile(osProxy utils.OsProxy) string {
 // EnvProxySocketPath overrides the default xcelerate proxy socket location when set.
 const EnvProxySocketPath = "BITRISE_XCELERATE_PROXY_SOCKET_PATH"
 
+// EnvSwiftPackagesPath is exported by `activate xcode` with the SPM checkout dir the xcodebuild
+// wrapper passes as -clonedSourcePackagesDirPath. Read-only signal for cache steps; the wrapper
+// does not consult it.
+const EnvSwiftPackagesPath = "BITRISE_XCODE_SOURCE_PACKAGES_PATH"
+
 // EnvInactivityTimeout overrides the xcelerate proxy inactivity window that
 // triggers a slim invocation emit. Value is a time.ParseDuration string.
 // Test-only knob: sole caller is the e2e-xcode-wrapper-watcher-race workflow, which

--- a/internal/config/xcelerate/paths.go
+++ b/internal/config/xcelerate/paths.go
@@ -44,9 +44,9 @@ func ConfigFile(osProxy utils.OsProxy) string {
 // EnvProxySocketPath overrides the default xcelerate proxy socket location when set.
 const EnvProxySocketPath = "BITRISE_XCELERATE_PROXY_SOCKET_PATH"
 
-// EnvDerivedDataPath is exported by `activate xcode` with a glob over the DerivedData dirs the
-// wrapper relocates builds to, so cache steps can reach the SPM checkouts under them. Advisory
-// only — the wrapper computes its own paths rather than reading this back.
+// EnvDerivedDataPath is exported by `activate xcode` with the root the wrapper relocates
+// DerivedData under. Builds live at <root>/<workspace-sha>, so consumers glob for the workspaces
+// they want. Advisory only — the wrapper computes its own paths rather than reading this back.
 const EnvDerivedDataPath = "BITRISE_XCODE_DERIVED_DATA_PATH"
 
 // EnvInactivityTimeout overrides the xcelerate proxy inactivity window that

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -86,9 +86,8 @@ const (
 	// xcodeManagedProjectTempDirTool is the per-workspace PROJECT_TEMP_DIR root managed by the wrapper.
 	xcodeManagedProjectTempDirTool = "xcode-ptd"
 
-	// xcodeManagedSwiftPackagesTool is the SPM checkout root managed by the wrapper. Deliberately
-	// not per-workspace: SPM checkouts are keyed by Package.resolved, not by workspace, so a shared
-	// root survives workspace-sha changes and can be cached under one stable path.
+	// xcodeManagedSwiftPackagesTool is the SPM checkout root managed by the wrapper. Not
+	// workspace-scoped: SPM keys checkouts by Package.resolved, so one root stays cacheable.
 	xcodeManagedSwiftPackagesTool = "xcode-spm"
 
 	// gradleInitScriptRelative is the per-user gradle init script written by `activate gradle`.
@@ -292,8 +291,7 @@ func (p Paths) XcodeManagedProjectTempDir(workspaceSHA string) string {
 }
 
 // XcodeManagedSwiftPackagesDir returns the wrapper-owned SPM checkout dir passed to xcodebuild as
-// -clonedSourcePackagesDirPath. Unlike the DerivedData and PROJECT_TEMP_DIR roots this is not
-// workspace-sha scoped, so it stays valid across branches and is exported for cache steps to use.
+// -clonedSourcePackagesDirPath.
 func (p Paths) XcodeManagedSwiftPackagesDir() string {
 	return p.BitriseCacheDir(xcodeManagedSwiftPackagesTool)
 }

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -86,6 +86,11 @@ const (
 	// xcodeManagedProjectTempDirTool is the per-workspace PROJECT_TEMP_DIR root managed by the wrapper.
 	xcodeManagedProjectTempDirTool = "xcode-ptd"
 
+	// xcodeManagedSwiftPackagesTool is the SPM checkout root managed by the wrapper. Deliberately
+	// not per-workspace: SPM checkouts are keyed by Package.resolved, not by workspace, so a shared
+	// root survives workspace-sha changes and can be cached under one stable path.
+	xcodeManagedSwiftPackagesTool = "xcode-spm"
+
 	// gradleInitScriptRelative is the per-user gradle init script written by `activate gradle`.
 	gradleInitScriptRelative = ".gradle/init.d/bitrise-build-cache.init.gradle.kts"
 
@@ -284,4 +289,11 @@ func (p Paths) XcodeManagedDerivedDataDir(workspaceSHA string) string {
 // workspace-sha, layered under BitriseCacheDir("xcode-ptd").
 func (p Paths) XcodeManagedProjectTempDir(workspaceSHA string) string {
 	return filepath.Join(p.BitriseCacheDir(xcodeManagedProjectTempDirTool), workspaceSHA)
+}
+
+// XcodeManagedSwiftPackagesDir returns the wrapper-owned SPM checkout dir passed to xcodebuild as
+// -clonedSourcePackagesDirPath. Unlike the DerivedData and PROJECT_TEMP_DIR roots this is not
+// workspace-sha scoped, so it stays valid across branches and is exported for cache steps to use.
+func (p Paths) XcodeManagedSwiftPackagesDir() string {
+	return p.BitriseCacheDir(xcodeManagedSwiftPackagesTool)
 }

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -86,8 +86,7 @@ const (
 	// xcodeManagedProjectTempDirTool is the per-workspace PROJECT_TEMP_DIR root managed by the wrapper.
 	xcodeManagedProjectTempDirTool = "xcode-ptd"
 
-	// xcodeManagedSwiftPackagesTool is the SPM checkout root managed by the wrapper. Not
-	// workspace-scoped: SPM keys checkouts by Package.resolved, so one root stays cacheable.
+	// xcodeManagedSwiftPackagesTool is the SPM checkout root managed by the wrapper.
 	xcodeManagedSwiftPackagesTool = "xcode-spm"
 
 	// gradleInitScriptRelative is the per-user gradle init script written by `activate gradle`.
@@ -290,8 +289,16 @@ func (p Paths) XcodeManagedProjectTempDir(workspaceSHA string) string {
 	return filepath.Join(p.BitriseCacheDir(xcodeManagedProjectTempDirTool), workspaceSHA)
 }
 
-// XcodeManagedSwiftPackagesDir returns the wrapper-owned SPM checkout dir passed to xcodebuild as
-// -clonedSourcePackagesDirPath.
-func (p Paths) XcodeManagedSwiftPackagesDir() string {
+// XcodeManagedSwiftPackagesDir returns the wrapper-owned SPM checkout dir for a given
+// workspace-sha, passed to xcodebuild as -clonedSourcePackagesDirPath. Scoped per workspace like
+// the DerivedData and PROJECT_TEMP_DIR roots: sharing one mutable checkout tree across workspaces
+// lets a later build re-resolve over an earlier build's sources and lose its compilation cache.
+func (p Paths) XcodeManagedSwiftPackagesDir(workspaceSHA string) string {
+	return filepath.Join(p.XcodeManagedSwiftPackagesRoot(), workspaceSHA)
+}
+
+// XcodeManagedSwiftPackagesRoot returns the parent of every per-workspace SPM checkout dir. This is
+// what gets exported for cache steps, so one archive covers every workspace in the repo.
+func (p Paths) XcodeManagedSwiftPackagesRoot() string {
 	return p.BitriseCacheDir(xcodeManagedSwiftPackagesTool)
 }

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -280,8 +280,7 @@ func (p Paths) XcodeManagedDerivedDataDir(workspaceSHA string) string {
 	return filepath.Join(p.XcodeManagedDerivedDataRoot(), workspaceSHA)
 }
 
-// XcodeManagedDerivedDataRoot returns the parent of every per-workspace DerivedData dir. SPM
-// checkouts live at <root>/<workspace-sha>/SourcePackages, so this is what cache steps glob.
+// XcodeManagedDerivedDataRoot returns the parent of every per-workspace DerivedData dir.
 func (p Paths) XcodeManagedDerivedDataRoot() string {
 	return p.BitriseCacheDir(xcodeManagedDerivedDataTool)
 }

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -86,9 +86,6 @@ const (
 	// xcodeManagedProjectTempDirTool is the per-workspace PROJECT_TEMP_DIR root managed by the wrapper.
 	xcodeManagedProjectTempDirTool = "xcode-ptd"
 
-	// xcodeManagedSwiftPackagesTool is the SPM checkout root managed by the wrapper.
-	xcodeManagedSwiftPackagesTool = "xcode-spm"
-
 	// gradleInitScriptRelative is the per-user gradle init script written by `activate gradle`.
 	gradleInitScriptRelative = ".gradle/init.d/bitrise-build-cache.init.gradle.kts"
 
@@ -280,25 +277,17 @@ func (p Paths) GradleInitScriptFile() string {
 // XcodeManagedDerivedDataDir returns the wrapper-owned DerivedData dir for a given
 // workspace-sha, layered under BitriseCacheDir("xcode-dd").
 func (p Paths) XcodeManagedDerivedDataDir(workspaceSHA string) string {
-	return filepath.Join(p.BitriseCacheDir(xcodeManagedDerivedDataTool), workspaceSHA)
+	return filepath.Join(p.XcodeManagedDerivedDataRoot(), workspaceSHA)
+}
+
+// XcodeManagedDerivedDataRoot returns the parent of every per-workspace DerivedData dir. SPM
+// checkouts live at <root>/<workspace-sha>/SourcePackages, so this is what cache steps glob.
+func (p Paths) XcodeManagedDerivedDataRoot() string {
+	return p.BitriseCacheDir(xcodeManagedDerivedDataTool)
 }
 
 // XcodeManagedProjectTempDir returns the wrapper-owned PROJECT_TEMP_DIR dir for a given
 // workspace-sha, layered under BitriseCacheDir("xcode-ptd").
 func (p Paths) XcodeManagedProjectTempDir(workspaceSHA string) string {
 	return filepath.Join(p.BitriseCacheDir(xcodeManagedProjectTempDirTool), workspaceSHA)
-}
-
-// XcodeManagedSwiftPackagesDir returns the wrapper-owned SPM checkout dir for a given
-// workspace-sha, passed to xcodebuild as -clonedSourcePackagesDirPath. Scoped per workspace like
-// the DerivedData and PROJECT_TEMP_DIR roots: sharing one mutable checkout tree across workspaces
-// lets a later build re-resolve over an earlier build's sources and lose its compilation cache.
-func (p Paths) XcodeManagedSwiftPackagesDir(workspaceSHA string) string {
-	return filepath.Join(p.XcodeManagedSwiftPackagesRoot(), workspaceSHA)
-}
-
-// XcodeManagedSwiftPackagesRoot returns the parent of every per-workspace SPM checkout dir. This is
-// what gets exported for cache steps, so one archive covers every workspace in the repo.
-func (p Paths) XcodeManagedSwiftPackagesRoot() string {
-	return p.BitriseCacheDir(xcodeManagedSwiftPackagesTool)
 }

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -70,6 +70,7 @@ func TestPaths_xcodeManagedDirs(t *testing.T) {
 
 	assert.Equal(t, "/h/.bitrise/cache/xcode-dd/abc123", p.XcodeManagedDerivedDataDir("abc123"))
 	assert.Equal(t, "/h/.bitrise/cache/xcode-ptd/abc123", p.XcodeManagedProjectTempDir("abc123"))
+	assert.Equal(t, "/h/.bitrise/cache/xcode-spm", p.XcodeManagedSwiftPackagesDir())
 }
 
 func TestPaths_xcelerateHandledInvocations(t *testing.T) {

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -70,8 +70,7 @@ func TestPaths_xcodeManagedDirs(t *testing.T) {
 
 	assert.Equal(t, "/h/.bitrise/cache/xcode-dd/abc123", p.XcodeManagedDerivedDataDir("abc123"))
 	assert.Equal(t, "/h/.bitrise/cache/xcode-ptd/abc123", p.XcodeManagedProjectTempDir("abc123"))
-	assert.Equal(t, "/h/.bitrise/cache/xcode-spm/abc123", p.XcodeManagedSwiftPackagesDir("abc123"))
-	assert.Equal(t, "/h/.bitrise/cache/xcode-spm", p.XcodeManagedSwiftPackagesRoot())
+	assert.Equal(t, "/h/.bitrise/cache/xcode-dd", p.XcodeManagedDerivedDataRoot())
 }
 
 func TestPaths_xcelerateHandledInvocations(t *testing.T) {

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -70,7 +70,8 @@ func TestPaths_xcodeManagedDirs(t *testing.T) {
 
 	assert.Equal(t, "/h/.bitrise/cache/xcode-dd/abc123", p.XcodeManagedDerivedDataDir("abc123"))
 	assert.Equal(t, "/h/.bitrise/cache/xcode-ptd/abc123", p.XcodeManagedProjectTempDir("abc123"))
-	assert.Equal(t, "/h/.bitrise/cache/xcode-spm", p.XcodeManagedSwiftPackagesDir())
+	assert.Equal(t, "/h/.bitrise/cache/xcode-spm/abc123", p.XcodeManagedSwiftPackagesDir("abc123"))
+	assert.Equal(t, "/h/.bitrise/cache/xcode-spm", p.XcodeManagedSwiftPackagesRoot())
 }
 
 func TestPaths_xcelerateHandledInvocations(t *testing.T) {

--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -159,14 +159,14 @@ func (p Default) HasBuildAction() bool {
 // packageResolvingQueryActions are query actions that still resolve the Swift package graph, so
 // their checkouts must land where the build reads them rather than in the default DerivedData.
 //
-// Deliberately just the one action. -list also resolves and also accepts the flag on Xcode 26.4.1,
-// but an unknown argv flag makes xcodebuild fail outright — unlike an unknown build setting, which
-// it ignores — and nothing here gates on the Xcode version. -resolvePackageDependencies and
-// -clonedSourcePackagesDirPath both shipped in Xcode 11, so that pairing is safe everywhere;
-// -list with this flag is not an obvious pairing and is unverified on older Xcode. Add it once
-// checked against the oldest stack we support.
+// Both accept -clonedSourcePackagesDirPath and write their checkouts to it (verified on Xcode
+// 26.4.1). -derivedDataPath cannot be used instead: xcodebuild rejects it on these actions unless
+// -scheme is also present. The flag has existed since Xcode 11, and the oldest stack running Xcode
+// build cache in the last 90 days is 16.0 (457 invocations across a handful of workspaces, against
+// ~550k on 26.x), so it is available everywhere this runs.
 var packageResolvingQueryActions = []string{
 	"-resolvePackageDependencies",
+	"-list",
 }
 
 // ResolvesPackages reports whether a non-build invocation still populates SPM checkouts.

--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -158,10 +158,15 @@ func (p Default) HasBuildAction() bool {
 
 // packageResolvingQueryActions are query actions that still resolve the Swift package graph, so
 // their checkouts must land where the build reads them rather than in the default DerivedData.
-// Verified against Xcode 26.4.1: both accept -clonedSourcePackagesDirPath and both write checkouts.
+//
+// Deliberately just the one action. -list also resolves and also accepts the flag on Xcode 26.4.1,
+// but an unknown argv flag makes xcodebuild fail outright — unlike an unknown build setting, which
+// it ignores — and nothing here gates on the Xcode version. -resolvePackageDependencies and
+// -clonedSourcePackagesDirPath both shipped in Xcode 11, so that pairing is safe everywhere;
+// -list with this flag is not an obvious pairing and is unverified on older Xcode. Add it once
+// checked against the oldest stack we support.
 var packageResolvingQueryActions = []string{
 	"-resolvePackageDependencies",
-	"-list",
 }
 
 // ResolvesPackages reports whether a non-build invocation still populates SPM checkouts.

--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -17,6 +17,7 @@ type XcodeArgs interface {
 	ShortCommand() string
 	HasBuildAction() bool
 	DerivedDataPath() string
+	ClonedSourcePackagesDirPath() string
 	ProjectTempDir() string
 	ProjectDir() string
 	UserOtherCFlags() string

--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -156,14 +156,7 @@ func (p Default) HasBuildAction() bool {
 	return HasBuildAction(p.OriginalArgs)
 }
 
-// packageResolvingQueryActions are query actions that still resolve the Swift package graph, so
-// their checkouts must land where the build reads them rather than in the default DerivedData.
-//
-// Both accept -clonedSourcePackagesDirPath and write their checkouts to it (verified on Xcode
-// 26.4.1). -derivedDataPath cannot be used instead: xcodebuild rejects it on these actions unless
-// -scheme is also present. The flag has existed since Xcode 11, and the oldest stack running Xcode
-// build cache in the last 90 days is 16.0 (457 invocations across a handful of workspaces, against
-// ~550k on 26.x), so it is available everywhere this runs.
+// packageResolvingQueryActions still populate SPM checkouts despite not building.
 var packageResolvingQueryActions = []string{
 	"-resolvePackageDependencies",
 	"-list",

--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -17,6 +17,8 @@ type XcodeArgs interface {
 	ShortCommand() string
 	HasBuildAction() bool
 	DerivedDataPath() string
+	ClonedSourcePackagesDirPath() string
+	ResolvesPackages() bool
 	ProjectTempDir() string
 	ProjectDir() string
 	UserOtherCFlags() string
@@ -152,6 +154,25 @@ func HasBuildAction(argv []string) bool {
 
 func (p Default) HasBuildAction() bool {
 	return HasBuildAction(p.OriginalArgs)
+}
+
+// packageResolvingQueryActions are query actions that still resolve the Swift package graph, so
+// their checkouts must land where the build reads them rather than in the default DerivedData.
+// Verified against Xcode 26.4.1: both accept -clonedSourcePackagesDirPath and both write checkouts.
+var packageResolvingQueryActions = []string{
+	"-resolvePackageDependencies",
+	"-list",
+}
+
+// ResolvesPackages reports whether a non-build invocation still populates SPM checkouts.
+func (p Default) ResolvesPackages() bool {
+	for _, arg := range p.OriginalArgs {
+		if slices.Contains(packageResolvingQueryActions, arg) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (p Default) ShortCommand() string {

--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -17,7 +17,6 @@ type XcodeArgs interface {
 	ShortCommand() string
 	HasBuildAction() bool
 	DerivedDataPath() string
-	ClonedSourcePackagesDirPath() string
 	ProjectTempDir() string
 	ProjectDir() string
 	UserOtherCFlags() string

--- a/internal/xcelerate/xcodeargs/mocks/args_mock.go
+++ b/internal/xcelerate/xcodeargs/mocks/args_mock.go
@@ -21,6 +21,9 @@ var _ xcodeargs.XcodeArgs = &XcodeArgsMock{}
 //			ArgsFunc: func(additional map[string]string) []string {
 //				panic("mock out the Args method")
 //			},
+//			ClonedSourcePackagesDirPathFunc: func() string {
+//				panic("mock out the ClonedSourcePackagesDirPath method")
+//			},
 //			CommandFunc: func() string {
 //				panic("mock out the Command method")
 //			},
@@ -35,6 +38,9 @@ var _ xcodeargs.XcodeArgs = &XcodeArgsMock{}
 //			},
 //			ProjectTempDirFunc: func() string {
 //				panic("mock out the ProjectTempDir method")
+//			},
+//			ResolvesPackagesFunc: func() bool {
+//				panic("mock out the ResolvesPackages method")
 //			},
 //			ShortCommandFunc: func() string {
 //				panic("mock out the ShortCommand method")
@@ -52,6 +58,9 @@ type XcodeArgsMock struct {
 	// ArgsFunc mocks the Args method.
 	ArgsFunc func(additional map[string]string) []string
 
+	// ClonedSourcePackagesDirPathFunc mocks the ClonedSourcePackagesDirPath method.
+	ClonedSourcePackagesDirPathFunc func() string
+
 	// CommandFunc mocks the Command method.
 	CommandFunc func() string
 
@@ -67,6 +76,9 @@ type XcodeArgsMock struct {
 	// ProjectTempDirFunc mocks the ProjectTempDir method.
 	ProjectTempDirFunc func() string
 
+	// ResolvesPackagesFunc mocks the ResolvesPackages method.
+	ResolvesPackagesFunc func() bool
+
 	// ShortCommandFunc mocks the ShortCommand method.
 	ShortCommandFunc func() string
 
@@ -79,6 +91,9 @@ type XcodeArgsMock struct {
 		Args []struct {
 			// Additional is the additional argument value.
 			Additional map[string]string
+		}
+		// ClonedSourcePackagesDirPath holds details about calls to the ClonedSourcePackagesDirPath method.
+		ClonedSourcePackagesDirPath []struct {
 		}
 		// Command holds details about calls to the Command method.
 		Command []struct {
@@ -95,6 +110,9 @@ type XcodeArgsMock struct {
 		// ProjectTempDir holds details about calls to the ProjectTempDir method.
 		ProjectTempDir []struct {
 		}
+		// ResolvesPackages holds details about calls to the ResolvesPackages method.
+		ResolvesPackages []struct {
+		}
 		// ShortCommand holds details about calls to the ShortCommand method.
 		ShortCommand []struct {
 		}
@@ -102,14 +120,16 @@ type XcodeArgsMock struct {
 		UserOtherCFlags []struct {
 		}
 	}
-	lockArgs            sync.RWMutex
-	lockCommand         sync.RWMutex
-	lockDerivedDataPath sync.RWMutex
-	lockHasBuildAction  sync.RWMutex
-	lockProjectDir      sync.RWMutex
-	lockProjectTempDir  sync.RWMutex
-	lockShortCommand    sync.RWMutex
-	lockUserOtherCFlags sync.RWMutex
+	lockArgs                        sync.RWMutex
+	lockClonedSourcePackagesDirPath sync.RWMutex
+	lockCommand                     sync.RWMutex
+	lockDerivedDataPath             sync.RWMutex
+	lockHasBuildAction              sync.RWMutex
+	lockProjectDir                  sync.RWMutex
+	lockProjectTempDir              sync.RWMutex
+	lockResolvesPackages            sync.RWMutex
+	lockShortCommand                sync.RWMutex
+	lockUserOtherCFlags             sync.RWMutex
 }
 
 // Args calls ArgsFunc.
@@ -144,6 +164,36 @@ func (mock *XcodeArgsMock) ArgsCalls() []struct {
 	mock.lockArgs.RLock()
 	calls = mock.calls.Args
 	mock.lockArgs.RUnlock()
+	return calls
+}
+
+// ClonedSourcePackagesDirPath calls ClonedSourcePackagesDirPathFunc.
+func (mock *XcodeArgsMock) ClonedSourcePackagesDirPath() string {
+	callInfo := struct {
+	}{}
+	mock.lockClonedSourcePackagesDirPath.Lock()
+	mock.calls.ClonedSourcePackagesDirPath = append(mock.calls.ClonedSourcePackagesDirPath, callInfo)
+	mock.lockClonedSourcePackagesDirPath.Unlock()
+	if mock.ClonedSourcePackagesDirPathFunc == nil {
+		var (
+			sOut string
+		)
+		return sOut
+	}
+	return mock.ClonedSourcePackagesDirPathFunc()
+}
+
+// ClonedSourcePackagesDirPathCalls gets all the calls that were made to ClonedSourcePackagesDirPath.
+// Check the length with:
+//
+//	len(mockedXcodeArgs.ClonedSourcePackagesDirPathCalls())
+func (mock *XcodeArgsMock) ClonedSourcePackagesDirPathCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockClonedSourcePackagesDirPath.RLock()
+	calls = mock.calls.ClonedSourcePackagesDirPath
+	mock.lockClonedSourcePackagesDirPath.RUnlock()
 	return calls
 }
 
@@ -294,6 +344,36 @@ func (mock *XcodeArgsMock) ProjectTempDirCalls() []struct {
 	mock.lockProjectTempDir.RLock()
 	calls = mock.calls.ProjectTempDir
 	mock.lockProjectTempDir.RUnlock()
+	return calls
+}
+
+// ResolvesPackages calls ResolvesPackagesFunc.
+func (mock *XcodeArgsMock) ResolvesPackages() bool {
+	callInfo := struct {
+	}{}
+	mock.lockResolvesPackages.Lock()
+	mock.calls.ResolvesPackages = append(mock.calls.ResolvesPackages, callInfo)
+	mock.lockResolvesPackages.Unlock()
+	if mock.ResolvesPackagesFunc == nil {
+		var (
+			bOut bool
+		)
+		return bOut
+	}
+	return mock.ResolvesPackagesFunc()
+}
+
+// ResolvesPackagesCalls gets all the calls that were made to ResolvesPackages.
+// Check the length with:
+//
+//	len(mockedXcodeArgs.ResolvesPackagesCalls())
+func (mock *XcodeArgsMock) ResolvesPackagesCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockResolvesPackages.RLock()
+	calls = mock.calls.ResolvesPackages
+	mock.lockResolvesPackages.RUnlock()
 	return calls
 }
 

--- a/internal/xcelerate/xcodeargs/mocks/args_mock.go
+++ b/internal/xcelerate/xcodeargs/mocks/args_mock.go
@@ -21,9 +21,6 @@ var _ xcodeargs.XcodeArgs = &XcodeArgsMock{}
 //			ArgsFunc: func(additional map[string]string) []string {
 //				panic("mock out the Args method")
 //			},
-//			ClonedSourcePackagesDirPathFunc: func() string {
-//				panic("mock out the ClonedSourcePackagesDirPath method")
-//			},
 //			CommandFunc: func() string {
 //				panic("mock out the Command method")
 //			},
@@ -55,9 +52,6 @@ type XcodeArgsMock struct {
 	// ArgsFunc mocks the Args method.
 	ArgsFunc func(additional map[string]string) []string
 
-	// ClonedSourcePackagesDirPathFunc mocks the ClonedSourcePackagesDirPath method.
-	ClonedSourcePackagesDirPathFunc func() string
-
 	// CommandFunc mocks the Command method.
 	CommandFunc func() string
 
@@ -86,9 +80,6 @@ type XcodeArgsMock struct {
 			// Additional is the additional argument value.
 			Additional map[string]string
 		}
-		// ClonedSourcePackagesDirPath holds details about calls to the ClonedSourcePackagesDirPath method.
-		ClonedSourcePackagesDirPath []struct {
-		}
 		// Command holds details about calls to the Command method.
 		Command []struct {
 		}
@@ -111,15 +102,14 @@ type XcodeArgsMock struct {
 		UserOtherCFlags []struct {
 		}
 	}
-	lockArgs                        sync.RWMutex
-	lockClonedSourcePackagesDirPath sync.RWMutex
-	lockCommand                     sync.RWMutex
-	lockDerivedDataPath             sync.RWMutex
-	lockHasBuildAction              sync.RWMutex
-	lockProjectDir                  sync.RWMutex
-	lockProjectTempDir              sync.RWMutex
-	lockShortCommand                sync.RWMutex
-	lockUserOtherCFlags             sync.RWMutex
+	lockArgs            sync.RWMutex
+	lockCommand         sync.RWMutex
+	lockDerivedDataPath sync.RWMutex
+	lockHasBuildAction  sync.RWMutex
+	lockProjectDir      sync.RWMutex
+	lockProjectTempDir  sync.RWMutex
+	lockShortCommand    sync.RWMutex
+	lockUserOtherCFlags sync.RWMutex
 }
 
 // Args calls ArgsFunc.
@@ -154,36 +144,6 @@ func (mock *XcodeArgsMock) ArgsCalls() []struct {
 	mock.lockArgs.RLock()
 	calls = mock.calls.Args
 	mock.lockArgs.RUnlock()
-	return calls
-}
-
-// ClonedSourcePackagesDirPath calls ClonedSourcePackagesDirPathFunc.
-func (mock *XcodeArgsMock) ClonedSourcePackagesDirPath() string {
-	callInfo := struct {
-	}{}
-	mock.lockClonedSourcePackagesDirPath.Lock()
-	mock.calls.ClonedSourcePackagesDirPath = append(mock.calls.ClonedSourcePackagesDirPath, callInfo)
-	mock.lockClonedSourcePackagesDirPath.Unlock()
-	if mock.ClonedSourcePackagesDirPathFunc == nil {
-		var (
-			sOut string
-		)
-		return sOut
-	}
-	return mock.ClonedSourcePackagesDirPathFunc()
-}
-
-// ClonedSourcePackagesDirPathCalls gets all the calls that were made to ClonedSourcePackagesDirPath.
-// Check the length with:
-//
-//	len(mockedXcodeArgs.ClonedSourcePackagesDirPathCalls())
-func (mock *XcodeArgsMock) ClonedSourcePackagesDirPathCalls() []struct {
-} {
-	var calls []struct {
-	}
-	mock.lockClonedSourcePackagesDirPath.RLock()
-	calls = mock.calls.ClonedSourcePackagesDirPath
-	mock.lockClonedSourcePackagesDirPath.RUnlock()
 	return calls
 }
 

--- a/internal/xcelerate/xcodeargs/mocks/args_mock.go
+++ b/internal/xcelerate/xcodeargs/mocks/args_mock.go
@@ -21,6 +21,9 @@ var _ xcodeargs.XcodeArgs = &XcodeArgsMock{}
 //			ArgsFunc: func(additional map[string]string) []string {
 //				panic("mock out the Args method")
 //			},
+//			ClonedSourcePackagesDirPathFunc: func() string {
+//				panic("mock out the ClonedSourcePackagesDirPath method")
+//			},
 //			CommandFunc: func() string {
 //				panic("mock out the Command method")
 //			},
@@ -52,6 +55,9 @@ type XcodeArgsMock struct {
 	// ArgsFunc mocks the Args method.
 	ArgsFunc func(additional map[string]string) []string
 
+	// ClonedSourcePackagesDirPathFunc mocks the ClonedSourcePackagesDirPath method.
+	ClonedSourcePackagesDirPathFunc func() string
+
 	// CommandFunc mocks the Command method.
 	CommandFunc func() string
 
@@ -80,6 +86,9 @@ type XcodeArgsMock struct {
 			// Additional is the additional argument value.
 			Additional map[string]string
 		}
+		// ClonedSourcePackagesDirPath holds details about calls to the ClonedSourcePackagesDirPath method.
+		ClonedSourcePackagesDirPath []struct {
+		}
 		// Command holds details about calls to the Command method.
 		Command []struct {
 		}
@@ -102,14 +111,15 @@ type XcodeArgsMock struct {
 		UserOtherCFlags []struct {
 		}
 	}
-	lockArgs            sync.RWMutex
-	lockCommand         sync.RWMutex
-	lockDerivedDataPath sync.RWMutex
-	lockHasBuildAction  sync.RWMutex
-	lockProjectDir      sync.RWMutex
-	lockProjectTempDir  sync.RWMutex
-	lockShortCommand    sync.RWMutex
-	lockUserOtherCFlags sync.RWMutex
+	lockArgs                        sync.RWMutex
+	lockClonedSourcePackagesDirPath sync.RWMutex
+	lockCommand                     sync.RWMutex
+	lockDerivedDataPath             sync.RWMutex
+	lockHasBuildAction              sync.RWMutex
+	lockProjectDir                  sync.RWMutex
+	lockProjectTempDir              sync.RWMutex
+	lockShortCommand                sync.RWMutex
+	lockUserOtherCFlags             sync.RWMutex
 }
 
 // Args calls ArgsFunc.
@@ -144,6 +154,36 @@ func (mock *XcodeArgsMock) ArgsCalls() []struct {
 	mock.lockArgs.RLock()
 	calls = mock.calls.Args
 	mock.lockArgs.RUnlock()
+	return calls
+}
+
+// ClonedSourcePackagesDirPath calls ClonedSourcePackagesDirPathFunc.
+func (mock *XcodeArgsMock) ClonedSourcePackagesDirPath() string {
+	callInfo := struct {
+	}{}
+	mock.lockClonedSourcePackagesDirPath.Lock()
+	mock.calls.ClonedSourcePackagesDirPath = append(mock.calls.ClonedSourcePackagesDirPath, callInfo)
+	mock.lockClonedSourcePackagesDirPath.Unlock()
+	if mock.ClonedSourcePackagesDirPathFunc == nil {
+		var (
+			sOut string
+		)
+		return sOut
+	}
+	return mock.ClonedSourcePackagesDirPathFunc()
+}
+
+// ClonedSourcePackagesDirPathCalls gets all the calls that were made to ClonedSourcePackagesDirPath.
+// Check the length with:
+//
+//	len(mockedXcodeArgs.ClonedSourcePackagesDirPathCalls())
+func (mock *XcodeArgsMock) ClonedSourcePackagesDirPathCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockClonedSourcePackagesDirPath.RLock()
+	calls = mock.calls.ClonedSourcePackagesDirPath
+	mock.lockClonedSourcePackagesDirPath.RUnlock()
 	return calls
 }
 

--- a/internal/xcelerate/xcodeargs/prefix_map.go
+++ b/internal/xcelerate/xcodeargs/prefix_map.go
@@ -25,22 +25,20 @@ const prefixMapFlag = "-fdepscan-prefix-map="
 // Build-setting keys and derivedDataPath flag literal used by the wrapper
 // when injecting prefix-map rules.
 const (
-	ClangEnablePrefixMappingKey     = "CLANG_ENABLE_PREFIX_MAPPING"
-	OtherCFlagsKey                  = "OTHER_CFLAGS"
-	ProjectTempDirKey               = "PROJECT_TEMP_DIR"
-	DerivedDataPathFlag             = "-derivedDataPath"
-	ClonedSourcePackagesDirPathFlag = "-clonedSourcePackagesDirPath"
+	ClangEnablePrefixMappingKey = "CLANG_ENABLE_PREFIX_MAPPING"
+	OtherCFlagsKey              = "OTHER_CFLAGS"
+	ProjectTempDirKey           = "PROJECT_TEMP_DIR"
+	DerivedDataPathFlag         = "-derivedDataPath"
 )
 
 // PrefixMapPaths is the set of absolute paths whose values will be rewritten
 // to stable virtual names in clang's CAS cache keys via -fdepscan-prefix-map.
 // Empty fields produce no rule.
 type PrefixMapPaths struct {
-	Home             string
-	ProjectDir       string
-	DerivedDataPath  string
-	ProjectTempDir   string
-	SwiftPackagesDir string
+	Home            string
+	ProjectDir      string
+	DerivedDataPath string
+	ProjectTempDir  string
 }
 
 // BuildOtherCFlagsValue returns the suffix to append after "$(inherited) " in
@@ -53,7 +51,6 @@ func BuildOtherCFlagsValue(p PrefixMapPaths) string {
 	rules := []rule{
 		{p.ProjectTempDir, "/^obj"},
 		{p.DerivedDataPath, "/^dd"},
-		{p.SwiftPackagesDir, "/^spm"},
 		{p.ProjectDir, "/^src"},
 		{p.Home, "/^home"},
 	}
@@ -134,12 +131,6 @@ func isBitrisePrefixMapRule(token string) bool {
 // working directory — clang rejects non-absolute inputs to -fdepscan-prefix-map=.
 func (p Default) DerivedDataPath() string {
 	return absOrEmpty(findLastFlagValue(p.OriginalArgs, "derivedDataPath"))
-}
-
-// ClonedSourcePackagesDirPath returns the last -clonedSourcePackagesDirPath value from
-// OriginalArgs, in both the space and `=` forms. Missing → empty.
-func (p Default) ClonedSourcePackagesDirPath() string {
-	return absOrEmpty(findLastFlagValue(p.OriginalArgs, "clonedSourcePackagesDirPath"))
 }
 
 // ProjectTempDir returns the last PROJECT_TEMP_DIR=... build-setting value

--- a/internal/xcelerate/xcodeargs/prefix_map.go
+++ b/internal/xcelerate/xcodeargs/prefix_map.go
@@ -29,6 +29,10 @@ const (
 	OtherCFlagsKey              = "OTHER_CFLAGS"
 	ProjectTempDirKey           = "PROJECT_TEMP_DIR"
 	DerivedDataPathFlag         = "-derivedDataPath"
+
+	// ClonedSourcePackagesDirPathFlag is injected on package-resolving query actions.
+	// -derivedDataPath cannot be: xcodebuild rejects it without -scheme.
+	ClonedSourcePackagesDirPathFlag = "-clonedSourcePackagesDirPath"
 )
 
 // PrefixMapPaths is the set of absolute paths whose values will be rewritten
@@ -131,6 +135,12 @@ func isBitrisePrefixMapRule(token string) bool {
 // working directory — clang rejects non-absolute inputs to -fdepscan-prefix-map=.
 func (p Default) DerivedDataPath() string {
 	return absOrEmpty(findLastFlagValue(p.OriginalArgs, "derivedDataPath"))
+}
+
+// ClonedSourcePackagesDirPath returns the last -clonedSourcePackagesDirPath value from
+// OriginalArgs, in both the space and `=` forms. Missing → empty.
+func (p Default) ClonedSourcePackagesDirPath() string {
+	return absOrEmpty(findLastFlagValue(p.OriginalArgs, "clonedSourcePackagesDirPath"))
 }
 
 // ProjectTempDir returns the last PROJECT_TEMP_DIR=... build-setting value

--- a/internal/xcelerate/xcodeargs/prefix_map.go
+++ b/internal/xcelerate/xcodeargs/prefix_map.go
@@ -30,8 +30,7 @@ const (
 	ProjectTempDirKey           = "PROJECT_TEMP_DIR"
 	DerivedDataPathFlag         = "-derivedDataPath"
 
-	// ClonedSourcePackagesDirPathFlag is injected on package-resolving query actions.
-	// -derivedDataPath cannot be: xcodebuild rejects it without -scheme.
+	// Used instead of -derivedDataPath on query actions, which reject that without -scheme.
 	ClonedSourcePackagesDirPathFlag = "-clonedSourcePackagesDirPath"
 )
 

--- a/internal/xcelerate/xcodeargs/prefix_map.go
+++ b/internal/xcelerate/xcodeargs/prefix_map.go
@@ -25,20 +25,22 @@ const prefixMapFlag = "-fdepscan-prefix-map="
 // Build-setting keys and derivedDataPath flag literal used by the wrapper
 // when injecting prefix-map rules.
 const (
-	ClangEnablePrefixMappingKey = "CLANG_ENABLE_PREFIX_MAPPING"
-	OtherCFlagsKey              = "OTHER_CFLAGS"
-	ProjectTempDirKey           = "PROJECT_TEMP_DIR"
-	DerivedDataPathFlag         = "-derivedDataPath"
+	ClangEnablePrefixMappingKey     = "CLANG_ENABLE_PREFIX_MAPPING"
+	OtherCFlagsKey                  = "OTHER_CFLAGS"
+	ProjectTempDirKey               = "PROJECT_TEMP_DIR"
+	DerivedDataPathFlag             = "-derivedDataPath"
+	ClonedSourcePackagesDirPathFlag = "-clonedSourcePackagesDirPath"
 )
 
 // PrefixMapPaths is the set of absolute paths whose values will be rewritten
 // to stable virtual names in clang's CAS cache keys via -fdepscan-prefix-map.
 // Empty fields produce no rule.
 type PrefixMapPaths struct {
-	Home            string
-	ProjectDir      string
-	DerivedDataPath string
-	ProjectTempDir  string
+	Home             string
+	ProjectDir       string
+	DerivedDataPath  string
+	ProjectTempDir   string
+	SwiftPackagesDir string
 }
 
 // BuildOtherCFlagsValue returns the suffix to append after "$(inherited) " in
@@ -51,6 +53,7 @@ func BuildOtherCFlagsValue(p PrefixMapPaths) string {
 	rules := []rule{
 		{p.ProjectTempDir, "/^obj"},
 		{p.DerivedDataPath, "/^dd"},
+		{p.SwiftPackagesDir, "/^spm"},
 		{p.ProjectDir, "/^src"},
 		{p.Home, "/^home"},
 	}
@@ -131,6 +134,12 @@ func isBitrisePrefixMapRule(token string) bool {
 // working directory — clang rejects non-absolute inputs to -fdepscan-prefix-map=.
 func (p Default) DerivedDataPath() string {
 	return absOrEmpty(findLastFlagValue(p.OriginalArgs, "derivedDataPath"))
+}
+
+// ClonedSourcePackagesDirPath returns the last -clonedSourcePackagesDirPath value from
+// OriginalArgs, in both the space and `=` forms. Missing → empty.
+func (p Default) ClonedSourcePackagesDirPath() string {
+	return absOrEmpty(findLastFlagValue(p.OriginalArgs, "clonedSourcePackagesDirPath"))
 }
 
 // ProjectTempDir returns the last PROJECT_TEMP_DIR=... build-setting value


### PR DESCRIPTION
Closes [ACI-5253](https://bitrise.atlassian.net/browse/ACI-5253). Found while investigating [ACI-5247](https://bitrise.atlassian.net/browse/ACI-5247) (Maven Clinic).

Two related holes in how SPM checkouts interact with the wrapper's DerivedData relocation. Neither changes where a *build* puts its checkouts.

## 1. Nothing tells cache steps where DerivedData went

`activate-build-cache-for-xcode` relocates DerivedData to `~/.bitrise/cache/xcode-dd/<workspace-sha>` and never publishes it. SPM checkouts live under DerivedData, so they move too — out of the `~/Library/Developer/Xcode/DerivedData/**/SourcePackages` location every SPM cache step targets, including our own `save-spm-cache`, whose `derived_data_path` defaults to exactly that.

The failure is silent: the cache reports hits while every build re-resolves from origin. Observed on Maven Clinic (generic `save-cache`/`restore-cache`, same root cause) in build `3b955e72`:

- `restore-cache` → `Exact hit for first key` / `Archive size: 5.81GB`
- the same build then fetched all 45 packages from GitHub
- `save-cache` at the end → `new cache archive is the same as the restored one`

Restored, never touched, re-saved. ~39s/build of cache work for nothing plus 162s/build of avoidable fetching — and in the worst case one fetch crawled for 33m53s, turning a ~17m build into 44m.

**Fix:** export the root at activation.

```
BITRISE_XCODE_DERIVED_DATA_PATH = ~/.bitrise/cache/xcode-dd
```

Builds live at `<root>/<workspace-sha>`, so cache steps glob `<root>/*/SourcePackages`. Skipped when the cache is off, flags are skipped, or prefix mapping is disabled — the same conditions under which the wrapper doesn't relocate DerivedData at all.

## 2. Package-resolving query actions fetch into the wrong place

`xcodebuild -resolvePackageDependencies` resolves the package graph and writes checkouts, but the wrapper classifies it as a query action and injects nothing. It fetches a **second full copy of every package** into the default DerivedData, which no build ever reads. "Resolve in its own bounded step" is the mitigation we hand to customers with slow SPM fetches — today that advice makes them fetch twice.

**Fix:** inject `-clonedSourcePackagesDirPath <derived-data>/SourcePackages` on those actions, following a user-supplied `-derivedDataPath` when present and the managed one otherwise. Skipped when the user already passed `-clonedSourcePackagesDirPath`, or when managed DerivedData is off.

### Verified on Xcode 26.4.1

| action | `-derivedDataPath` | `-clonedSourcePackagesDirPath` |
|---|---|---|
| `-resolvePackageDependencies` | ❌ `error: The flag -scheme, -testProductsPath, or -xctestrun is required when specifying -derivedDataPath` | ✅ accepted, wrote checkouts |
| `-list` | — | ✅ accepted, wrote checkouts |
| `-version`, `-showsdks` | — | ✅ accepted (no-op) |

That rejection is why the injection uses `-clonedSourcePackagesDirPath` and not `-derivedDataPath`, and it confirms the existing `queryActions` comment.

**Version safety, checked against fleet data.** An unknown argv flag makes xcodebuild **fail outright** — unlike an unknown build setting, which it ignores, which is why the `COMPILATION_CACHE_*` settings are safe on pre-26 Xcode — and nothing in the wrapper gates on the Xcode version (`xcodeversion` only records it for analytics). So the flag has to exist on every Xcode this runs against.

`-clonedSourcePackagesDirPath` shipped in Xcode 11. Xcode build-cache invocations over the last 90 days (`mrt_product.build_tool_invocations`):

| stack | invocations | workspaces |
|---|---|---|
| `osx-xcode-26.*` | ~537,000 | most |
| `osx-xcode-latest-stable` | 13,708 | 10 |
| `osx-xcode-16.0.x` – `16.4.x` | 457 total | a handful |
| `osx-xcode-27.0.x-edge` | 8 | 2 |

Nothing below Xcode 16, five majors above where the flag landed. Two caveats worth naming: 78k invocations have a `NULL` stack (non-Bitrise CI, where the Xcode version is unrecorded), and I verified *acceptance* only on 26.4.1 — though `-version` and `-showsdks` also accepted the flag in the same probe, which suggests xcodebuild parses it globally rather than per-action.

`-showBuildSettings` and `-showdestinations` may also resolve packages, but my probe could not confirm it without a real workspace and scheme. Adding them is a one-line change.

## What was reverted, and why neither fix repeats it

An earlier version of this PR moved the checkouts to `~/.bitrise/cache/xcode-spm` with a `/^spm` prefix-map rule. **That cost 40% of the Xcode compilation cache**, and `e2e-xcode-cas-key-stable` caught it:

```
                       checkout A          checkout B
relocated (shared)     392/392 (100%)*     235/392 (60%)   ← *warm remote, not stability
relocated (per-sha)    235/392  (60%)      235/392 (60%)
```

Per-workspace scoping didn't help, because isolation was never the problem. Our prefix mapping is **clang-only** — `CLANG_ENABLE_PREFIX_MAPPING` plus `-fdepscan-prefix-map` in `OTHER_CFLAGS` — and this workload is essentially all Swift:

```
SwiftCompile                        547
SwiftExplicitDependencyGeneratePcm  200
PrecompileModule                     37
SwiftEmitModule                      27
CompileC                              1   ← one
```

A sampled cache **miss** shows the un-canonicalised path in the failing task:

```
SwiftCompile normal arm64 Compiling Descriptions.swift …
  /Users/vagrant/.bitrise/cache/xcode-spm/7826c2999ce1a68e/checkouts/swift-collections/…
```

Xcode's own Swift caching canonicalises paths under DerivedData — that is what makes this e2e pass on `main` with two checkouts at different absolute paths — but it knows nothing about a directory we invent, and a clang flag can't teach it.

**Both fixes above avoid this by construction.** Neither introduces a new path: the export only publishes where things already are, and the query-action injection passes xcodebuild's own default relative to the DerivedData already in play. No new path reaches a compile command, so no cache key can move.

## Consumers

[save-spm-cache#15](https://github.com/bitrise-steplib/bitrise-step-save-spm-cache/pull/15) reads the export and caches `<root>/*/SourcePackages`. No companion change is needed in `restore-spm-cache` — that PR was opened and then [closed](https://github.com/bitrise-steplib/bitrise-step-restore-spm-cache/pull/15) once it turned out its existing prefix fallback already finds the new key namespace. There is no release ordering between the two.

## Testing

- `make lint` clean; unit tests pass for every package touched.
- Query-action injection: injection for a resolving action, following a user `-derivedDataPath`, leaving a user-supplied `-clonedSourcePackagesDirPath` alone, and no-op for non-resolving query actions.
- e2e in `e2e-xcode-comp-cache` (extended rather than a new workflow): save `$BITRISE_XCODE_DERIVED_DATA_PATH/*/SourcePackages`, wipe it, restore it, then run `-resolvePackageDependencies` and fail on any `Fetching from` line. Reuses the workflow's existing build to populate, so it costs no second full build.
  - That resolve deliberately passes **no** `-clonedSourcePackagesDirPath`, so it exercises the injection from fix 2 as well: without it the resolve would read the default DerivedData, find nothing and re-fetch. One assertion, both fixes.
- `e2e-xcode-cas-key-stable` is the regression guard for the reverted approach and must be green before this merges.

No e2e for the `-list` half specifically — the natural assertion is that it leaves the default DerivedData empty, which needs a workflow that runs `-list`.

Unrelated: `internal/xcelerate/enrichment` fails locally on a clean tree too, and is being fixed elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5253]: https://bitrise.atlassian.net/browse/ACI-5253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACI-5247]: https://bitrise.atlassian.net/browse/ACI-5247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


