### PR TITLE
[ACI-5268] Allow opting out of Swift caching without losing clang caching

### DIFF
--- a/cmd/reactnative/activate_react_native.go
+++ b/cmd/reactnative/activate_react_native.go
@@ -15,6 +15,8 @@ var (
 	xcodeEnabled         bool
 	cppEnabled           bool
 	disablePrefixMapping bool
+	noSwiftCache         bool
+	buildCacheSkipFlags  bool
 )
 
 //nolint:gochecknoglobals
@@ -38,6 +40,8 @@ Note: This is a convenience activation method, if your activation requires fine-
 			XcodeEnabled:         xcodeEnabled,
 			CppEnabled:           cppEnabled,
 			DisablePrefixMapping: disablePrefixMapping,
+			NoSwiftCache:         noSwiftCache,
+			BuildCacheSkipFlags:  buildCacheSkipFlags,
 			DebugLogging:         common.IsDebugLogMode,
 		})
 
@@ -55,4 +59,6 @@ func init() {
 	activateReactNativeCmd.Flags().BoolVar(&xcodeEnabled, "xcode", true, "Activate Xcode build cache (iOS).")
 	activateReactNativeCmd.Flags().BoolVar(&cppEnabled, "cpp", true, "Activate C++ build cache via ccache (native modules).")
 	activateReactNativeCmd.Flags().BoolVar(&disablePrefixMapping, "disable-prefix-mapping", false, "Disable Clang prefix-mapping flags for the Xcode build cache (see `activate xcode --disable-prefix-mapping`).")
+	activateReactNativeCmd.Flags().BoolVar(&noSwiftCache, "no-swift-cache", false, "Cache clang/Objective-C compilation only, leaving Swift uncached (see `activate xcode --no-swift-cache`).")
+	activateReactNativeCmd.Flags().BoolVar(&buildCacheSkipFlags, "cache-skip-flags", false, "Skip passing cache flags to xcodebuild except the socket path (see `activate xcode --cache-skip-flags`).")
 }

--- a/cmd/xcode/activate_xcode.go
+++ b/cmd/xcode/activate_xcode.go
@@ -121,6 +121,11 @@ Useful if there are multiple Xcode versions installed and you want to use a spec
 		activateXcodeParams.BuildCacheSkipFlags,
 		`Skip passing cache flags to xcodebuild except the COMPILATION_CACHE_REMOTE_SERVICE_PATH.
 Cache will have to be enabled manually in the Xcode project settings.`)
+	activateXcodeCmd.Flags().BoolVar(&activateXcodeParams.NoSwiftCache,
+		"no-swift-cache",
+		activateXcodeParams.NoSwiftCache,
+		`Cache clang/Objective-C compilation only, leaving Swift uncached.
+Swift compile caching requires explicit modules, which some projects cannot build under (typically failing with "unable to resolve module dependency").`)
 	activateXcodeCmd.Flags().BoolVar(&activateXcodeParams.DisablePrefixMapping,
 		"disable-prefix-mapping",
 		activateXcodeParams.DisablePrefixMapping,

--- a/cmd/xcode/xcodebuild.go
+++ b/cmd/xcode/xcodebuild.go
@@ -692,7 +692,7 @@ func (c *XcodebuildRunner) assembleArgs() []string {
 		return c.XcodeArgs.Args(additional)
 	}
 
-	maps.Copy(additional, xcodeargs.CacheArgs)
+	maps.Copy(additional, xcodeargs.BuildCacheArgs(c.Config.NoSwiftCache))
 
 	diagnosticRemarks := "NO"
 	if c.Config.DebugLogging {

--- a/cmd/xcode/xcodebuild_test.go
+++ b/cmd/xcode/xcodebuild_test.go
@@ -602,3 +602,43 @@ func Test_queryActionSourcePackages(t *testing.T) {
 		assert.NotContains(t, captured, xcodeargs.ClonedSourcePackagesDirPathFlag)
 	})
 }
+
+func Test_xcodebuildCmdFn_NoSwiftCache(t *testing.T) {
+	var receivedAdditional map[string]string
+	xcodeArgProvider := xcodeargsMocks.XcodeArgsMock{
+		HasBuildActionFunc: func() bool { return true },
+		ArgsFunc: func(additional map[string]string) []string {
+			receivedAdditional = additional
+
+			return []string{"xcodebuild"}
+		},
+		CommandFunc:      func() string { return "xcodebuild" },
+		ShortCommandFunc: func() string { return "xcodebuild" },
+	}
+
+	SUT := &xcode.XcodebuildRunner{
+		Config: xcelerate.Config{
+			BuildCacheEnabled: true,
+			NoSwiftCache:      true,
+			ProxySocketPath:   "/tmp/proxy.sock",
+		},
+		Metadata:     common.CacheConfigMetadata{},
+		InvocationID: uuid.NewString(),
+		Logger:       mockLogger,
+		CacheLogger:  mockLogger,
+		XcodeRunner: &mocks.XcodeRunnerMock{
+			RunFunc: func(_ context.Context, _ []string) xcodeargs.RunStats { return xcodeargs.RunStats{} },
+		},
+		ProxySessionClient: &mocks.SessionClientMock{},
+		XcodeArgs:          &xcodeArgProvider,
+	}
+
+	_ = SUT.Run(context.Background())
+
+	assert.Equal(t, "NO", receivedAdditional[xcodeargs.SwiftEnableExplicitModulesKey])
+	assert.Equal(t, "NO", receivedAdditional[xcodeargs.SwiftEnableCompileCacheKey])
+	assert.NotContains(t, receivedAdditional, xcodeargs.SwiftUseIntegratedDriverKey)
+	assert.Equal(t, "c c++ objective-c objective-c++", receivedAdditional[xcodeargs.SupportedLanguagesKey])
+	assert.Equal(t, "YES", receivedAdditional["CLANG_ENABLE_COMPILE_CACHE"])
+	assert.Equal(t, "/tmp/proxy.sock", receivedAdditional["COMPILATION_CACHE_REMOTE_SERVICE_PATH"])
+}

--- a/internal/config/xcelerate/config.go
+++ b/internal/config/xcelerate/config.go
@@ -30,6 +30,7 @@ type Params struct {
 	BuildCacheEnabled           bool
 	BuildCacheEndpoint          string
 	BuildCacheSkipFlags         bool
+	NoSwiftCache                bool
 	DisablePrefixMapping        bool
 	DebugLogging                bool
 	Silent                      bool
@@ -56,6 +57,7 @@ type Config struct {
 	OriginalXcrunPath      string    `json:"originalXcrunPath"`
 	BuildCacheEnabled      bool      `json:"buildCacheEnabled"`
 	BuildCacheSkipFlags    bool      `json:"buildCacheSkipFlags"`
+	NoSwiftCache           bool      `json:"noSwiftCache,omitempty"`
 	DisablePrefixMapping   bool      `json:"disablePrefixMapping,omitempty"`
 	BuildCacheEndpoint     string    `json:"buildCacheEndpoint"`
 	PushEnabled            bool      `json:"pushEnabled"`
@@ -101,6 +103,7 @@ func DefaultParams() Params {
 	return Params{
 		BuildCacheEnabled:           true,
 		BuildCacheSkipFlags:         false,
+		NoSwiftCache:                false,
 		DisablePrefixMapping:        false,
 		BuildCacheEndpoint:          "",
 		Silent:                      false,
@@ -203,6 +206,7 @@ func NewConfig(ctx context.Context,
 		OriginalXcrunPath:      xcrunPath,
 		BuildCacheEnabled:      params.BuildCacheEnabled,
 		BuildCacheSkipFlags:    params.BuildCacheSkipFlags,
+		NoSwiftCache:           params.NoSwiftCache,
 		DisablePrefixMapping:   params.DisablePrefixMapping,
 		BuildCacheEndpoint:     params.BuildCacheEndpoint,
 		PushEnabled:            params.PushEnabled,

--- a/internal/xcelerate/xcodeargs/args.go
+++ b/internal/xcelerate/xcodeargs/args.go
@@ -2,6 +2,7 @@
 package xcodeargs
 
 import (
+	"maps"
 	"slices"
 	"strings"
 
@@ -24,6 +25,16 @@ type XcodeArgs interface {
 	UserOtherCFlags() string
 }
 
+const (
+	SwiftEnableCompileCacheKey    = "SWIFT_ENABLE_COMPILE_CACHE"
+	SwiftEnableExplicitModulesKey = "SWIFT_ENABLE_EXPLICIT_MODULES"
+	SwiftUseIntegratedDriverKey   = "SWIFT_USE_INTEGRATED_DRIVER"
+	SupportedLanguagesKey         = "COMPILATION_CACHE_REMOTE_SUPPORTED_LANGUAGES"
+
+	cachedLanguages = "swift c c++ objective-c objective-c++"
+	swiftLanguage   = "swift"
+)
+
 // Xcode 26 gates the compile-cache plugin behind the master toggle
 // COMPILATION_CACHE_ENABLE_CACHING. Without it, SwiftBuild resolves the
 // individual COMPILATION_CACHE_* keys but never emits -cache-compile-job on
@@ -34,12 +45,33 @@ var CacheArgs = map[string]string{
 	"COMPILATION_CACHE_ENABLE_PLUGIN":               "YES",
 	"COMPILATION_CACHE_ENABLE_INTEGRATED_QUERIES":   "YES",
 	"COMPILATION_CACHE_ENABLE_DETACHED_KEY_QUERIES": "YES",
-	"SWIFT_ENABLE_COMPILE_CACHE":                    "YES",
-	"SWIFT_ENABLE_EXPLICIT_MODULES":                 "YES",
-	"SWIFT_USE_INTEGRATED_DRIVER":                   "YES",
+	SwiftEnableCompileCacheKey:                      "YES",
+	SwiftEnableExplicitModulesKey:                   "YES",
+	SwiftUseIntegratedDriverKey:                     "YES",
 	"CLANG_ENABLE_COMPILE_CACHE":                    "YES",
 	"CLANG_ENABLE_MODULES":                          "YES",
-	"COMPILATION_CACHE_REMOTE_SUPPORTED_LANGUAGES":  "swift c c++ objective-c objective-c++",
+	SupportedLanguagesKey:                           cachedLanguages,
+}
+
+// BuildCacheArgs returns the wrapper-owned build settings for a cached build.
+// noSwiftCache drops the whole Swift leg because Swift caching requires
+// explicit modules, which some projects cannot build under.
+func BuildCacheArgs(noSwiftCache bool) map[string]string {
+	args := maps.Clone(CacheArgs)
+	if !noSwiftCache {
+		return args
+	}
+
+	args[SwiftEnableCompileCacheKey] = "NO"
+	args[SwiftEnableExplicitModulesKey] = "NO"
+	// Left to the project: caching needs the integrated driver, not caching doesn't need the legacy one.
+	delete(args, SwiftUseIntegratedDriverKey)
+	args[SupportedLanguagesKey] = strings.Join(
+		slices.DeleteFunc(strings.Fields(cachedLanguages), func(lang string) bool { return lang == swiftLanguage }),
+		" ",
+	)
+
+	return args
 }
 
 // buildActions is the subset of xcodebuild action keywords that trigger an

--- a/internal/xcelerate/xcodeargs/args_test.go
+++ b/internal/xcelerate/xcodeargs/args_test.go
@@ -399,3 +399,33 @@ func Test_HasBuildAction(t *testing.T) {
 		})
 	}
 }
+
+func Test_BuildCacheArgs(t *testing.T) {
+	t.Run("default keeps the Swift leg on", func(t *testing.T) {
+		args := xcodeargs.BuildCacheArgs(false)
+
+		assert.Equal(t, xcodeargs.CacheArgs, args)
+	})
+
+	t.Run("noSwiftCache turns Swift off and keeps clang caching", func(t *testing.T) {
+		args := xcodeargs.BuildCacheArgs(true)
+
+		assert.Equal(t, "NO", args[xcodeargs.SwiftEnableCompileCacheKey])
+		assert.Equal(t, "NO", args[xcodeargs.SwiftEnableExplicitModulesKey])
+		assert.NotContains(t, args, xcodeargs.SwiftUseIntegratedDriverKey)
+		assert.Equal(t, "c c++ objective-c objective-c++", args[xcodeargs.SupportedLanguagesKey])
+
+		assert.Equal(t, "YES", args["CLANG_ENABLE_COMPILE_CACHE"])
+		assert.Equal(t, "YES", args["CLANG_ENABLE_MODULES"])
+		assert.Equal(t, "YES", args["COMPILATION_CACHE_ENABLE_CACHING"])
+		assert.Equal(t, "YES", args["COMPILATION_CACHE_ENABLE_PLUGIN"])
+	})
+
+	t.Run("does not mutate CacheArgs", func(t *testing.T) {
+		_ = xcodeargs.BuildCacheArgs(true)
+
+		assert.Equal(t, "YES", xcodeargs.CacheArgs[xcodeargs.SwiftEnableExplicitModulesKey])
+		assert.Equal(t, "YES", xcodeargs.CacheArgs[xcodeargs.SwiftUseIntegratedDriverKey])
+		assert.Equal(t, "swift c c++ objective-c objective-c++", xcodeargs.CacheArgs[xcodeargs.SupportedLanguagesKey])
+	})
+}

--- a/pkg/reactnative/activator.go
+++ b/pkg/reactnative/activator.go
@@ -34,6 +34,8 @@ type ActivatorParams struct {
 	XcodeEnabled         bool
 	CppEnabled           bool
 	DisablePrefixMapping bool
+	NoSwiftCache         bool
+	BuildCacheSkipFlags  bool
 	DebugLogging         bool
 
 	// Logger overrides the default logger. If nil, a default logger is created.
@@ -67,7 +69,13 @@ func NewActivator(params ActivatorParams) *Activator {
 	}
 
 	if params.XcodeEnabled {
-		a.xcode = &xcodeActivator{logger: logger, debugLogging: params.DebugLogging, disablePrefixMapping: params.DisablePrefixMapping}
+		a.xcode = &xcodeActivator{
+			logger:               logger,
+			debugLogging:         params.DebugLogging,
+			disablePrefixMapping: params.DisablePrefixMapping,
+			noSwiftCache:         params.NoSwiftCache,
+			buildCacheSkipFlags:  params.BuildCacheSkipFlags,
+		}
 	}
 
 	// ccache only meaningfully wraps the Android/Gradle native build path in
@@ -306,12 +314,16 @@ type xcodeActivator struct {
 	logger               log.Logger
 	debugLogging         bool
 	disablePrefixMapping bool
+	noSwiftCache         bool
+	buildCacheSkipFlags  bool
 }
 
 func (x *xcodeActivator) activate(ctx context.Context) error {
 	xcodeParams := xcelerate.DefaultParams()
 	xcodeParams.DebugLogging = x.debugLogging
 	xcodeParams.DisablePrefixMapping = x.disablePrefixMapping
+	xcodeParams.NoSwiftCache = x.noSwiftCache
+	xcodeParams.BuildCacheSkipFlags = x.buildCacheSkipFlags
 
 	if err := xcelerate.Activate(
 		ctx,


### PR DESCRIPTION
[ACI-5268](https://bitrise.atlassian.net/browse/ACI-5268)

## Summary

The wrapper injects `SWIFT_ENABLE_EXPLICIT_MODULES=YES` into every wrapped build, so projects that can't build under Swift explicit modules fail *because* the cache is on. This broke **ahm (Medibank)**: archive failed with `unable to resolve module dependency: 'React_RCTAppDelegate'` on a 100% warm cache (5212/5212 blob hits, 0 B uploaded), and they turned the iOS leg off within three days.

This is not exotic to their project — a stock `@react-native-community/cli` 0.86.2 app reproduces it (see Testing). The template's `AppDelegate.swift` imports `React_RCTAppDelegate` and the template Podfile is static-linkage by default, so every default RN app on an activated machine hits this.

The existing `--cache-skip-flags` (ACI-4284) is all-or-nothing — it drops every cache setting and expects the customer to configure caching in the Xcode project — and was never plumbed through React Native activation, so RN customers had no opt-out at all.

`--no-swift-cache` drops the Swift leg and keeps clang/Objective-C caching, which is the bulk of an RN app's compile units.

## Changes

- `xcodeargs.BuildCacheArgs(noSwiftCache)` replaces the direct `maps.Copy(additional, xcodeargs.CacheArgs)` in `assembleArgs`. Opt-out sets `SWIFT_ENABLE_EXPLICIT_MODULES=NO` / `SWIFT_ENABLE_COMPILE_CACHE=NO` and drops `swift` from `COMPILATION_CACHE_REMOTE_SUPPORTED_LANGUAGES`. `CacheArgs` is cloned, never mutated.
- `--no-swift-cache` on `activate xcode`, plumbed through `xcelerate.Params` → `Config`.
- `--no-swift-cache` on `activate react-native`, plus `--cache-skip-flags` now plumbed through RN activation — it was previously unreachable there.

## Testing

`make lint` 0 issues, `make test-unit` green. New: `Test_BuildCacheArgs` (default unchanged, opt-out flips the Swift keys, `CacheArgs` not mutated) and `Test_xcodebuildCmdFn_NoSwiftCache` (the config field reaches the build settings).

Verified end-to-end on a real project — `npx @react-native-community/cli@latest init RNRepro --install-pods`, RN 0.86.2, Xcode 26.4.1, Release build for `generic/platform=iOS`:

| Run | Bitrise involved? | Extra settings | Result |
|---|---|---|---|
| Raw baseline | no (`/usr/bin/xcodebuild`) | none | BUILD SUCCEEDED |
| Raw, single variable | no | `SWIFT_ENABLE_EXPLICIT_MODULES=YES` | FAILED, exit 65 |
| Wrapper, stock | yes (shim injects `CacheArgs`) | none | FAILED, exit 65 |
| Wrapper + this fix's values | yes | `BuildCacheArgs(true)` output | BUILD SUCCEEDED |

Both failures are the customer's exact error at `AppDelegate.swift:3:8`. The passing fix run kept `CLANG_ENABLE_COMPILE_CACHE=YES` and languages `c c++ objective-c objective-c++`, so it isn't passing by disabling everything.

## Notes for reviewers

- `SWIFT_USE_INTEGRATED_DRIVER` is dropped from the injected settings rather than forced to `NO` — caching needs the integrated driver, but not caching doesn't need the legacy one. Project default wins.
- One flag for the whole Swift leg, not per-setting overrides: Swift caching requires explicit modules, so there is no useful "explicit modules off, Swift caching on" state.
- Follow-ups on the ticket, not here: matching step inputs on `activate-build-cache-for-xcode` and `activate-build-cache-for-react-native` (until those land the flag is unreachable for step users, which is the gap that broke ahm), and a wrapper-side hint on `unable to resolve module dependency`, deferred until the RN doctor gating (#444) lands.
- Reproduction recipe is on ACI-5268 if anyone wants to re-run it.


[ACI-5268]: https://bitrise.atlassian.net/browse/ACI-5268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ