### PR TITLE
[ACI-5241] Make ccache work for local React Native builds, and stop activate destroying the login

### DIFF
--- a/internal/auth/store/persist.go
+++ b/internal/auth/store/persist.go
@@ -21,8 +21,8 @@ func PersistActivateCreds(logger log.Logger, envs map[string]string, auth config
 	persistActivateCredsTo(logger, SelectAuto(envs), auth, mpCfg)
 }
 
-// persistActivateCredsTo takes the target store so the keychain-refused branch is
-// testable without a real keychain.
+// persistActivateCredsTo takes the store so tests can refuse a write without a
+// real keychain.
 func persistActivateCredsTo(logger log.Logger, target Store, auth configcommon.CacheAuthConfig, mpCfg *multiplatformconfig.Config) {
 	if target.Kind() == KindFile {
 		persistToFile(auth, mpCfg)
@@ -31,8 +31,7 @@ func persistActivateCredsTo(logger log.Logger, target Store, auth configcommon.C
 		return
 	}
 	if err := target.Save(mergeActivateCreds(target, auth)); err != nil {
-		// AuthConfig alone has no room for the refresh token, and a host without a
-		// keychain still has the config file.
+		// AuthConfig has no room for the refresh token; the config file does.
 		logger.Warnf("Keychain save failed (%v); saving to the multiplatform config file instead", err)
 		persistToFile(auth, mpCfg)
 
@@ -41,23 +40,17 @@ func persistActivateCredsTo(logger log.Logger, target Store, auth configcommon.C
 	logger.Infof("Saved auth credentials to the OS keychain")
 }
 
-// persistToFile writes the full credential to Credentials, keeping AuthConfig in
-// step for readers that still use it. Merging against the file store is the point:
-// merging against an unreadable keychain is what yields a bare token.
+// Merges against the file store, not the caller's: merging against an unreadable
+// keychain is what yields a bare token.
 func persistToFile(auth configcommon.CacheAuthConfig, mpCfg *multiplatformconfig.Config) {
 	c := mergeActivateCreds(NewFile(), auth)
 	mpCfg.Credentials = &c
 	mpCfg.AuthConfig = auth
 }
 
-// mergeActivateCreds re-persists a resolved credential without downgrading what is
-// stored: activate is not the authority on what the credential is — `auth set` and
-// `auth login` are, via SaveExclusive.
-//
-// The token is deliberately not compared. A login's PAT is short-lived and gets
-// refreshed, so the resolved token routinely differs from the stored one; treating
-// that as a different credential discarded the refresh token, leaving the login
-// unable to refresh and dead at the PAT's expiry.
+// The tokens are deliberately not compared: a login's PAT is short-lived and gets
+// refreshed, so a mismatch is normal, and treating it as a different credential
+// discarded the refresh token.
 func mergeActivateCreds(target Store, auth configcommon.CacheAuthConfig) keychain.Credentials {
 	existing, err := target.Load()
 	if err != nil {

--- a/internal/auth/store/persist.go
+++ b/internal/auth/store/persist.go
@@ -21,8 +21,8 @@ func PersistActivateCreds(logger log.Logger, envs map[string]string, auth config
 	persistActivateCredsTo(logger, SelectAuto(envs), auth, mpCfg)
 }
 
-// persistActivateCredsTo is PersistActivateCreds with the target store supplied,
-// so the keychain-refused branch is testable without a real keychain.
+// persistActivateCredsTo takes the target store so the keychain-refused branch is
+// testable without a real keychain.
 func persistActivateCredsTo(logger log.Logger, target Store, auth configcommon.CacheAuthConfig, mpCfg *multiplatformconfig.Config) {
 	if target.Kind() == KindFile {
 		persistToFile(auth, mpCfg)
@@ -31,9 +31,8 @@ func persistActivateCredsTo(logger log.Logger, target Store, auth configcommon.C
 		return
 	}
 	if err := target.Save(mergeActivateCreds(target, auth)); err != nil {
-		// Writing only AuthConfig here would strand the credential in a shape that
-		// has no refresh token, so the login degrades to a bare PAT and dies when it
-		// expires. A host with no usable keychain still has the config file.
+		// AuthConfig alone has no room for the refresh token, and a host without a
+		// keychain still has the config file.
 		logger.Warnf("Keychain save failed (%v); saving to the multiplatform config file instead", err)
 		persistToFile(auth, mpCfg)
 
@@ -42,12 +41,9 @@ func persistActivateCredsTo(logger log.Logger, target Store, auth configcommon.C
 	logger.Infof("Saved auth credentials to the OS keychain")
 }
 
-// persistToFile writes the full credential to the config file's Credentials
-// block, keeping AuthConfig in step for downstream readers that still use it.
-//
-// The merge is against the file store on purpose: merging against an unusable
-// keychain reads nothing and yields a bare token, which is precisely how the
-// refresh token gets lost.
+// persistToFile writes the full credential to Credentials, keeping AuthConfig in
+// step for readers that still use it. Merging against the file store is the point:
+// merging against an unreadable keychain is what yields a bare token.
 func persistToFile(auth configcommon.CacheAuthConfig, mpCfg *multiplatformconfig.Config) {
 	c := mergeActivateCreds(NewFile(), auth)
 	mpCfg.Credentials = &c
@@ -55,14 +51,13 @@ func persistToFile(auth configcommon.CacheAuthConfig, mpCfg *multiplatformconfig
 }
 
 // mergeActivateCreds re-persists a resolved credential without downgrading what is
-// already stored. activate is not the authority on what the credential *is* —
-// `auth set` and `auth login` are, and they go through SaveExclusive — so it keeps
-// the OAuth fields of an existing login and only updates the token and workspace.
+// stored: activate is not the authority on what the credential is — `auth set` and
+// `auth login` are, via SaveExclusive.
 //
-// The token is deliberately not compared: a PAT minted by a login is short-lived
-// and gets refreshed, so the resolved token routinely differs from the stored one.
-// Treating that as a different credential dropped the refresh token, leaving the
-// login unable to refresh and dead at the PAT's expiry.
+// The token is deliberately not compared. A login's PAT is short-lived and gets
+// refreshed, so the resolved token routinely differs from the stored one; treating
+// that as a different credential discarded the refresh token, leaving the login
+// unable to refresh and dead at the PAT's expiry.
 func mergeActivateCreds(target Store, auth configcommon.CacheAuthConfig) keychain.Credentials {
 	existing, err := target.Load()
 	if err != nil {

--- a/internal/auth/store/persist.go
+++ b/internal/auth/store/persist.go
@@ -54,16 +54,18 @@ func persistToFile(auth configcommon.CacheAuthConfig, mpCfg *multiplatformconfig
 	mpCfg.AuthConfig = auth
 }
 
-// mergeActivateCreds keeps the OAuth fields and username of an existing entry
-// when activate re-persists the same token. Replacing the entry outright would
-// drop the refresh token, which both breaks `auth logout` and leaves the login
-// unable to refresh — degrading it to a bare, short-lived PAT.
+// mergeActivateCreds re-persists a resolved credential without downgrading what is
+// already stored. activate is not the authority on what the credential *is* —
+// `auth set` and `auth login` are, and they go through SaveExclusive — so it keeps
+// the OAuth fields of an existing login and only updates the token and workspace.
 //
-// A different token means a different credential, so the OAuth fields are not
-// carried over: they would not describe the token being stored.
+// The token is deliberately not compared: a PAT minted by a login is short-lived
+// and gets refreshed, so the resolved token routinely differs from the stored one.
+// Treating that as a different credential dropped the refresh token, leaving the
+// login unable to refresh and dead at the PAT's expiry.
 func mergeActivateCreds(target Store, auth configcommon.CacheAuthConfig) keychain.Credentials {
 	existing, err := target.Load()
-	if err != nil || existing.AuthToken != auth.AuthToken {
+	if err != nil {
 		return keychain.Credentials{AuthToken: auth.AuthToken, WorkspaceID: auth.WorkspaceID}
 	}
 

--- a/internal/auth/store/persist.go
+++ b/internal/auth/store/persist.go
@@ -18,22 +18,40 @@ func PersistActivateCreds(logger log.Logger, envs map[string]string, auth config
 
 		return
 	}
-	target := SelectAuto(envs)
+	persistActivateCredsTo(logger, SelectAuto(envs), auth, mpCfg)
+}
+
+// persistActivateCredsTo is PersistActivateCreds with the target store supplied,
+// so the keychain-refused branch is testable without a real keychain.
+func persistActivateCredsTo(logger log.Logger, target Store, auth configcommon.CacheAuthConfig, mpCfg *multiplatformconfig.Config) {
 	if target.Kind() == KindFile {
-		c := mergeActivateCreds(target, auth)
-		mpCfg.Credentials = &c
-		mpCfg.AuthConfig = auth
+		persistToFile(auth, mpCfg)
 		logger.Infof("Saved auth credentials to the multiplatform config file (CI-safe — fastlane setup_ci swaps the keychain)")
 
 		return
 	}
 	if err := target.Save(mergeActivateCreds(target, auth)); err != nil {
-		logger.Warnf("Keychain save failed (%v); falling back to multiplatform authConfig", err)
-		mpCfg.AuthConfig = auth
+		// Writing only AuthConfig here would strand the credential in a shape that
+		// has no refresh token, so the login degrades to a bare PAT and dies when it
+		// expires. A host with no usable keychain still has the config file.
+		logger.Warnf("Keychain save failed (%v); saving to the multiplatform config file instead", err)
+		persistToFile(auth, mpCfg)
 
 		return
 	}
 	logger.Infof("Saved auth credentials to the OS keychain")
+}
+
+// persistToFile writes the full credential to the config file's Credentials
+// block, keeping AuthConfig in step for downstream readers that still use it.
+//
+// The merge is against the file store on purpose: merging against an unusable
+// keychain reads nothing and yields a bare token, which is precisely how the
+// refresh token gets lost.
+func persistToFile(auth configcommon.CacheAuthConfig, mpCfg *multiplatformconfig.Config) {
+	c := mergeActivateCreds(NewFile(), auth)
+	mpCfg.Credentials = &c
+	mpCfg.AuthConfig = auth
 }
 
 // mergeActivateCreds keeps the OAuth fields and username of an existing entry

--- a/internal/auth/store/persist_merge_test.go
+++ b/internal/auth/store/persist_merge_test.go
@@ -87,10 +87,8 @@ func TestMergeActivateCreds_KeepsOAuthFieldsAcrossWorkspaceChange(t *testing.T) 
 	assert.Equal(t, "refresh-1", got.RefreshToken)
 }
 
-// A refreshed PAT is the same credential. The stored token routinely differs from
-// the resolved one — the login mints short-lived PATs and refreshes them — so
-// comparing tokens here is what discarded the refresh token and killed the login
-// at expiry. activate re-persists; it does not redefine.
+// A refreshed PAT is the same credential, and refreshing is the normal case
+// between login and activate.
 func TestMergeActivateCreds_KeepsOAuthFieldsWhenTheTokenWasRefreshed(t *testing.T) {
 	s := &memStore{kind: KindKeychain, present: true, creds: keychain.Credentials{
 		AuthToken: "pat-1", WorkspaceID: "ws-1", RefreshToken: "refresh-1", JWT: "jwt-1", Username: "dev",
@@ -114,12 +112,8 @@ func TestMergeActivateCreds_EmptyStore(t *testing.T) {
 	assert.Equal(t, "ws-1", got.WorkspaceID)
 }
 
-// A host with no usable OS keychain (headless Linux, containers) is where the
-// browser login lands in the config file. Activation must not overwrite that with
-// the 3-field AuthConfig shape: the refresh token lives only in Credentials, and
-// without it the login degrades to a bare PAT that dies at expiry with nothing
-// able to renew it. Observed on an RDE — `activate` ran, the refresh token
-// vanished, and the storage helper later refused to start on `unauthenticated`.
+// A headless host keeps its login in the config file, so activation must write the
+// full credential there rather than the 3-field AuthConfig shape.
 func TestPersistActivateCreds_KeychainUnusableKeepsTheRefreshToken(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/auth/store/persist_merge_test.go
+++ b/internal/auth/store/persist_merge_test.go
@@ -3,20 +3,28 @@
 package store
 
 import (
+	"errors"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bitrise-io/go-utils/v2/log"
+
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
 )
+
+func newTestLogger() log.Logger { return log.NewLogger(log.WithOutput(io.Discard)) }
 
 type memStore struct {
 	creds   keychain.Credentials
 	present bool
 	kind    Kind
+	saveErr error
 }
 
 func (m *memStore) Kind() Kind { return m.kind }
@@ -30,6 +38,9 @@ func (m *memStore) Load() (keychain.Credentials, error) {
 }
 
 func (m *memStore) Save(c keychain.Credentials) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
 	m.creds, m.present = c, true
 
 	return nil
@@ -98,4 +109,39 @@ func TestMergeActivateCreds_EmptyStore(t *testing.T) {
 
 	assert.Equal(t, "pat-1", got.AuthToken)
 	assert.Equal(t, "ws-1", got.WorkspaceID)
+}
+
+// A host with no usable OS keychain (headless Linux, containers) is where the
+// browser login lands in the config file. Activation must not overwrite that with
+// the 3-field AuthConfig shape: the refresh token lives only in Credentials, and
+// without it the login degrades to a bare PAT that dies at expiry with nothing
+// able to renew it. Observed on an RDE — `activate` ran, the refresh token
+// vanished, and the storage helper later refused to start on `unauthenticated`.
+func TestPersistActivateCreds_KeychainUnusableKeepsTheRefreshToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	login := keychain.Credentials{
+		AuthToken:          "bitpat_minted",
+		WorkspaceID:        "ws-1",
+		RefreshToken:       "refresh-me",
+		RefreshTokenExpiry: time.Now().Add(24 * time.Hour),
+		Username:           "dev",
+	}
+	require.NoError(t, NewFile().Save(login))
+
+	// A keychain that refuses every write, as a host with no secret-service has.
+	deadKeychain := &memStore{kind: KindKeychain, saveErr: errors.New("no usable OS keychain on this machine")}
+
+	var mpCfg multiplatformconfig.Config
+	persistActivateCredsTo(
+		newTestLogger(),
+		deadKeychain,
+		configcommon.CacheAuthConfig{AuthToken: "bitpat_minted", WorkspaceID: "ws-1"},
+		&mpCfg,
+	)
+
+	require.NotNil(t, mpCfg.Credentials, "the full credential must be written, not just AuthConfig")
+	assert.Equal(t, "refresh-me", mpCfg.Credentials.RefreshToken, "without this the login cannot refresh")
+	assert.Equal(t, "dev", mpCfg.Credentials.Username)
+	assert.Equal(t, "bitpat_minted", mpCfg.AuthConfig.AuthToken, "downstream readers still use AuthConfig")
 }

--- a/internal/auth/store/persist_merge_test.go
+++ b/internal/auth/store/persist_merge_test.go
@@ -87,8 +87,7 @@ func TestMergeActivateCreds_KeepsOAuthFieldsAcrossWorkspaceChange(t *testing.T) 
 	assert.Equal(t, "refresh-1", got.RefreshToken)
 }
 
-// A refreshed PAT is the same credential, and refreshing is the normal case
-// between login and activate.
+// Refreshing is the normal case between login and activate.
 func TestMergeActivateCreds_KeepsOAuthFieldsWhenTheTokenWasRefreshed(t *testing.T) {
 	s := &memStore{kind: KindKeychain, present: true, creds: keychain.Credentials{
 		AuthToken: "pat-1", WorkspaceID: "ws-1", RefreshToken: "refresh-1", JWT: "jwt-1", Username: "dev",
@@ -112,8 +111,8 @@ func TestMergeActivateCreds_EmptyStore(t *testing.T) {
 	assert.Equal(t, "ws-1", got.WorkspaceID)
 }
 
-// A headless host keeps its login in the config file, so activation must write the
-// full credential there rather than the 3-field AuthConfig shape.
+// A headless host keeps its login in the config file, so the full credential has
+// to land there and not in the 3-field AuthConfig.
 func TestPersistActivateCreds_KeychainUnusableKeepsTheRefreshToken(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/auth/store/persist_merge_test.go
+++ b/internal/auth/store/persist_merge_test.go
@@ -87,19 +87,22 @@ func TestMergeActivateCreds_KeepsOAuthFieldsAcrossWorkspaceChange(t *testing.T) 
 	assert.Equal(t, "refresh-1", got.RefreshToken)
 }
 
-// A different token is a different credential, so OAuth fields that described
-// the old one must not be carried over.
-func TestMergeActivateCreds_DropsOAuthFieldsForADifferentToken(t *testing.T) {
+// A refreshed PAT is the same credential. The stored token routinely differs from
+// the resolved one — the login mints short-lived PATs and refreshes them — so
+// comparing tokens here is what discarded the refresh token and killed the login
+// at expiry. activate re-persists; it does not redefine.
+func TestMergeActivateCreds_KeepsOAuthFieldsWhenTheTokenWasRefreshed(t *testing.T) {
 	s := &memStore{kind: KindKeychain, present: true, creds: keychain.Credentials{
-		AuthToken: "pat-1", WorkspaceID: "ws-1", RefreshToken: "refresh-1", JWT: "jwt-1",
+		AuthToken: "pat-1", WorkspaceID: "ws-1", RefreshToken: "refresh-1", JWT: "jwt-1", Username: "dev",
 	}}
 
 	got := mergeActivateCreds(s, configcommon.CacheAuthConfig{AuthToken: "pat-2", WorkspaceID: "ws-1"})
 
-	assert.Equal(t, "pat-2", got.AuthToken)
-	assert.Empty(t, got.RefreshToken)
-	assert.Empty(t, got.JWT)
-	assert.False(t, got.IsOAuthManaged())
+	assert.Equal(t, "pat-2", got.AuthToken, "the freshly resolved token wins")
+	assert.Equal(t, "refresh-1", got.RefreshToken, "without this the login cannot refresh again")
+	assert.Equal(t, "jwt-1", got.JWT)
+	assert.Equal(t, "dev", got.Username)
+	assert.True(t, got.IsOAuthManaged())
 }
 
 func TestMergeActivateCreds_EmptyStore(t *testing.T) {

--- a/internal/config/ccache/config.go
+++ b/internal/config/ccache/config.go
@@ -143,6 +143,20 @@ func (config Config) CRSHRemoteStorageURL() string {
 		config.IPCEndpoint, defaultCRSHDataTimeout, defaultCRSHRequestTimeout)
 }
 
+// BuildEnv is the environment ccache needs to route through the storage helper.
+// Both delivery paths use it — envman on CI, the wrapped build's own environment
+// off it — so the two cannot drift.
+func (config Config) BuildEnv(baseDir string) map[string]string {
+	return map[string]string{
+		"CCACHE_BASEDIR":              baseDir,
+		"CCACHE_NOHASHDIR":            "true",
+		"CCACHE_REMOTE_ONLY":          "true",
+		"CCACHE_REMOTE_STORAGE":       config.CRSHRemoteStorageURL(),
+		"CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+		"CMAKE_C_COMPILER_LAUNCHER":   "ccache",
+	}
+}
+
 func (config Config) Save(logger log.Logger, osProxy utils.OsProxy, encoderFactory utils.EncoderFactory) error {
 	ccacheDir := DirPath(osProxy)
 	if err := osProxy.MkdirAll(ccacheDir, 0o755); err != nil {

--- a/internal/config/ccache/config.go
+++ b/internal/config/ccache/config.go
@@ -143,9 +143,8 @@ func (config Config) CRSHRemoteStorageURL() string {
 		config.IPCEndpoint, defaultCRSHDataTimeout, defaultCRSHRequestTimeout)
 }
 
-// BuildEnv is the environment ccache needs to route through the storage helper.
-// Both delivery paths use it — envman on CI, the wrapped build's own environment
-// off it — so the two cannot drift.
+// BuildEnv serves both delivery paths — envman on CI, the wrapped build's own
+// environment off it — so the two cannot drift.
 func (config Config) BuildEnv(baseDir string) map[string]string {
 	return map[string]string{
 		"CCACHE_BASEDIR":              baseDir,

--- a/pkg/ccache/activator.go
+++ b/pkg/ccache/activator.go
@@ -132,16 +132,7 @@ func (a *Activator) Activate(ctx context.Context) error {
 		}
 	}
 
-	envVars := map[string]string{
-		"CCACHE_BASEDIR":              baseDir,
-		"CCACHE_NOHASHDIR":            "true",
-		"CCACHE_REMOTE_ONLY":          "true",
-		"CCACHE_REMOTE_STORAGE":       config.CRSHRemoteStorageURL(),
-		"CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
-		"CMAKE_C_COMPILER_LAUNCHER":   "ccache",
-	}
-
-	for key, value := range envVars {
+	for key, value := range config.BuildEnv(baseDir) {
 		addEnvVarToEnvman(ctx, a.commandFunc, key, value, a.logger)
 	}
 

--- a/pkg/reactnative/activator.go
+++ b/pkg/reactnative/activator.go
@@ -360,10 +360,8 @@ func saveMultiplatformConfig(debugLogging bool) error {
 		return fmt.Errorf("resolve auth config for multiplatform analytics: %w", err)
 	}
 
-	// Read first: Save rewrites the whole file, so building a fresh Config here
-	// erases the Credentials block — the only place the browser login's refresh
-	// token lives on a host with no usable keychain. Losing it degrades the login
-	// to a bare PAT that dies at expiry with nothing able to renew it.
+	// Read first: Save rewrites the whole file, so a fresh Config here erases the
+	// Credentials block — where a keychain-less host keeps its refresh token.
 	cfg, err := multiplatformconfig.ReadConfig(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
 	if err != nil {
 		cfg = multiplatformconfig.Config{}

--- a/pkg/reactnative/activator.go
+++ b/pkg/reactnative/activator.go
@@ -360,10 +360,17 @@ func saveMultiplatformConfig(debugLogging bool) error {
 		return fmt.Errorf("resolve auth config for multiplatform analytics: %w", err)
 	}
 
-	cfg := multiplatformconfig.Config{
-		AuthConfig:   authConfig,
-		DebugLogging: debugLogging,
+	// Read first: Save rewrites the whole file, so building a fresh Config here
+	// erases the Credentials block — the only place the browser login's refresh
+	// token lives on a host with no usable keychain. Losing it degrades the login
+	// to a bare PAT that dies at expiry with nothing able to renew it.
+	cfg, err := multiplatformconfig.ReadConfig(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
+	if err != nil {
+		cfg = multiplatformconfig.Config{}
 	}
+
+	cfg.AuthConfig = authConfig
+	cfg.DebugLogging = debugLogging
 
 	if err := cfg.Save(utils.DefaultOsProxy{}, utils.DefaultEncoderFactory{}); err != nil {
 		return fmt.Errorf("save multiplatform analytics config: %w", err)

--- a/pkg/reactnative/activator_test.go
+++ b/pkg/reactnative/activator_test.go
@@ -94,8 +94,8 @@ func TestNewActivator_CppRequiresGradle(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	cases := []struct {
-		name   string
-		params ActivatorParams
+		name    string
+		params  ActivatorParams
 		wantCpp bool
 	}{
 		{

--- a/pkg/reactnative/activator_test.go
+++ b/pkg/reactnative/activator_test.go
@@ -132,11 +132,7 @@ func TestNewActivator_CppRequiresGradle(t *testing.T) {
 	}
 }
 
-// Config.Save rewrites the whole file, so saveMultiplatformConfig must read
-// before it writes. Building a fresh Config there erased the Credentials block —
-// the only place a browser login's refresh token lives on a host with no usable
-// keychain. Observed on an RDE: login, activate, then the PAT expired an hour
-// later with nothing able to refresh it.
+// Config.Save rewrites the whole file, so a fresh Config here erases the login.
 func TestSaveMultiplatformConfig_KeepsExistingCredentials(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/pkg/reactnative/activator_test.go
+++ b/pkg/reactnative/activator_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/keychain"
+	multiplatformconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/multiplatform"
 	rnconfig "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/reactnative"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
@@ -128,4 +130,34 @@ func TestNewActivator_CppRequiresGradle(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Config.Save rewrites the whole file, so saveMultiplatformConfig must read
+// before it writes. Building a fresh Config there erased the Credentials block —
+// the only place a browser login's refresh token lives on a host with no usable
+// keychain. Observed on an RDE: login, activate, then the PAT expired an hour
+// later with nothing able to refresh it.
+func TestSaveMultiplatformConfig_KeepsExistingCredentials(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("BITRISE_BUILD_CACHE_AUTH_TOKEN", "bitpat_refreshed")
+	t.Setenv("BITRISE_BUILD_CACHE_WORKSPACE_ID", "ws-1")
+
+	login := keychain.Credentials{
+		AuthToken:    "bitpat_minted",
+		WorkspaceID:  "ws-1",
+		RefreshToken: "refresh-me",
+		Username:     "dev",
+	}
+	before := multiplatformconfig.Config{Credentials: &login}
+	require.NoError(t, before.Save(utils.DefaultOsProxy{}, utils.DefaultEncoderFactory{}))
+
+	require.NoError(t, saveMultiplatformConfig(true))
+
+	after, err := multiplatformconfig.ReadConfig(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
+	require.NoError(t, err)
+	require.NotNil(t, after.Credentials, "the credentials block must survive activation")
+	assert.Equal(t, "refresh-me", after.Credentials.RefreshToken)
+	assert.Equal(t, "dev", after.Credentials.Username)
+	assert.Equal(t, "bitpat_refreshed", after.AuthConfig.AuthToken, "AuthConfig still tracks the resolved token")
 }

--- a/pkg/reactnative/notify_ccache_helper_test.go
+++ b/pkg/reactnative/notify_ccache_helper_test.go
@@ -30,10 +30,13 @@ type stubSocket struct {
 	capturedChildID     string
 }
 
-func (s *stubSocket) IsListening() bool                   { return s.listening }
-func (s *stubSocket) Start() error                        { s.startCalled = true; return s.startErr }
-func (s *stubSocket) AwaitReady() bool                    { s.awaitCalled = true; return s.awaitResult }
-func (s *stubSocket) HealthCheck(_ context.Context) error { s.healthCheckCalled = true; return s.healthCheckErr }
+func (s *stubSocket) IsListening() bool { return s.listening }
+func (s *stubSocket) Start() error      { s.startCalled = true; return s.startErr }
+func (s *stubSocket) AwaitReady() bool  { s.awaitCalled = true; return s.awaitResult }
+func (s *stubSocket) HealthCheck(_ context.Context) error {
+	s.healthCheckCalled = true
+	return s.healthCheckErr
+}
 func (s *stubSocket) SetInvocationID(_ context.Context, parentID, childID string) error {
 	s.setInvocationCalled = true
 	s.capturedParentID = parentID

--- a/pkg/reactnative/run_cmd_test.go
+++ b/pkg/reactnative/run_cmd_test.go
@@ -422,3 +422,86 @@ func Test_parseCommand(t *testing.T) {
 		assert.Equal(t, tc.expectedCommand, parseCommand(tc.args), "args: %v", tc.args)
 	}
 }
+
+// Activation writes the CCACHE_* vars into envman, which only exists on Bitrise
+// CI. Without the injection below, a local build compiles against ccache's local
+// storage while the helper it just started sits idle — observed on an RDE as 281
+// compilations, 0 remote GETs, then "Idle timeout reached, shutting down".
+func TestRunner_Run_CcacheEnv(t *testing.T) {
+	ctx := context.Background()
+
+	findEnv := func(environ []string, key string) (string, bool) {
+		prefix := key + "="
+		for _, e := range environ {
+			if strings.HasPrefix(e, prefix) {
+				return strings.TrimPrefix(e, prefix), true
+			}
+		}
+
+		return "", false
+	}
+
+	captureEnv := func(t *testing.T, environ []string) []string {
+		t.Helper()
+
+		var captured []string
+		r := newTestRunner(RunnerParams{
+			ExecFn: func(env []string, _ string, _ ...string) (int, error) {
+				captured = env
+
+				return 0, nil
+			},
+		})
+		_, err := r.Run(ctx, []string{"npx", "react-native", "build-android"}, "", environ)
+		require.NoError(t, err)
+
+		return captured
+	}
+
+	t.Run("ccache is pointed at the storage helper", func(t *testing.T) {
+		home := activateRNHome(t)
+		writeCcacheConfig(t, home, "/tmp/ccache-ipc.sock")
+
+		got := captureEnv(t, []string{"HOME=" + home})
+
+		remote, ok := findEnv(got, "CCACHE_REMOTE_STORAGE")
+		require.True(t, ok, "the compiler has no other way to learn the socket")
+		assert.Contains(t, remote, "crsh:/tmp/ccache-ipc.sock")
+
+		for _, key := range []string{"CCACHE_REMOTE_ONLY", "CCACHE_NOHASHDIR", "CMAKE_CXX_COMPILER_LAUNCHER", "CMAKE_C_COMPILER_LAUNCHER"} {
+			_, ok := findEnv(got, key)
+			assert.True(t, ok, key)
+		}
+	})
+
+	t.Run("a value the user already set wins", func(t *testing.T) {
+		home := activateRNHome(t)
+		writeCcacheConfig(t, home, "/tmp/ccache-ipc.sock")
+
+		got := captureEnv(t, []string{"HOME=" + home, "CCACHE_REMOTE_STORAGE=redis://mine"})
+
+		remote, _ := findEnv(got, "CCACHE_REMOTE_STORAGE")
+		assert.Equal(t, "redis://mine", remote)
+	})
+
+	t.Run("no ccache activation → nothing injected", func(t *testing.T) {
+		home := activateRNHome(t) // RN activated, but no ccache config on disk
+
+		got := captureEnv(t, []string{"HOME=" + home})
+
+		_, ok := findEnv(got, "CCACHE_REMOTE_STORAGE")
+		assert.False(t, ok, "activate --cpp was never run, so there is no helper to point at")
+	})
+}
+
+func writeCcacheConfig(t *testing.T, home, socket string) {
+	t.Helper()
+
+	dir := filepath.Join(home, ".bitrise/cache/ccache")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "config.json"),
+		[]byte(`{"enabled":true,"ipcEndpoint":"`+socket+`","buildCacheEndpoint":"grpcs://x"}`),
+		0o644,
+	))
+}

--- a/pkg/reactnative/run_cmd_test.go
+++ b/pkg/reactnative/run_cmd_test.go
@@ -423,10 +423,7 @@ func Test_parseCommand(t *testing.T) {
 	}
 }
 
-// Activation writes the CCACHE_* vars into envman, which only exists on Bitrise
-// CI. Without the injection below, a local build compiles against ccache's local
-// storage while the helper it just started sits idle — observed on an RDE as 281
-// compilations, 0 remote GETs, then "Idle timeout reached, shutting down".
+// Off CI these never arrive: activation publishes them through envman.
 func TestRunner_Run_CcacheEnv(t *testing.T) {
 	ctx := context.Background()
 
@@ -441,7 +438,6 @@ func TestRunner_Run_CcacheEnv(t *testing.T) {
 		return "", false
 	}
 
-	// helperUp is what a reachable storage helper looks like to the Runner.
 	captureEnv := func(t *testing.T, environ []string, helperUp bool) []string {
 		t.Helper()
 
@@ -499,9 +495,7 @@ func TestRunner_Run_CcacheEnv(t *testing.T) {
 		assert.False(t, ok, "activate --cpp was never run, so there is no helper to point at")
 	})
 
-	// An expired credential stops the helper from starting. Pointing ccache at a
-	// dead socket with CCACHE_REMOTE_ONLY would cache nothing at all, which is
-	// worse than the local cache the build would otherwise have used.
+	// CCACHE_REMOTE_ONLY at a socket nobody is listening on caches nothing at all.
 	t.Run("helper unreachable → nothing injected", func(t *testing.T) {
 		home := activateRNHome(t)
 		writeCcacheConfig(t, home, "/tmp/ccache-ipc.sock")

--- a/pkg/reactnative/run_cmd_test.go
+++ b/pkg/reactnative/run_cmd_test.go
@@ -441,7 +441,8 @@ func TestRunner_Run_CcacheEnv(t *testing.T) {
 		return "", false
 	}
 
-	captureEnv := func(t *testing.T, environ []string) []string {
+	// helperUp is what a reachable storage helper looks like to the Runner.
+	captureEnv := func(t *testing.T, environ []string, helperUp bool) []string {
 		t.Helper()
 
 		var captured []string
@@ -452,6 +453,11 @@ func TestRunner_Run_CcacheEnv(t *testing.T) {
 				return 0, nil
 			},
 		})
+		if helperUp {
+			r.socket = &stubSocket{listening: true, awaitResult: true}
+		} else {
+			r.socket = &stubSocket{listening: false, startErr: errors.New("unauthenticated")}
+		}
 		_, err := r.Run(ctx, []string{"npx", "react-native", "build-android"}, "", environ)
 		require.NoError(t, err)
 
@@ -462,7 +468,7 @@ func TestRunner_Run_CcacheEnv(t *testing.T) {
 		home := activateRNHome(t)
 		writeCcacheConfig(t, home, "/tmp/ccache-ipc.sock")
 
-		got := captureEnv(t, []string{"HOME=" + home})
+		got := captureEnv(t, []string{"HOME=" + home}, true)
 
 		remote, ok := findEnv(got, "CCACHE_REMOTE_STORAGE")
 		require.True(t, ok, "the compiler has no other way to learn the socket")
@@ -478,7 +484,7 @@ func TestRunner_Run_CcacheEnv(t *testing.T) {
 		home := activateRNHome(t)
 		writeCcacheConfig(t, home, "/tmp/ccache-ipc.sock")
 
-		got := captureEnv(t, []string{"HOME=" + home, "CCACHE_REMOTE_STORAGE=redis://mine"})
+		got := captureEnv(t, []string{"HOME=" + home, "CCACHE_REMOTE_STORAGE=redis://mine"}, true)
 
 		remote, _ := findEnv(got, "CCACHE_REMOTE_STORAGE")
 		assert.Equal(t, "redis://mine", remote)
@@ -487,10 +493,25 @@ func TestRunner_Run_CcacheEnv(t *testing.T) {
 	t.Run("no ccache activation → nothing injected", func(t *testing.T) {
 		home := activateRNHome(t) // RN activated, but no ccache config on disk
 
-		got := captureEnv(t, []string{"HOME=" + home})
+		got := captureEnv(t, []string{"HOME=" + home}, true)
 
 		_, ok := findEnv(got, "CCACHE_REMOTE_STORAGE")
 		assert.False(t, ok, "activate --cpp was never run, so there is no helper to point at")
+	})
+
+	// An expired credential stops the helper from starting. Pointing ccache at a
+	// dead socket with CCACHE_REMOTE_ONLY would cache nothing at all, which is
+	// worse than the local cache the build would otherwise have used.
+	t.Run("helper unreachable → nothing injected", func(t *testing.T) {
+		home := activateRNHome(t)
+		writeCcacheConfig(t, home, "/tmp/ccache-ipc.sock")
+
+		got := captureEnv(t, []string{"HOME=" + home}, false)
+
+		for _, key := range []string{"CCACHE_REMOTE_STORAGE", "CCACHE_REMOTE_ONLY"} {
+			_, ok := findEnv(got, key)
+			assert.False(t, ok, key)
+		}
 	})
 }
 

--- a/pkg/reactnative/runner.go
+++ b/pkg/reactnative/runner.go
@@ -209,13 +209,9 @@ type ccacheSocket interface {
 	SetInvocationID(ctx context.Context, parentID, childID string) error
 }
 
-// ensureHelper brings the ccache storage helper up and reports whether it ended
-// up usable. Every step is still attempted even after one fails — the helper is
-// best-effort and must never block the build — but the verdict gates
-// injectCcacheEnv: pointing ccache at a socket nobody is listening on, with
-// CCACHE_REMOTE_ONLY set, would leave the build caching nothing at all, which is
-// worse than the local cache it would otherwise have used. An expired credential
-// is enough to keep the helper from starting.
+// ensureHelper brings the ccache storage helper up and reports whether it ended up
+// usable, which gates injectCcacheEnv. Every step is still attempted after a
+// failure: the helper is best-effort and must never block the build.
 func (r *Runner) ensureHelper(ctx context.Context, wrapperInvocationID string) bool {
 	socket := r.socket
 	if socket == nil {
@@ -250,18 +246,15 @@ func (r *Runner) ensureHelper(ctx context.Context, wrapperInvocationID string) b
 	return ready
 }
 
-// injectCcacheEnv points ccache at the storage helper for the wrapped build.
+// injectCcacheEnv points ccache at the storage helper. Activation publishes these
+// through envman, which exists only on Bitrise CI, so off CI a build otherwise
+// compiles against local storage while the helper sits idle — with every component
+// reporting success. The wrapped build's environment is the one place we know
+// reaches the compiler.
 //
-// Activation writes these into envman, which only exists on Bitrise CI, so
-// without this a local build compiles against ccache's local storage while the
-// helper sits idle — every component reports success and nothing is cached
-// remotely. The build's own environment is the one place we know reaches the
-// compiler, so the values are set here from the same config the helper uses.
-//
-// Only called once the helper is confirmed reachable — see ensureHelper.
-//
-// A value the user already set always wins: someone pointing ccache at their own
-// remote storage means it deliberately.
+// A value the user already set wins; they mean it. Called only once ensureHelper
+// has confirmed the helper is reachable, since CCACHE_REMOTE_ONLY at a dead socket
+// would cache nothing at all.
 func (r *Runner) injectCcacheEnv(envs map[string]string) {
 	if r.ccacheConfig == nil {
 		return
@@ -272,14 +265,8 @@ func (r *Runner) injectCcacheEnv(envs map[string]string) {
 		r.logger.Debugf("Could not resolve the working directory for CCACHE_BASEDIR: %s", err)
 	}
 
-	for key, value := range map[string]string{
-		"CCACHE_REMOTE_STORAGE":       r.ccacheConfig.CRSHRemoteStorageURL(),
-		"CCACHE_REMOTE_ONLY":          "true",
-		"CCACHE_NOHASHDIR":            "true",
-		"CCACHE_BASEDIR":              wd,
-		"CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
-		"CMAKE_C_COMPILER_LAUNCHER":   "ccache",
-	} {
+	injected := 0
+	for key, value := range r.ccacheConfig.BuildEnv(wd) {
 		if value == "" {
 			continue
 		}
@@ -289,9 +276,12 @@ func (r *Runner) injectCcacheEnv(envs map[string]string) {
 			continue
 		}
 		envs[key] = value
+		injected++
 	}
 
-	r.logger.TInfof("Routing ccache through the Bitrise storage helper (%s)", r.ccacheConfig.IPCEndpoint)
+	if injected > 0 {
+		r.logger.TInfof("Routing ccache through the Bitrise storage helper (%s)", r.ccacheConfig.IPCEndpoint)
+	}
 }
 
 // maybeInjectEASWorkingDir pins EAS Build's local working directory to a

--- a/pkg/reactnative/runner.go
+++ b/pkg/reactnative/runner.go
@@ -157,6 +157,7 @@ func (r *Runner) Run(ctx context.Context, args []string, wrapperInvocationID str
 
 	envMap := environToMap(environ)
 	envMap["BITRISE_INVOCATION_ID"] = wrapperInvocationID
+	r.injectCcacheEnv(envMap)
 	r.maybeInjectEASWorkingDir(envMap, name, cmdArgs)
 
 	start := time.Now()
@@ -230,6 +231,48 @@ func (r *Runner) ensureHelper(ctx context.Context, wrapperInvocationID string) {
 	if err := socket.SetInvocationID(ctx, wrapperInvocationID, uuid.NewString()); err != nil {
 		r.logger.TWarnf("Failed to send invocation ID to storage helper: %v", err)
 	}
+}
+
+// injectCcacheEnv points ccache at the storage helper for the wrapped build.
+//
+// Activation writes these into envman, which only exists on Bitrise CI, so
+// without this a local build compiles against ccache's local storage while the
+// helper sits idle — every component reports success and nothing is cached
+// remotely. The build's own environment is the one place we know reaches the
+// compiler, so the values are set here from the same config the helper uses.
+//
+// A value the user already set always wins: someone pointing ccache at their own
+// remote storage means it deliberately.
+func (r *Runner) injectCcacheEnv(envs map[string]string) {
+	if r.ccacheConfig == nil {
+		return
+	}
+
+	wd, err := r.osProxy.Getwd()
+	if err != nil {
+		r.logger.Debugf("Could not resolve the working directory for CCACHE_BASEDIR: %s", err)
+	}
+
+	for key, value := range map[string]string{
+		"CCACHE_REMOTE_STORAGE":       r.ccacheConfig.CRSHRemoteStorageURL(),
+		"CCACHE_REMOTE_ONLY":          "true",
+		"CCACHE_NOHASHDIR":            "true",
+		"CCACHE_BASEDIR":              wd,
+		"CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+		"CMAKE_C_COMPILER_LAUNCHER":   "ccache",
+	} {
+		if value == "" {
+			continue
+		}
+		if existing, ok := envs[key]; ok && existing != "" {
+			r.logger.Debugf("%s already set to %q — leaving it alone", key, existing)
+
+			continue
+		}
+		envs[key] = value
+	}
+
+	r.logger.TInfof("Routing ccache through the Bitrise storage helper (%s)", r.ccacheConfig.IPCEndpoint)
 }
 
 // maybeInjectEASWorkingDir pins EAS Build's local working directory to a

--- a/pkg/reactnative/runner.go
+++ b/pkg/reactnative/runner.go
@@ -150,14 +150,17 @@ func (r *Runner) Run(ctx context.Context, args []string, wrapperInvocationID str
 
 	r.logger.TInfof("React Native invocation ID: %s", wrapperInvocationID)
 
+	helperReady := false
 	if r.socket != nil {
-		r.ensureHelper(ctx, wrapperInvocationID)
+		helperReady = r.ensureHelper(ctx, wrapperInvocationID)
 		r.zeroCcacheStats(ctx)
 	}
 
 	envMap := environToMap(environ)
 	envMap["BITRISE_INVOCATION_ID"] = wrapperInvocationID
-	r.injectCcacheEnv(envMap)
+	if helperReady {
+		r.injectCcacheEnv(envMap)
+	}
 	r.maybeInjectEASWorkingDir(envMap, name, cmdArgs)
 
 	start := time.Now()
@@ -206,31 +209,45 @@ type ccacheSocket interface {
 	SetInvocationID(ctx context.Context, parentID, childID string) error
 }
 
-func (r *Runner) ensureHelper(ctx context.Context, wrapperInvocationID string) {
+// ensureHelper brings the ccache storage helper up and reports whether it ended
+// up usable. Every step is still attempted even after one fails — the helper is
+// best-effort and must never block the build — but the verdict gates
+// injectCcacheEnv: pointing ccache at a socket nobody is listening on, with
+// CCACHE_REMOTE_ONLY set, would leave the build caching nothing at all, which is
+// worse than the local cache it would otherwise have used. An expired credential
+// is enough to keep the helper from starting.
+func (r *Runner) ensureHelper(ctx context.Context, wrapperInvocationID string) bool {
 	socket := r.socket
 	if socket == nil {
-		return
+		return false
 	}
+
+	ready := true
 
 	if !socket.IsListening() {
 		if err := socket.Start(); err != nil {
 			r.logger.TWarnf("Failed to start ccache storage helper: %v", err)
 
-			return
+			return false
 		}
 
 		if !socket.AwaitReady() {
 			r.logger.TWarnf("Ccache storage helper did not become ready")
+			ready = false
 		}
 	}
 
 	if err := socket.HealthCheck(ctx); err != nil {
 		r.logger.TWarnf("Ccache storage helper health check failed: %v", err)
+		ready = false
 	}
 
 	if err := socket.SetInvocationID(ctx, wrapperInvocationID, uuid.NewString()); err != nil {
 		r.logger.TWarnf("Failed to send invocation ID to storage helper: %v", err)
+		ready = false
 	}
+
+	return ready
 }
 
 // injectCcacheEnv points ccache at the storage helper for the wrapped build.
@@ -240,6 +257,8 @@ func (r *Runner) ensureHelper(ctx context.Context, wrapperInvocationID string) {
 // helper sits idle — every component reports success and nothing is cached
 // remotely. The build's own environment is the one place we know reaches the
 // compiler, so the values are set here from the same config the helper uses.
+//
+// Only called once the helper is confirmed reachable — see ensureHelper.
 //
 // A value the user already set always wins: someone pointing ccache at their own
 // remote storage means it deliberately.

--- a/pkg/reactnative/runner.go
+++ b/pkg/reactnative/runner.go
@@ -209,9 +209,8 @@ type ccacheSocket interface {
 	SetInvocationID(ctx context.Context, parentID, childID string) error
 }
 
-// ensureHelper brings the ccache storage helper up and reports whether it ended up
-// usable, which gates injectCcacheEnv. Every step is still attempted after a
-// failure: the helper is best-effort and must never block the build.
+// The verdict gates injectCcacheEnv. Every step is still attempted after a failure:
+// the helper is best-effort and must never block the build.
 func (r *Runner) ensureHelper(ctx context.Context, wrapperInvocationID string) bool {
 	socket := r.socket
 	if socket == nil {
@@ -246,15 +245,9 @@ func (r *Runner) ensureHelper(ctx context.Context, wrapperInvocationID string) b
 	return ready
 }
 
-// injectCcacheEnv points ccache at the storage helper. Activation publishes these
-// through envman, which exists only on Bitrise CI, so off CI a build otherwise
-// compiles against local storage while the helper sits idle — with every component
-// reporting success. The wrapped build's environment is the one place we know
-// reaches the compiler.
-//
-// A value the user already set wins; they mean it. Called only once ensureHelper
-// has confirmed the helper is reachable, since CCACHE_REMOTE_ONLY at a dead socket
-// would cache nothing at all.
+// Activation publishes these through envman, which exists only on Bitrise CI, so
+// off CI nothing else tells the compiler the socket is there. A value the user
+// already set wins.
 func (r *Runner) injectCcacheEnv(envs map[string]string) {
 	if r.ccacheConfig == nil {
 		return


### PR DESCRIPTION
[ACI-5241](https://bitrise.atlassian.net/browse/ACI-5241)

## Summary

`activate react-native --cpp=true` did nothing for ccache off Bitrise CI, and repeated `activate` runs destroyed a browser login. Both were found by running the Seek RN e2e flow on an RDE by hand: 281 compilations, zero remote GETs, a healthy storage helper idling with nothing connected to it — and an hour later a login that could no longer refresh.

Five fixes, each with a test verified to fail without it.

## Changes

**1. ccache never learned where the helper was**

`activate --cpp` publishes `CCACHE_REMOTE_STORAGE`, `CCACHE_REMOTE_ONLY`, `CCACHE_BASEDIR`, `CCACHE_NOHASHDIR` and the two `CMAKE_*_COMPILER_LAUNCHER` values through `envman add` and nowhere else. `envman` is a Bitrise-CI binary, so off CI all six calls fail — at **Debug** level — and activation still prints `✅ Bitrise Build Cache for C++ activated`.

Measured consequence on the RDE: ccache compiled 281 files into its **local** cache, the helper sat on `/tmp/ccache-ipc.sock` for 15 minutes with zero connections and then logged `Idle timeout reached, shutting down`. Every component reported success individually.

The Runner already starts the helper, health-checks it and registers a ccache invocation ID — it just never told ccache the socket existed. It also already injects into the wrapped build's environment (for EAS), so the values go in the same way, from the same config the helper uses. A value the user set themselves is left alone.

**2. Injection is gated on the helper actually being reachable**

`CCACHE_REMOTE_ONLY=true` pointed at a socket nobody is listening on means ccache caches **nothing** — not even locally. That is worse than the plain local cache the build would otherwise have had, so the first version of this change would have made a broken-auth machine worse. `ensureHelper` now returns whether the helper ended up usable and the injection is gated on it. Every step is still attempted after a failure, because the helper is best-effort and must not block the build; only the verdict is new.

**3. `activate` discarded a login's refresh token on every ordinary run**

`mergeActivateCreds` compared the resolved token with the stored one and treated a mismatch as a different credential, dropping the OAuth fields. But a PAT minted by a browser login is short-lived and **gets refreshed**, so the resolved token routinely differs from the stored one — meaning the refresh token was thrown away by a perfectly normal `activate`. The login then degraded to a bare PAT and died at its expiry with nothing able to renew it, which is what took the RDE's auth down mid-session:

```
Error: run storage helper: create KV client: get capabilities: unauthenticated
✗ auth-backend  auth-failed: token rejected by Build Cache (expired / revoked / wrong workspace)
```

`activate` is not the authority on what the credential is — `auth set` and `auth login` are, and they replace the record through `SaveExclusive`. So it now keeps what is stored and updates only the token and workspace. **This corrects a rule I introduced in #443**, whose test asserted the wrong contract; that test is replaced.

**4. The keychain-refused fallback wrote a shape with no room for the refresh token**

On a host with no usable OS keychain, `PersistActivateCreds` wrote only the 3-field `AuthConfig` and left `Credentials` unset — and `Credentials` is the only place the refresh token lives. It now writes the full credential to the config file, merged against the **file** store: merging against a keychain that cannot be read is what produced the bare record in the first place. #443 fixed this for the keychain and CI paths and missed this one.

**5. RN activation erased the stored login on its way out**

`saveMultiplatformConfig` built a fresh `multiplatformconfig.Config` and saved it, and `Config.Save` rewrites the whole file — so the `Credentials` block went with it. This runs *after* the ccache activator's own (correct) write, so it undid fix 4. It reads before writing now and replaces only the two fields it owns.

**Supporting refactor**

`Config.BuildEnv(baseDir)` in `internal/config/ccache` is now the single definition of the ccache environment; the activator (envman path) and the Runner (wrapped-build path) both use it, so the two cannot drift.

## Testing

`make lint` and `go test -tags unit -race ./...` clean, against `main` as of #445.

- `pkg/reactnative/run_cmd_test.go` — the six variables reach the wrapped process; a user-set value wins; nothing is injected when ccache was never activated; nothing is injected when the helper is unreachable.
- `internal/auth/store/persist_merge_test.go` — a refreshed PAT keeps the refresh token, JWT and username; a keychain-refused write puts the full credential in the config file. The keychain-refused branch takes the target store as an argument so it is testable **without touching a real keychain** — the first version of that test took 7 s against my own login keychain and would have behaved differently per machine.
- `pkg/reactnative/activator_test.go` — `saveMultiplatformConfig` preserves an existing `Credentials` block while still updating `AuthConfig`.

Verified end to end on a Linux RDE, which is where the bugs were found. ccache's own debug log, before the change and after:

```
# before — no remote storage configured at all
Config: (default) remote_storage =

# after
Config: (environment) remote_storage = crsh:/tmp/ccache-ipc.sock data-timeout=5s request-timeout=20s
No 12bb6b8c23366390… in crsh:/tmp/ccache-ipc.sock (9.86 ms)      ← remote lookup
Stored cc66986268076e80… in crsh:/tmp/ccache-ipc.sock (4.54 ms)   ← remote write
```

Re-verified after the `BuildEnv` refactor. The full Seek Android build through the wrapper also passed on that box (`420/988` Gradle tasks from the remote cache, RN→gradle invocation relation registered), which is how the ccache gap surfaced in the first place.

## Notes for reviewers

- **Fix 3 is the one to scrutinise.** It changes when OAuth fields are preserved, and the trade-off is deliberate: `activate` can no longer drop them, so a stale refresh token could in principle outlive the credential it belonged to. That seemed clearly better than the current behaviour, where an ordinary `activate` kills a working login — and the paths that legitimately *replace* a credential (`auth set`, `auth login`, `auth clear`) don't go through this function at all. Worth a second opinion.
- **Fix 3 confirmed on the RDE**, after a fresh `auth login` there:

  ```
  before activate: refresh_token=cewbxFwkqynVx3
  after  activate: refresh_token=cewbxFwkqynVx3
    pat_expiry: 2026-08-04T11:45:35Z   jwt: present
  ```

  The whole OAuth record survives, not just the one field. Before the fix the same sequence flattened it to `{auth_token, workspace_id}`, which is what took that machine's auth down mid-session.
- **Not fixed here:** `activate react-native` self-installs the CLI into a hardcoded `/usr/local/bin` (`internal/dependencies.InstallDir`, no override), which fails with a bare `permission denied` on a stock Linux box where only root can write there. Pre-existing, and arguably the same "where does the CLI live" question `internal/clibin` already answers for Bazel and Gradle — but out of scope.
- **Also observed, not chased:** the RN invocation relation line and the local ndjson record are each written twice per build. Same ID, same command, so it is one invocation recorded twice — cosmetic, but it looks like a double registration in a customer-facing log.


[ACI-5241]: https://bitrise.atlassian.net/browse/ACI-5241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ