### PR TITLE
feat: ACI-5253 point package-resolving query actions at the build's checkout dir

### DIFF
--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"maps"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"syscall"
@@ -681,7 +682,7 @@ func (c *XcodebuildRunner) assembleArgs() []string {
 
 	// Query-only invocations (-list, -version, -showBuildSettings on its own, ...) reject -derivedDataPath and don't need cache wiring. Primary short-circuit is in Run() after assembleArgs returns; this branch is defensive.
 	if !c.XcodeArgs.HasBuildAction() {
-		return c.XcodeArgs.Args(additional)
+		return append(c.XcodeArgs.Args(additional), c.sourcePackagesArgvForQueryAction()...)
 	}
 
 	additional["COMPILATION_CACHE_REMOTE_SERVICE_PATH"] = c.Config.ProxySocketPath
@@ -730,6 +731,37 @@ func (c *XcodebuildRunner) assembleArgs() []string {
 	}
 
 	return append(toPass, extraArgv...)
+}
+
+// sourcePackagesArgvForQueryAction points a package-resolving query action at the SPM checkout dir
+// the build itself uses. Without it `xcodebuild -list` and `-resolvePackageDependencies` fetch a
+// second copy of every package into the default DerivedData, which no build ever reads.
+//
+// This injects xcodebuild's own default location relative to the DerivedData in play, so no new
+// path reaches a compile command and compilation cache keys are untouched. -derivedDataPath is not
+// an option here: xcodebuild rejects it on these actions unless -scheme is also present.
+func (c *XcodebuildRunner) sourcePackagesArgvForQueryAction() []string {
+	if !c.XcodeArgs.ResolvesPackages() || c.XcodeArgs.ClonedSourcePackagesDirPath() != "" {
+		return nil
+	}
+	if c.Config.BuildCacheSkipFlags || c.Config.DisablePrefixMapping || c.NoPrefixMap {
+		return nil
+	}
+
+	dd := c.XcodeArgs.DerivedDataPath()
+	if dd == "" {
+		projectDir := c.XcodeArgs.ProjectDir()
+		if c.NoManagedDD || projectDir == "" {
+			return nil
+		}
+		p := c.resolvePaths()
+		if p.Home == "" {
+			return nil
+		}
+		dd = p.XcodeManagedDerivedDataDir(workspaceSHA(projectDir))
+	}
+
+	return []string{xcodeargs.ClonedSourcePackagesDirPathFlag, filepath.Join(dd, "SourcePackages")}
 }
 
 const (

--- a/cmd/xcode/xcodebuild_test.go
+++ b/cmd/xcode/xcodebuild_test.go
@@ -4,6 +4,7 @@ package xcode_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -500,4 +501,84 @@ func Test_xcodebuildCmdFn_callsEndSessionAfterRun(t *testing.T) {
 	gotMs := calls[0].In.GetEndTimeUnixMs()
 	assert.GreaterOrEqual(t, gotMs, beforeMs, "EndTimeUnixMs must be captured at or after the wrapper started EndSession")
 	assert.LessOrEqual(t, gotMs, afterMs, "EndTimeUnixMs must be captured at or before the wrapper returned")
+}
+
+func Test_queryActionSourcePackages(t *testing.T) {
+	newRunner := func(argsMock *xcodeargsMocks.XcodeArgsMock, capturedArgs *[]string) *xcode.XcodebuildRunner {
+		return &xcode.XcodebuildRunner{
+			Config:       xcelerate.Config{BuildCacheEnabled: true, ProxySocketPath: "/tmp/p.sock"},
+			Metadata:     common.CacheConfigMetadata{},
+			InvocationID: uuid.NewString(),
+			Logger:       mockLogger,
+			CacheLogger:  mockLogger,
+			XcodeRunner: &mocks.XcodeRunnerMock{
+				RunFunc: func(_ context.Context, args []string) xcodeargs.RunStats {
+					*capturedArgs = append([]string(nil), args...)
+
+					return xcodeargs.RunStats{}
+				},
+			},
+			ProxySessionClient: &mocks.SessionClientMock{},
+			XcodeArgs:          argsMock,
+			Paths:              paths.FromHome("/h"),
+		}
+	}
+
+	newArgs := func(resolves bool, userSPM, userDD string) *xcodeargsMocks.XcodeArgsMock {
+		return &xcodeargsMocks.XcodeArgsMock{
+			HasBuildActionFunc:              func() bool { return false },
+			ResolvesPackagesFunc:            func() bool { return resolves },
+			ClonedSourcePackagesDirPathFunc: func() string { return userSPM },
+			DerivedDataPathFunc:             func() string { return userDD },
+			ProjectDirFunc:                  func() string { return "/work/app" },
+			ProjectTempDirFunc:              func() string { return "" },
+			UserOtherCFlagsFunc:             func() string { return "" },
+			ArgsFunc:                        func(_ map[string]string) []string { return []string{"xcodebuild"} },
+			CommandFunc:                     func() string { return "xcodebuild" },
+			ShortCommandFunc:                func() string { return "xcodebuild" },
+		}
+	}
+
+	t.Run("points a resolving query action at the managed checkout dir", func(t *testing.T) {
+		var captured []string
+		r := newRunner(newArgs(true, "", ""), &captured)
+
+		_ = r.Run(context.Background())
+
+		require.Contains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
+		idx := indexOf(captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
+		require.Less(t, idx+1, len(captured))
+		// xcodebuild's own default relative to the managed DerivedData, so no new path is introduced.
+		assert.Contains(t, captured[idx+1], "/h/.bitrise/cache/xcode-dd/")
+		assert.True(t, strings.HasSuffix(captured[idx+1], "/SourcePackages"), captured[idx+1])
+	})
+
+	t.Run("follows a user-supplied derivedDataPath", func(t *testing.T) {
+		var captured []string
+		r := newRunner(newArgs(true, "", "/user/dd"), &captured)
+
+		_ = r.Run(context.Background())
+
+		idx := indexOf(captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
+		require.GreaterOrEqual(t, idx, 0)
+		assert.Equal(t, "/user/dd/SourcePackages", captured[idx+1])
+	})
+
+	t.Run("leaves a user-supplied clonedSourcePackagesDirPath alone", func(t *testing.T) {
+		var captured []string
+		r := newRunner(newArgs(true, "/user/spm", ""), &captured)
+
+		_ = r.Run(context.Background())
+
+		assert.NotContains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
+	})
+
+	t.Run("no-op for query actions that do not resolve packages", func(t *testing.T) {
+		var captured []string
+		r := newRunner(newArgs(false, "", ""), &captured)
+
+		_ = r.Run(context.Background())
+
+		assert.NotContains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
+	})
 }

--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -17,6 +17,8 @@ type XcodeArgs interface {
 	ShortCommand() string
 	HasBuildAction() bool
 	DerivedDataPath() string
+	ClonedSourcePackagesDirPath() string
+	ResolvesPackages() bool
 	ProjectTempDir() string
 	ProjectDir() string
 	UserOtherCFlags() string
@@ -152,6 +154,25 @@ func HasBuildAction(argv []string) bool {
 
 func (p Default) HasBuildAction() bool {
 	return HasBuildAction(p.OriginalArgs)
+}
+
+// packageResolvingQueryActions are query actions that still resolve the Swift package graph, so
+// their checkouts must land where the build reads them rather than in the default DerivedData.
+// Verified against Xcode 26.4.1: both accept -clonedSourcePackagesDirPath and both write checkouts.
+var packageResolvingQueryActions = []string{
+	"-resolvePackageDependencies",
+	"-list",
+}
+
+// ResolvesPackages reports whether a non-build invocation still populates SPM checkouts.
+func (p Default) ResolvesPackages() bool {
+	for _, arg := range p.OriginalArgs {
+		if slices.Contains(packageResolvingQueryActions, arg) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (p Default) ShortCommand() string {

--- a/internal/xcelerate/xcodeargs/mocks/args_mock.go
+++ b/internal/xcelerate/xcodeargs/mocks/args_mock.go
@@ -21,6 +21,9 @@ var _ xcodeargs.XcodeArgs = &XcodeArgsMock{}
 //			ArgsFunc: func(additional map[string]string) []string {
 //				panic("mock out the Args method")
 //			},
+//			ClonedSourcePackagesDirPathFunc: func() string {
+//				panic("mock out the ClonedSourcePackagesDirPath method")
+//			},
 //			CommandFunc: func() string {
 //				panic("mock out the Command method")
 //			},
@@ -35,6 +38,9 @@ var _ xcodeargs.XcodeArgs = &XcodeArgsMock{}
 //			},
 //			ProjectTempDirFunc: func() string {
 //				panic("mock out the ProjectTempDir method")
+//			},
+//			ResolvesPackagesFunc: func() bool {
+//				panic("mock out the ResolvesPackages method")
 //			},
 //			ShortCommandFunc: func() string {
 //				panic("mock out the ShortCommand method")
@@ -52,6 +58,9 @@ type XcodeArgsMock struct {
 	// ArgsFunc mocks the Args method.
 	ArgsFunc func(additional map[string]string) []string
 
+	// ClonedSourcePackagesDirPathFunc mocks the ClonedSourcePackagesDirPath method.
+	ClonedSourcePackagesDirPathFunc func() string
+
 	// CommandFunc mocks the Command method.
 	CommandFunc func() string
 
@@ -67,6 +76,9 @@ type XcodeArgsMock struct {
 	// ProjectTempDirFunc mocks the ProjectTempDir method.
 	ProjectTempDirFunc func() string
 
+	// ResolvesPackagesFunc mocks the ResolvesPackages method.
+	ResolvesPackagesFunc func() bool
+
 	// ShortCommandFunc mocks the ShortCommand method.
 	ShortCommandFunc func() string
 
@@ -79,6 +91,9 @@ type XcodeArgsMock struct {
 		Args []struct {
 			// Additional is the additional argument value.
 			Additional map[string]string
+		}
+		// ClonedSourcePackagesDirPath holds details about calls to the ClonedSourcePackagesDirPath method.
+		ClonedSourcePackagesDirPath []struct {
 		}
 		// Command holds details about calls to the Command method.
 		Command []struct {
@@ -95,6 +110,9 @@ type XcodeArgsMock struct {
 		// ProjectTempDir holds details about calls to the ProjectTempDir method.
 		ProjectTempDir []struct {
 		}
+		// ResolvesPackages holds details about calls to the ResolvesPackages method.
+		ResolvesPackages []struct {
+		}
 		// ShortCommand holds details about calls to the ShortCommand method.
 		ShortCommand []struct {
 		}
@@ -102,14 +120,16 @@ type XcodeArgsMock struct {
 		UserOtherCFlags []struct {
 		}
 	}
-	lockArgs            sync.RWMutex
-	lockCommand         sync.RWMutex
-	lockDerivedDataPath sync.RWMutex
-	lockHasBuildAction  sync.RWMutex
-	lockProjectDir      sync.RWMutex
-	lockProjectTempDir  sync.RWMutex
-	lockShortCommand    sync.RWMutex
-	lockUserOtherCFlags sync.RWMutex
+	lockArgs                        sync.RWMutex
+	lockClonedSourcePackagesDirPath sync.RWMutex
+	lockCommand                     sync.RWMutex
+	lockDerivedDataPath             sync.RWMutex
+	lockHasBuildAction              sync.RWMutex
+	lockProjectDir                  sync.RWMutex
+	lockProjectTempDir              sync.RWMutex
+	lockResolvesPackages            sync.RWMutex
+	lockShortCommand                sync.RWMutex
+	lockUserOtherCFlags             sync.RWMutex
 }
 
 // Args calls ArgsFunc.
@@ -144,6 +164,36 @@ func (mock *XcodeArgsMock) ArgsCalls() []struct {
 	mock.lockArgs.RLock()
 	calls = mock.calls.Args
 	mock.lockArgs.RUnlock()
+	return calls
+}
+
+// ClonedSourcePackagesDirPath calls ClonedSourcePackagesDirPathFunc.
+func (mock *XcodeArgsMock) ClonedSourcePackagesDirPath() string {
+	callInfo := struct {
+	}{}
+	mock.lockClonedSourcePackagesDirPath.Lock()
+	mock.calls.ClonedSourcePackagesDirPath = append(mock.calls.ClonedSourcePackagesDirPath, callInfo)
+	mock.lockClonedSourcePackagesDirPath.Unlock()
+	if mock.ClonedSourcePackagesDirPathFunc == nil {
+		var (
+			sOut string
+		)
+		return sOut
+	}
+	return mock.ClonedSourcePackagesDirPathFunc()
+}
+
+// ClonedSourcePackagesDirPathCalls gets all the calls that were made to ClonedSourcePackagesDirPath.
+// Check the length with:
+//
+//	len(mockedXcodeArgs.ClonedSourcePackagesDirPathCalls())
+func (mock *XcodeArgsMock) ClonedSourcePackagesDirPathCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockClonedSourcePackagesDirPath.RLock()
+	calls = mock.calls.ClonedSourcePackagesDirPath
+	mock.lockClonedSourcePackagesDirPath.RUnlock()
 	return calls
 }
 
@@ -294,6 +344,36 @@ func (mock *XcodeArgsMock) ProjectTempDirCalls() []struct {
 	mock.lockProjectTempDir.RLock()
 	calls = mock.calls.ProjectTempDir
 	mock.lockProjectTempDir.RUnlock()
+	return calls
+}
+
+// ResolvesPackages calls ResolvesPackagesFunc.
+func (mock *XcodeArgsMock) ResolvesPackages() bool {
+	callInfo := struct {
+	}{}
+	mock.lockResolvesPackages.Lock()
+	mock.calls.ResolvesPackages = append(mock.calls.ResolvesPackages, callInfo)
+	mock.lockResolvesPackages.Unlock()
+	if mock.ResolvesPackagesFunc == nil {
+		var (
+			bOut bool
+		)
+		return bOut
+	}
+	return mock.ResolvesPackagesFunc()
+}
+
+// ResolvesPackagesCalls gets all the calls that were made to ResolvesPackages.
+// Check the length with:
+//
+//	len(mockedXcodeArgs.ResolvesPackagesCalls())
+func (mock *XcodeArgsMock) ResolvesPackagesCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockResolvesPackages.RLock()
+	calls = mock.calls.ResolvesPackages
+	mock.lockResolvesPackages.RUnlock()
 	return calls
 }
 

--- a/internal/xcelerate/xcodeargs/prefix_map.go
+++ b/internal/xcelerate/xcodeargs/prefix_map.go
@@ -29,6 +29,10 @@ const (
 	OtherCFlagsKey              = "OTHER_CFLAGS"
 	ProjectTempDirKey           = "PROJECT_TEMP_DIR"
 	DerivedDataPathFlag         = "-derivedDataPath"
+
+	// ClonedSourcePackagesDirPathFlag is injected on package-resolving query actions.
+	// -derivedDataPath cannot be: xcodebuild rejects it without -scheme.
+	ClonedSourcePackagesDirPathFlag = "-clonedSourcePackagesDirPath"
 )
 
 // PrefixMapPaths is the set of absolute paths whose values will be rewritten
@@ -131,6 +135,12 @@ func isBitrisePrefixMapRule(token string) bool {
 // working directory — clang rejects non-absolute inputs to -fdepscan-prefix-map=.
 func (p Default) DerivedDataPath() string {
 	return absOrEmpty(findLastFlagValue(p.OriginalArgs, "derivedDataPath"))
+}
+
+// ClonedSourcePackagesDirPath returns the last -clonedSourcePackagesDirPath value from
+// OriginalArgs, in both the space and `=` forms. Missing → empty.
+func (p Default) ClonedSourcePackagesDirPath() string {
+	return absOrEmpty(findLastFlagValue(p.OriginalArgs, "clonedSourcePackagesDirPath"))
 }
 
 // ProjectTempDir returns the last PROJECT_TEMP_DIR=... build-setting value


### PR DESCRIPTION
Stacked on #445 — review that first; this PR's diff is only the query-action injection.

## Problem

`xcodebuild -list` and `xcodebuild -resolvePackageDependencies` both resolve the Swift package graph and write checkouts. The wrapper classifies them as query actions and injects nothing, so their checkouts land in the **default** DerivedData while the build reads the relocated one.

Every such invocation therefore downloads a second full copy of every package that no build will ever use. `-list` in particular is common in CI scripts, and "resolve in its own bounded step" is the mitigation we hand to customers hitting slow SPM fetches — today that advice makes them fetch twice.

## Change

Inject `-clonedSourcePackagesDirPath <derived-data>/SourcePackages` on those two actions, following a user-supplied `-derivedDataPath` when present and the managed one otherwise. Skipped when the user already passed `-clonedSourcePackagesDirPath`, and when managed DerivedData is off (`--no-prefix-map`, `NoManagedDD`, `DisablePrefixMapping`, `BuildCacheSkipFlags`) — in those cases the build uses default DerivedData and the query action should too.

## Why this is safe, given the reverted attempt

The value injected is **xcodebuild's own default relative to the DerivedData already in play**. Build actions resolve there implicitly today, so this introduces no new path into any compile command and cannot move a compilation cache key.

That is the difference from the approach reverted in #445, which invented `~/.bitrise/cache/xcode-spm` and cost 40% of the Xcode compilation cache — our prefix mapping is clang-only and the workload is Swift, so nothing canonicalised the new location.

## Verified on Xcode 26.4.1

| action | `-derivedDataPath` | `-clonedSourcePackagesDirPath` |
|---|---|---|
| `-resolvePackageDependencies` | ❌ `error: The flag -scheme, -testProductsPath, or -xctestrun is required when specifying -derivedDataPath` | ✅ accepted, wrote checkouts |
| `-list` | — | ✅ accepted, wrote checkouts |
| `-version`, `-showsdks` | — | ✅ accepted (no-op) |

That rejection is why the injection uses `-clonedSourcePackagesDirPath` rather than `-derivedDataPath`, and it confirms the existing `queryActions` comment.

The action list is deliberately limited to the two verified to write checkouts. `-showBuildSettings` and `-showdestinations` may also resolve packages, but my probe could not confirm it — they need a real workspace and scheme, which the synthetic package I tested against does not have. Worth extending once verified; the list is a one-line change.

## Testing

`make lint` clean; unit tests pass. New tests cover: injection for a resolving query action, following a user `-derivedDataPath`, leaving a user-supplied `-clonedSourcePackagesDirPath` alone, and no-op for query actions that do not resolve packages.

No e2e yet — the natural assertion is that `xcodebuild -list` leaves the default DerivedData empty, which needs a workflow that runs it. Happy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)