### PR TITLE
fix: ACI-5271 send GITHUB_TOKEN when polling GitHub releases API

### DIFF
--- a/internal/doctor/check_cli_version.go
+++ b/internal/doctor/check_cli_version.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/githubapi"
 )
 
 func (d *Doctor) cliVersionCheck() Check {
@@ -66,6 +68,7 @@ func fetchLatestGitHubRelease(ctx context.Context, client *http.Client) (string,
 		return "", fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
+	githubapi.SetAuthHeader(req)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/githubapi/auth.go
+++ b/internal/githubapi/auth.go
@@ -1,0 +1,18 @@
+package githubapi
+
+import (
+	"net/http"
+	"os"
+)
+
+func SetAuthHeader(req *http.Request) {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		token = os.Getenv("GH_TOKEN")
+	}
+	if token == "" {
+		return
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+}

--- a/internal/githubapi/auth_test.go
+++ b/internal/githubapi/auth_test.go
@@ -1,0 +1,47 @@
+//go:build unit
+
+package githubapi
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetAuthHeader_noEnv(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.test", nil)
+	require.NoError(t, err)
+
+	SetAuthHeader(req)
+
+	assert.Empty(t, req.Header.Get("Authorization"))
+}
+
+func TestSetAuthHeader_githubToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghp_primary")
+	t.Setenv("GH_TOKEN", "ghp_fallback")
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.test", nil)
+	require.NoError(t, err)
+
+	SetAuthHeader(req)
+
+	assert.Equal(t, "Bearer ghp_primary", req.Header.Get("Authorization"))
+}
+
+func TestSetAuthHeader_ghTokenFallback(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "ghp_fallback")
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.test", nil)
+	require.NoError(t, err)
+
+	SetAuthHeader(req)
+
+	assert.Equal(t, "Bearer ghp_fallback", req.Header.Get("Authorization"))
+}

--- a/internal/versioncheck/nudge.go
+++ b/internal/versioncheck/nudge.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"golang.org/x/mod/semver"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/githubapi"
 )
 
 const GitHubReleasesURL = "https://api.github.com/repos/bitrise-io/bitrise-build-cache-cli/releases/latest"
@@ -63,6 +65,7 @@ func FetchLatestVersion(ctx context.Context, client *http.Client, url string) (s
 
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "bitrise-build-cache-cli/version-check")
+	githubapi.SetAuthHeader(req)
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Doctor `cli-version` check + versioncheck nudge poll `api.github.com/.../releases/latest` unauthenticated → shared-egress IPs (Bitrise RDE, corporate NAT, VPN) blow through the 60-req/hr budget → 403 flips `Overall` to `warn`.
- Extracted a shared `internal/githubapi.SetAuthHeader(req)` that reads `GITHUB_TOKEN` (fallback `GH_TOKEN`) and attaches `Authorization: Bearer <token>` when present. Authenticated budget jumps to 5000/hr.
- Wired into both call sites (`internal/doctor/check_cli_version.go`, `internal/versioncheck/nudge.go`).

Jira: [ACI-5271](https://bitrise.atlassian.net/browse/ACI-5271)

## Test plan

- [x] `make lint` clean
- [x] `go test -tags unit -race ./internal/githubapi ./internal/doctor ./internal/versioncheck` — pass
- [x] Unit tests cover: no env → no header; `GITHUB_TOKEN` set → `Bearer`; `GH_TOKEN` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5271]: https://bitrise.atlassian.net/browse/ACI-5271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ