### PR TITLE
ACI-5273: doctor probes xcodebuild/xcrun resolve to the xcelerate wrapper

### DIFF
--- a/internal/doctor/check_xcelerate_wrapper_path.go
+++ b/internal/doctor/check_xcelerate_wrapper_path.go
@@ -1,0 +1,64 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/paths"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/toolconfig"
+)
+
+func (d *Doctor) xcelerateWrapperPathCheck() Check {
+	return Check{
+		Name: "xcelerate-wrapper-path",
+		Diagnose: func(_ context.Context) Result {
+			if !d.toolActivated(toolconfig.Xcelerate) {
+				return Result{State: StateOK, Detail: "skipped (xcode not activated)"}
+			}
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return Result{State: StateError, Detail: "resolve home dir: " + err.Error()}
+			}
+
+			binDir := paths.FromHome(home).XcelerateBinDir()
+
+			for _, name := range []string{"xcodebuild", "xcrun"} {
+				if res, ok := diagnoseWrapperOnPath(name, binDir, d.LookPath); !ok {
+					return res
+				}
+			}
+
+			return Result{State: StateOK, Detail: "xcodebuild, xcrun resolve to the xcelerate wrapper"}
+		},
+	}
+}
+
+func diagnoseWrapperOnPath(name, binDir string, lookPath func(string) (string, error)) (Result, bool) {
+	expected := filepath.Join(binDir, name)
+
+	actual, err := lookPath(name)
+	if err != nil {
+		return Result{State: StateWarn, Detail: fmt.Sprintf("%s not on PATH — open a new terminal or `source ~/.zshrc` so the wrapper installed by `activate xcode` becomes visible", name)}, false
+	}
+
+	if pathsEqual(actual, expected) {
+		return Result{}, true
+	}
+
+	return Result{State: StateWarn, Detail: fmt.Sprintf("%s resolves to %s; open a new terminal or `source ~/.zshrc` — your current shell hasn't picked up the wrapper PATH added by `activate xcode` (expected %s)", name, actual, expected)}, false
+}
+
+func pathsEqual(a, b string) bool {
+	return resolveSymlinks(a) == resolveSymlinks(b)
+}
+
+func resolveSymlinks(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+
+	return p
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -260,6 +260,7 @@ func (d *Doctor) checks(opts Options) []Check {
 
 	checks = append(checks,
 		d.xcelerateProxyCheck(),
+		d.xcelerateWrapperPathCheck(),
 		d.enrichmentCheck(),
 		d.ccacheHelperCheck(),
 		d.ccacheBinaryCheck(),

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -230,6 +230,91 @@ func TestXcelerateProxyCheck_skippedWhenNotActivated(t *testing.T) {
 	assert.Contains(t, res.Detail, "skipped")
 }
 
+// ──────────────────────────── xcelerate wrapper path ────────────────────────────
+
+func TestXcelerateWrapperPathCheck_skippedWhenNotActivated(t *testing.T) {
+	r := &Doctor{ActivatedTools: func() map[toolconfig.Tool]bool { return nil }}
+
+	res := r.xcelerateWrapperPathCheck().Diagnose(context.Background())
+	assert.Equal(t, StateOK, res.State)
+	assert.Contains(t, res.Detail, "skipped")
+}
+
+func TestXcelerateWrapperPathCheck_wrapperOnPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binDir := filepath.Join(home, ".bitrise-xcelerate", "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+
+	lookPath := func(name string) (string, error) {
+		return filepath.Join(binDir, name), nil
+	}
+
+	r := &Doctor{
+		ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Xcelerate: true} },
+		LookPath:       lookPath,
+	}
+
+	res := r.xcelerateWrapperPathCheck().Diagnose(context.Background())
+	assert.Equal(t, StateOK, res.State)
+	assert.Contains(t, res.Detail, "xcodebuild")
+	assert.Contains(t, res.Detail, "xcrun")
+}
+
+func TestXcelerateWrapperPathCheck_mismatchIsWarn(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	r := &Doctor{
+		ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Xcelerate: true} },
+		LookPath:       func(string) (string, error) { return "/usr/bin/xcodebuild", nil },
+	}
+
+	res := r.xcelerateWrapperPathCheck().Diagnose(context.Background())
+	assert.Equal(t, StateWarn, res.State)
+	assert.Contains(t, res.Detail, "xcodebuild resolves to /usr/bin/xcodebuild")
+	assert.Contains(t, res.Detail, "source ~/.zshrc")
+}
+
+func TestXcelerateWrapperPathCheck_notOnPathIsWarn(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	r := &Doctor{
+		ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Xcelerate: true} },
+		LookPath:       func(string) (string, error) { return "", errors.New("not found") },
+	}
+
+	res := r.xcelerateWrapperPathCheck().Diagnose(context.Background())
+	assert.Equal(t, StateWarn, res.State)
+	assert.Contains(t, res.Detail, "xcodebuild not on PATH")
+}
+
+func TestXcelerateWrapperPathCheck_symlinkedWrapperIsOK(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binDir := filepath.Join(home, ".bitrise-xcelerate", "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+
+	realDir := filepath.Join(home, "real-bin")
+	require.NoError(t, os.MkdirAll(realDir, 0o755))
+	for _, name := range []string{"xcodebuild", "xcrun"} {
+		realPath := filepath.Join(realDir, name)
+		require.NoError(t, os.WriteFile(realPath, nil, 0o755))
+		require.NoError(t, os.Symlink(realPath, filepath.Join(binDir, name)))
+	}
+
+	r := &Doctor{
+		ActivatedTools: func() map[toolconfig.Tool]bool { return map[toolconfig.Tool]bool{toolconfig.Xcelerate: true} },
+		LookPath: func(name string) (string, error) {
+			return filepath.Join(realDir, name), nil
+		},
+	}
+
+	res := r.xcelerateWrapperPathCheck().Diagnose(context.Background())
+	assert.Equal(t, StateOK, res.State)
+}
+
 // ──────────────────────────── ccache ────────────────────────────
 
 func TestCcacheHelperCheck_noSocketIsWarn(t *testing.T) {


### PR DESCRIPTION
## Summary
- New doctor check `xcelerate-wrapper-path`: warns when `activate xcode` has installed the wrapper at `~/.bitrise-xcelerate/bin/{xcodebuild,xcrun}` but the current shell still resolves those to `/usr/bin` — the case where a user builds in the same shell they ran `activate` in and gets no cache while `Overall: ok` misleadingly says everything is fine.
- Gated on Xcelerate being activated; skipped otherwise. Same code path covers React Native since it activates Xcode.
- Uses `filepath.EvalSymlinks` on both actual and expected before comparing so installer / brew symlinks don't false-positive.

Fixes ACI-5273.

## Test plan
- [x] `make check` clean (pre-existing bazel `Test_enableForBazelCmdFn/No_envs_specified` failure on main aside).
- [x] Unit tests: activated + match OK, activated + mismatch warn, activated + not on PATH warn, not-activated skipped, symlinked wrapper OK.
- [x] Manual: run `activate xcode` in a fresh shell without sourcing rc, then `bitrise-build-cache doctor` — expect warn with `source ~/.zshrc` hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)