### PR TITLE
fix: ACI-5272 skip doctor ccache-binary probe when c++ not activated

### DIFF
--- a/internal/doctor/check_ccache.go
+++ b/internal/doctor/check_ccache.go
@@ -18,6 +18,10 @@ func (d *Doctor) ccacheBinaryCheck() Check {
 	return Check{
 		Name: "ccache-binary",
 		Diagnose: func(_ context.Context) Result {
+			if !d.toolActivated(toolconfig.Ccache) {
+				return Result{State: StateOK, Detail: "skipped (c++ not activated)"}
+			}
+
 			path, err := d.LookPath("ccache")
 			if err != nil {
 				return Result{State: StateWarn, Detail: "ccache binary not found in PATH. Install via `brew install ccache` if you build C/C++."}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -250,6 +250,16 @@ func TestCcacheBinaryCheck_missingIsWarn(t *testing.T) {
 	assert.Equal(t, StateWarn, res.State)
 }
 
+func TestCcacheBinaryCheck_skippedWhenCcacheNotActivated(t *testing.T) {
+	r := &Doctor{
+		ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Xcelerate: true} },
+		LookPath:       func(string) (string, error) { return "", errors.New("not found") },
+	}
+	res := r.ccacheBinaryCheck().Diagnose(context.Background())
+	assert.Equal(t, StateOK, res.State)
+	assert.Equal(t, "skipped (c++ not activated)", res.Detail)
+}
+
 // ──────────────────────────── log-dirs ────────────────────────────
 
 func TestLogDirsCheck_missingIsFixable(t *testing.T) {


### PR DESCRIPTION
## Summary

- `internal/doctor/check_ccache.go`: gate `ccacheBinaryCheck` on `d.toolActivated(toolconfig.Ccache)`, returning `skipped (c++ not activated)` — mirrors the sibling `ccacheHelperCheck` via `socketDaemonCheck`.
- Prevents `bitrise-build-cache doctor` from flipping `Overall` to `warn` on Xcode/Bazel-only machines that never installed ccache.

## Test plan

- [x] `go test -tags unit -race ./internal/doctor/ -run TestCcacheBinaryCheck` — 3/3 pass (new `TestCcacheBinaryCheck_skippedWhenCcacheNotActivated`).
- [x] `make check` clean apart from the pre-existing `Test_enableForBazelCmdFn/No_envs_specified` failure on `main`.

Ticket: https://bitrise.atlassian.net/browse/ACI-5272