### PR TITLE
[NOJIRA] Auto-bump the bazel step on every CLI release

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -145,6 +145,10 @@ workflows:
         envs:
         - STEP_NAME: bitrise-step-activate-gradle-mirrors
         - UPDATE_SCRIPT_PATH: ../scripts/update_activate_gradle_mirrors.sh
+    - bundle::update-step:
+        envs:
+        - STEP_NAME: bitrise-step-activate-build-cache-for-bazel
+        - UPDATE_SCRIPT_PATH: ../scripts/update_activate_build_cache_for_bazel.sh
     - slack@4:
         inputs:
           - channel: "#team-advanced-ci-alerts-website"
@@ -1974,6 +1978,10 @@ workflows:
           envs:
             - STEP_NAME: bitrise-step-activate-gradle-mirrors
             - UPDATE_SCRIPT_PATH: ../scripts/update_activate_gradle_mirrors.sh
+      - bundle::update-step:
+          envs:
+            - STEP_NAME: bitrise-step-activate-build-cache-for-bazel
+            - UPDATE_SCRIPT_PATH: ../scripts/update_activate_build_cache_for_bazel.sh
 
   e2e-scenarios-linux:
     description: |

--- a/scripts/update_activate_build_cache_for_bazel.sh
+++ b/scripts/update_activate_build_cache_for_bazel.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -ex
+
+# The bazel step installs the CLI by pinned version instead of vendoring it as a
+# Go module, so the bump is a single line in step.sh rather than a `go get`.
+# Written via a temp file because `sed -i` takes a backup suffix on BSD sed.
+tmp="$(mktemp)"
+sed -E "s|^(export BITRISE_BUILD_CACHE_CLI_VERSION=\")[^\"]+(\")|\1${BITRISE_GIT_TAG}\2|" step.sh > "$tmp"
+mv "$tmp" step.sh
+
+# Guard against a regex that matched nothing or matched too much.
+actual_diff="$(git diff --numstat)"
+if [ "$actual_diff" != "1	1	step.sh" ]; then
+  echo "Expected exactly one changed line in step.sh, got:"
+  echo "$actual_diff"
+  exit 1
+fi


### PR DESCRIPTION
## TLDR

- Adds the bazel step to the release workflow's `bundle::update-step` set, so it gets a bump PR like the other five consumers.
- New `scripts/update_activate_build_cache_for_bazel.sh` rewrites the pinned CLI version in `step.sh`.
- Added to the manual `update-steps` workflow too, so a re-run covers bazel.

## Why bazel was missing, and why its script differs

The five existing consumers vendor the CLI as a Go module, so their update scripts are a `go get` + `go mod tidy`/`vendor`. The bazel step installs the CLI by pinned version in `step.sh` (`export BITRISE_BUILD_CACHE_CLI_VERSION="…"`) and has no `go.mod` at all, which is presumably why it was never wired in — there was no script shape that fit.

The cost of that omission: nothing pushed a bump, Renovate doesn't track a shell variable, and the pin sat on `v0.17.7` from July 2025 until it was moved to `v3.4.4` today — three majors behind, with every CLI fix in between invisible to bazel users, including the ACI-5269 credential-helper fix.

The new script rewrites that one line and then asserts `git diff --numstat` is exactly `1	1	step.sh`, so a regex that matches nothing (variable renamed) or too much fails the release step instead of silently opening an empty or over-broad PR. It writes through a temp file rather than `sed -i`, since BSD sed reads `-i`'s next argument as a backup suffix.

## Testing

- Ran the script against a real checkout of the bazel step: `v3.4.4` → `v9.9.9`, exactly one changed line.
- Ran it against a checkout with the variable renamed: guard fires, exit 1.
- `make lint` clean; both `bitrise.yml` insertions parse (the `release` and `update-steps` workflows have different list indentation).
- The script itself only runs during a real release, so the first live exercise will be the next CLI release's bazel bump PR.
