### PR TITLE
feat: ACI-5290 KV client conn pool + drop proxy ccSemaphore

### DIFF
--- a/internal/build_cache/kv/client.go
+++ b/internal/build_cache/kv/client.go
@@ -243,6 +243,8 @@ type writer struct {
 	response     *bytestream.WriteResponse
 	release      func()
 	releaseOnce  sync.Once
+	closeOnce    sync.Once
+	closeErr     error
 }
 
 func (w *writer) Response() *bytestream.WriteResponse {
@@ -279,13 +281,15 @@ func (w *writer) doRelease() {
 func (w *writer) Close() error {
 	defer w.doRelease()
 
-	var err error
-	w.response, err = w.stream.CloseAndRecv()
-	if err != nil {
-		return fmt.Errorf("close stream: %w", err)
-	}
+	w.closeOnce.Do(func() {
+		resp, err := w.stream.CloseAndRecv()
+		w.response = resp
+		if err != nil {
+			w.closeErr = fmt.Errorf("close stream: %w", err)
+		}
+	})
 
-	return nil
+	return w.closeErr
 }
 
 type reader struct {

--- a/internal/build_cache/kv/client.go
+++ b/internal/build_cache/kv/client.go
@@ -232,7 +232,7 @@ type writer struct {
 	offset       int64
 	fileSize     int64
 	response     *bytestream.WriteResponse
-	release      func() // nil-safe; releases the pool-entry semaphore once the stream drains
+	release      func()
 	releaseOnce  sync.Once
 }
 
@@ -286,7 +286,7 @@ type reader struct {
 	buf      bytes.Buffer
 
 	metadataReady chan struct{}
-	release       func() // nil-safe; releases the pool-entry semaphore on Close
+	release       func()
 	releaseOnce   sync.Once
 }
 
@@ -368,13 +368,17 @@ func (r *reader) Metadata() map[string]string {
 	return m
 }
 
-func (r *reader) Close() error {
-	r.buf.Reset()
+func (r *reader) doRelease() {
 	r.releaseOnce.Do(func() {
 		if r.release != nil {
 			r.release()
 		}
 	})
+}
+
+func (r *reader) Close() error {
+	r.buf.Reset()
+	r.doRelease()
 
 	return nil
 }

--- a/internal/build_cache/kv/client.go
+++ b/internal/build_cache/kv/client.go
@@ -36,10 +36,8 @@ const (
 )
 
 // Channel-pool sizing mirrors the Gradle plugin's ClientBalancer.
-var (
-	numChannels     = max(2, runtime.NumCPU()/6)
-	perChannelLimit = runtime.NumCPU()
-)
+func numChannels() int     { return max(2, runtime.NumCPU()/6) }
+func perChannelLimit() int { return runtime.NumCPU() }
 
 // AuthSource returns the credentials to use for a single RPC. Implementations
 // may cache and refresh transparently; kv.Client re-reads on every call.
@@ -190,8 +188,8 @@ func buildChannels(p NewClientParams) ([]*channel, error) {
 		PermitWithoutStream: true,
 	}
 
-	channels := make([]*channel, 0, numChannels)
-	for range numChannels {
+	channels := make([]*channel, 0, numChannels())
+	for range numChannels() {
 		conn, err := grpc.NewClient(p.Host,
 			grpc.WithTransportCredentials(creds),
 			grpc.WithKeepaliveParams(kaParams),
@@ -206,7 +204,7 @@ func buildChannels(p NewClientParams) ([]*channel, error) {
 
 		channels = append(channels, &channel{
 			conn:               conn,
-			sem:                make(chan struct{}, perChannelLimit),
+			sem:                make(chan struct{}, perChannelLimit()),
 			bitriseKVClient:    kv_storage.NewKVStorageClient(conn),
 			capabilitiesClient: remoteexecution.NewCapabilitiesClient(conn),
 			casClient:          remoteexecution.NewContentAddressableStorageClient(conn),

--- a/internal/build_cache/kv/client.go
+++ b/internal/build_cache/kv/client.go
@@ -37,11 +37,11 @@ type staticAuthSource struct {
 
 func (s staticAuthSource) Get() common.CacheAuthConfig { return s.cfg }
 
-// poolEntry binds one gRPC connection to its per-channel semaphore and the
+// channel binds one gRPC connection to its per-channel semaphore and the
 // three sub-clients dialed on top of it. The semaphore caps concurrent RPCs on
 // this channel so we can never open more streams than HTTP/2 supports without
 // waiting on the transport itself.
-type poolEntry struct {
+type channel struct {
 	conn               *grpc.ClientConn // nil when test-injected (see NewClient).
 	sem                chan struct{}    // nil disables throttling (test-injected mode).
 	bitriseKVClient    kv_storage.KVStorageClient
@@ -49,25 +49,25 @@ type poolEntry struct {
 	casClient          remoteexecution.ContentAddressableStorageClient
 }
 
-func (e *poolEntry) acquire() {
-	if e.sem == nil {
+func (ch *channel) acquire() {
+	if ch.sem == nil {
 		return
 	}
 
-	e.sem <- struct{}{}
+	ch.sem <- struct{}{}
 }
 
-func (e *poolEntry) release() {
-	if e.sem == nil {
+func (ch *channel) release() {
+	if ch.sem == nil {
 		return
 	}
 
-	<-e.sem
+	<-ch.sem
 }
 
 type Client struct {
-	pool                []*poolEntry
-	poolCursor          atomic.Uint64
+	channels            []*channel
+	channelCursor       atomic.Uint64
 	clientName          string
 	authSource          AuthSource
 	cacheConfigMetadata common.CacheConfigMetadata
@@ -81,13 +81,13 @@ type Client struct {
 	uploadRetryWait     time.Duration
 }
 
-// pickEntry round-robins across pool entries. Callers must acquire the entry's
+// pickChannel round-robins across channels. Callers must acquire the channel's
 // semaphore before use and release it once the RPC (including any streaming
 // body) has drained.
-func (c *Client) pickEntry() *poolEntry {
-	i := c.poolCursor.Add(1) - 1
+func (c *Client) pickChannel() *channel {
+	i := c.channelCursor.Add(1) - 1
 
-	return c.pool[i%uint64(len(c.pool))]
+	return c.channels[i%uint64(len(c.channels))]
 }
 
 type NewClientParams struct {
@@ -128,13 +128,13 @@ func NewClient(p NewClientParams) (*Client, error) {
 		authSource = staticAuthSource{cfg: p.AuthConfig}
 	}
 
-	pool, err := buildPool(p)
+	channels, err := buildChannels(p)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
-		pool:                pool,
+		channels:            channels,
 		clientName:          p.ClientName,
 		authSource:          authSource,
 		logger:              p.Logger,
@@ -148,16 +148,16 @@ func NewClient(p NewClientParams) (*Client, error) {
 	}, nil
 }
 
-// buildPool dials one gRPC connection per pool slot, each with its own
+// buildChannels dials one gRPC connection per channel, each with its own
 // per-channel semaphore. Sizing mirrors the Gradle plugin's ClientBalancer:
 // numChannels = max(2, NumCPU/6), perChannelLimit = NumCPU.
 //
 // If callers inject a stub (BitriseKVClient or CapabilitiesClient) the pool
-// collapses to a single, no-throttle entry that hands the stub straight back —
-// keeps every test that only wires one mock working unchanged.
-func buildPool(p NewClientParams) ([]*poolEntry, error) {
+// collapses to a single, no-throttle channel that hands the stub straight
+// back — keeps every test that only wires one mock working unchanged.
+func buildChannels(p NewClientParams) ([]*channel, error) {
 	if p.BitriseKVClient != nil || p.CapabilitiesClient != nil {
-		return []*poolEntry{{
+		return []*channel{{
 			bitriseKVClient:    p.BitriseKVClient,
 			capabilitiesClient: p.CapabilitiesClient,
 		}}, nil
@@ -177,22 +177,21 @@ func buildPool(p NewClientParams) ([]*poolEntry, error) {
 	numChannels := max(2, runtime.NumCPU()/6)
 	perChannelLimit := runtime.NumCPU()
 
-	pool := make([]*poolEntry, 0, numChannels)
+	channels := make([]*channel, 0, numChannels)
 	for range numChannels {
 		conn, err := grpc.NewClient(p.Host,
 			grpc.WithTransportCredentials(creds),
 			grpc.WithKeepaliveParams(kaParams),
 		)
 		if err != nil {
-			// unwind partial pool so we don't leak conns
-			for _, e := range pool {
-				_ = e.conn.Close()
+			for _, ch := range channels {
+				_ = ch.conn.Close()
 			}
 
 			return nil, fmt.Errorf("dial %s: %w", p.Host, err)
 		}
 
-		pool = append(pool, &poolEntry{
+		channels = append(channels, &channel{
 			conn:               conn,
 			sem:                make(chan struct{}, perChannelLimit),
 			bitriseKVClient:    kv_storage.NewKVStorageClient(conn),
@@ -201,7 +200,7 @@ func buildPool(p NewClientParams) ([]*poolEntry, error) {
 		})
 	}
 
-	return pool, nil
+	return channels, nil
 }
 
 func (c *Client) SetLogger(logger log.Logger) {
@@ -209,16 +208,15 @@ func (c *Client) SetLogger(logger log.Logger) {
 }
 
 // Close releases every gRPC connection in the pool. Safe to call when the
-// client was built with injected stubs — pool entries without a conn are
-// skipped.
+// client was built with injected stubs — channels without a conn are skipped.
 func (c *Client) Close() error {
 	var firstErr error
-	for _, e := range c.pool {
-		if e.conn == nil {
+	for _, ch := range c.channels {
+		if ch.conn == nil {
 			continue
 		}
 
-		if err := e.conn.Close(); err != nil && firstErr == nil {
+		if err := ch.conn.Close(); err != nil && firstErr == nil {
 			firstErr = fmt.Errorf("close kv grpc conn: %w", err)
 		}
 	}

--- a/internal/build_cache/kv/client.go
+++ b/internal/build_cache/kv/client.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -14,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
 	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/build/bazel/remote/execution/v2"
@@ -34,11 +37,37 @@ type staticAuthSource struct {
 
 func (s staticAuthSource) Get() common.CacheAuthConfig { return s.cfg }
 
+// poolEntry binds one gRPC connection to its per-channel semaphore and the
+// three sub-clients dialed on top of it. The semaphore caps concurrent RPCs on
+// this channel so we can never open more streams than HTTP/2 supports without
+// waiting on the transport itself.
+type poolEntry struct {
+	conn               *grpc.ClientConn // nil when test-injected (see NewClient).
+	sem                chan struct{}    // nil disables throttling (test-injected mode).
+	bitriseKVClient    kv_storage.KVStorageClient
+	capabilitiesClient remoteexecution.CapabilitiesClient
+	casClient          remoteexecution.ContentAddressableStorageClient
+}
+
+func (e *poolEntry) acquire() {
+	if e.sem == nil {
+		return
+	}
+
+	e.sem <- struct{}{}
+}
+
+func (e *poolEntry) release() {
+	if e.sem == nil {
+		return
+	}
+
+	<-e.sem
+}
+
 type Client struct {
-	conn                *grpc.ClientConn // nil when test-injected via BitriseKVClient / CapabilitiesClient.
-	bitriseKVClient     kv_storage.KVStorageClient
-	capabilitiesClient  remoteexecution.CapabilitiesClient
-	casClient           remoteexecution.ContentAddressableStorageClient
+	pool                []*poolEntry
+	poolCursor          atomic.Uint64
 	clientName          string
 	authSource          AuthSource
 	cacheConfigMetadata common.CacheConfigMetadata
@@ -50,6 +79,15 @@ type Client struct {
 	downloadRetryWait   time.Duration
 	uploadRetry         uint
 	uploadRetryWait     time.Duration
+}
+
+// pickEntry round-robins across pool entries. Callers must acquire the entry's
+// semaphore before use and release it once the RPC (including any streaming
+// body) has drained.
+func (c *Client) pickEntry() *poolEntry {
+	i := c.poolCursor.Add(1) - 1
+
+	return c.pool[i%uint64(len(c.pool))]
 }
 
 type NewClientParams struct {
@@ -72,25 +110,6 @@ type NewClientParams struct {
 }
 
 func NewClient(p NewClientParams) (*Client, error) {
-	creds := credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
-	if p.UseInsecure {
-		creds = insecure.NewCredentials()
-	}
-
-	conn, err := grpc.NewClient(p.Host, grpc.WithTransportCredentials(creds))
-	if err != nil {
-		return nil, fmt.Errorf("dial %s: %w", p.Host, err)
-	}
-
-	bitriseKVClient := p.BitriseKVClient
-	if bitriseKVClient == nil {
-		bitriseKVClient = kv_storage.NewKVStorageClient(conn)
-	}
-	capabilitiesClient := p.CapabilitiesClient
-	if capabilitiesClient == nil {
-		capabilitiesClient = remoteexecution.NewCapabilitiesClient(conn)
-	}
-
 	if p.DownloadRetry == 0 {
 		p.DownloadRetry = 3
 	}
@@ -109,11 +128,13 @@ func NewClient(p NewClientParams) (*Client, error) {
 		authSource = staticAuthSource{cfg: p.AuthConfig}
 	}
 
+	pool, err := buildPool(p)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Client{
-		conn:                conn,
-		bitriseKVClient:     bitriseKVClient,
-		capabilitiesClient:  capabilitiesClient,
-		casClient:           remoteexecution.NewContentAddressableStorageClient(conn),
+		pool:                pool,
 		clientName:          p.ClientName,
 		authSource:          authSource,
 		logger:              p.Logger,
@@ -127,22 +148,82 @@ func NewClient(p NewClientParams) (*Client, error) {
 	}, nil
 }
 
+// buildPool dials one gRPC connection per pool slot, each with its own
+// per-channel semaphore. Sizing mirrors the Gradle plugin's ClientBalancer:
+// numChannels = max(2, NumCPU/6), perChannelLimit = NumCPU.
+//
+// If callers inject a stub (BitriseKVClient or CapabilitiesClient) the pool
+// collapses to a single, no-throttle entry that hands the stub straight back —
+// keeps every test that only wires one mock working unchanged.
+func buildPool(p NewClientParams) ([]*poolEntry, error) {
+	if p.BitriseKVClient != nil || p.CapabilitiesClient != nil {
+		return []*poolEntry{{
+			bitriseKVClient:    p.BitriseKVClient,
+			capabilitiesClient: p.CapabilitiesClient,
+		}}, nil
+	}
+
+	creds := credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
+	if p.UseInsecure {
+		creds = insecure.NewCredentials()
+	}
+
+	kaParams := keepalive.ClientParameters{
+		Time:                30 * time.Second,
+		Timeout:             10 * time.Second,
+		PermitWithoutStream: true,
+	}
+
+	numChannels := max(2, runtime.NumCPU()/6)
+	perChannelLimit := runtime.NumCPU()
+
+	pool := make([]*poolEntry, 0, numChannels)
+	for range numChannels {
+		conn, err := grpc.NewClient(p.Host,
+			grpc.WithTransportCredentials(creds),
+			grpc.WithKeepaliveParams(kaParams),
+		)
+		if err != nil {
+			// unwind partial pool so we don't leak conns
+			for _, e := range pool {
+				_ = e.conn.Close()
+			}
+
+			return nil, fmt.Errorf("dial %s: %w", p.Host, err)
+		}
+
+		pool = append(pool, &poolEntry{
+			conn:               conn,
+			sem:                make(chan struct{}, perChannelLimit),
+			bitriseKVClient:    kv_storage.NewKVStorageClient(conn),
+			capabilitiesClient: remoteexecution.NewCapabilitiesClient(conn),
+			casClient:          remoteexecution.NewContentAddressableStorageClient(conn),
+		})
+	}
+
+	return pool, nil
+}
+
 func (c *Client) SetLogger(logger log.Logger) {
 	c.logger = logger
 }
 
-// Close releases the gRPC connection. Safe to call when the client was built
-// with injected stubs (no conn) — returns nil in that case.
+// Close releases every gRPC connection in the pool. Safe to call when the
+// client was built with injected stubs — pool entries without a conn are
+// skipped.
 func (c *Client) Close() error {
-	if c.conn == nil {
-		return nil
+	var firstErr error
+	for _, e := range c.pool {
+		if e.conn == nil {
+			continue
+		}
+
+		if err := e.conn.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("close kv grpc conn: %w", err)
+		}
 	}
 
-	if err := c.conn.Close(); err != nil {
-		return fmt.Errorf("close kv grpc conn: %w", err)
-	}
-
-	return nil
+	return firstErr
 }
 
 type writer struct {
@@ -151,6 +232,8 @@ type writer struct {
 	offset       int64
 	fileSize     int64
 	response     *bytestream.WriteResponse
+	release      func() // nil-safe; releases the pool-entry semaphore once the stream drains
+	releaseOnce  sync.Once
 }
 
 func (w *writer) Response() *bytestream.WriteResponse {
@@ -176,7 +259,17 @@ func (w *writer) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+func (w *writer) doRelease() {
+	w.releaseOnce.Do(func() {
+		if w.release != nil {
+			w.release()
+		}
+	})
+}
+
 func (w *writer) Close() error {
+	defer w.doRelease()
+
 	var err error
 	w.response, err = w.stream.CloseAndRecv()
 	if err != nil {
@@ -193,6 +286,8 @@ type reader struct {
 	buf      bytes.Buffer
 
 	metadataReady chan struct{}
+	release       func() // nil-safe; releases the pool-entry semaphore on Close
+	releaseOnce   sync.Once
 }
 
 func (r *reader) Read(p []byte) (int, error) {
@@ -275,6 +370,11 @@ func (r *reader) Metadata() map[string]string {
 
 func (r *reader) Close() error {
 	r.buf.Reset()
+	r.releaseOnce.Do(func() {
+		if r.release != nil {
+			r.release()
+		}
+	})
 
 	return nil
 }

--- a/internal/build_cache/kv/client.go
+++ b/internal/build_cache/kv/client.go
@@ -25,6 +25,22 @@ import (
 
 //go:generate moq -rm -stub -pkg mocks -out ./mocks/kv_storage.go ./../../../proto/kv_storage KVStorageClient
 
+const (
+	defaultDownloadRetry     uint          = 3
+	defaultUploadRetry       uint          = 3
+	defaultDownloadRetryWait time.Duration = 1 * time.Second
+	defaultUploadRetryWait   time.Duration = 1 * time.Second
+
+	keepaliveTime    = 30 * time.Second
+	keepaliveTimeout = 10 * time.Second
+)
+
+// Channel-pool sizing mirrors the Gradle plugin's ClientBalancer.
+var (
+	numChannels     = max(2, runtime.NumCPU()/6)
+	perChannelLimit = runtime.NumCPU()
+)
+
 // AuthSource returns the credentials to use for a single RPC. Implementations
 // may cache and refresh transparently; kv.Client re-reads on every call.
 type AuthSource interface {
@@ -111,16 +127,16 @@ type NewClientParams struct {
 
 func NewClient(p NewClientParams) (*Client, error) {
 	if p.DownloadRetry == 0 {
-		p.DownloadRetry = 3
+		p.DownloadRetry = defaultDownloadRetry
 	}
 	if p.DownloadRetryWait == 0 {
-		p.DownloadRetryWait = 1 * time.Second
+		p.DownloadRetryWait = defaultDownloadRetryWait
 	}
 	if p.UploadRetry == 0 {
-		p.UploadRetry = 3
+		p.UploadRetry = defaultUploadRetry
 	}
 	if p.UploadRetryWait == 0 {
-		p.UploadRetryWait = 1 * time.Second
+		p.UploadRetryWait = defaultUploadRetryWait
 	}
 
 	authSource := p.AuthSource
@@ -149,8 +165,8 @@ func NewClient(p NewClientParams) (*Client, error) {
 }
 
 // buildChannels dials one gRPC connection per channel, each with its own
-// per-channel semaphore. Sizing mirrors the Gradle plugin's ClientBalancer:
-// numChannels = max(2, NumCPU/6), perChannelLimit = NumCPU.
+// per-channel semaphore. Sizing (numChannels, perChannelLimit) is defined at
+// package level and mirrors the Gradle plugin's ClientBalancer.
 //
 // If callers inject a stub (BitriseKVClient or CapabilitiesClient) the pool
 // collapses to a single, no-throttle channel that hands the stub straight
@@ -169,13 +185,10 @@ func buildChannels(p NewClientParams) ([]*channel, error) {
 	}
 
 	kaParams := keepalive.ClientParameters{
-		Time:                30 * time.Second,
-		Timeout:             10 * time.Second,
+		Time:                keepaliveTime,
+		Timeout:             keepaliveTimeout,
 		PermitWithoutStream: true,
 	}
-
-	numChannels := max(2, runtime.NumCPU()/6)
-	perChannelLimit := runtime.NumCPU()
 
 	channels := make([]*channel, 0, numChannels)
 	for range numChannels {

--- a/internal/build_cache/kv/methods.go
+++ b/internal/build_cache/kv/methods.go
@@ -115,14 +115,6 @@ func (c *Client) initiatePut(ctx context.Context, params PutParams) (*writer, er
 		release:      entry.release,
 	}
 
-	// Guarantee the pool-entry sem is released even when the caller abandons
-	// the stream (io.Copy error, AlreadyExists, context cancel) without
-	// calling Close.
-	go func() {
-		<-ctx.Done()
-		w.doRelease()
-	}()
-
 	return w, nil
 }
 
@@ -160,17 +152,6 @@ func (c *Client) initiateGet(ctx context.Context, logger log.Logger, name string
 		release:       entry.release,
 	}
 	go r.readStreamMetadata()
-
-	// Fallback release for cases where Close is not called (context cancel
-	// while a Read is in flight would surface as an error to the caller).
-	go func() {
-		<-ctx.Done()
-		r.releaseOnce.Do(func() {
-			if r.release != nil {
-				r.release()
-			}
-		})
-	}()
 
 	return r, nil
 }

--- a/internal/build_cache/kv/methods.go
+++ b/internal/build_cache/kv/methods.go
@@ -37,11 +37,15 @@ type FileDigest struct {
 }
 
 func (c *Client) GetCapabilities(ctx context.Context) error {
+	entry := c.pickEntry()
+	entry.acquire()
+	defer entry.release()
+
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	callCtx := metadata.NewOutgoingContext(timeoutCtx, c.getMethodCallMetadata(true))
 
-	_, err := c.capabilitiesClient.GetCapabilities(callCtx, &remoteexecution.GetCapabilitiesRequest{})
+	_, err := entry.capabilitiesClient.GetCapabilities(callCtx, &remoteexecution.GetCapabilitiesRequest{})
 	if err != nil {
 		st, ok := status.FromError(err)
 		if ok && st.Code() == codes.Unauthenticated {
@@ -86,8 +90,13 @@ func (c *Client) initiatePut(ctx context.Context, params PutParams) (*writer, er
 	// Timeout is the responsibility of the caller
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	stream, err := c.bitriseKVClient.Put(ctx)
+	entry := c.pickEntry()
+	entry.acquire()
+
+	stream, err := entry.bitriseKVClient.Put(ctx)
 	if err != nil {
+		entry.release()
+
 		st, ok := status.FromError(err)
 		if ok && st.Code() == codes.Unauthenticated {
 			return nil, ErrCacheUnauthenticated
@@ -98,12 +107,23 @@ func (c *Client) initiatePut(ctx context.Context, params PutParams) (*writer, er
 
 	resourceName := fmt.Sprintf("kv/%s", params.Name)
 
-	return &writer{
+	w := &writer{
 		stream:       stream,
 		resourceName: resourceName,
 		offset:       params.Offset,
 		fileSize:     params.FileSize,
-	}, nil
+		release:      entry.release,
+	}
+
+	// Guarantee the pool-entry sem is released even when the caller abandons
+	// the stream (io.Copy error, AlreadyExists, context cancel) without
+	// calling Close.
+	go func() {
+		<-ctx.Done()
+		w.doRelease()
+	}()
+
+	return w, nil
 }
 
 func (c *Client) initiateGet(ctx context.Context, logger log.Logger, name string, offset int64) (*reader, error) {
@@ -117,8 +137,14 @@ func (c *Client) initiateGet(ctx context.Context, logger log.Logger, name string
 		ReadOffset:   offset,
 		ReadLimit:    0,
 	}
-	stream, err := c.bitriseKVClient.Get(ctx, readReq)
+
+	entry := c.pickEntry()
+	entry.acquire()
+
+	stream, err := entry.bitriseKVClient.Get(ctx, readReq)
 	if err != nil {
+		entry.release()
+
 		st, ok := status.FromError(err)
 		if ok && st.Code() == codes.Unauthenticated {
 			return nil, ErrCacheUnauthenticated
@@ -131,13 +157,29 @@ func (c *Client) initiateGet(ctx context.Context, logger log.Logger, name string
 		logger:        logger,
 		stream:        stream,
 		metadataReady: make(chan struct{}),
+		release:       entry.release,
 	}
 	go r.readStreamMetadata()
+
+	// Fallback release for cases where Close is not called (context cancel
+	// while a Read is in flight would surface as an error to the caller).
+	go func() {
+		<-ctx.Done()
+		r.releaseOnce.Do(func() {
+			if r.release != nil {
+				r.release()
+			}
+		})
+	}()
 
 	return r, nil
 }
 
 func (c *Client) Delete(ctx context.Context, name string) error {
+	entry := c.pickEntry()
+	entry.acquire()
+	defer entry.release()
+
 	resourceName := fmt.Sprintf("kv/%s", name)
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
@@ -149,7 +191,7 @@ func (c *Client) Delete(ctx context.Context, name string) error {
 		ReadOffset:   0,
 		ReadLimit:    0,
 	}
-	_, err := c.bitriseKVClient.Delete(callCtx, readReq)
+	_, err := entry.bitriseKVClient.Delete(callCtx, readReq)
 	if err != nil {
 		return fmt.Errorf("initiate delete: %w", err)
 	}
@@ -166,13 +208,17 @@ func (c *Client) findMissing(ctx context.Context,
 			c.logger.Debugf("Retrying FindMissingBlobs... (attempt %d)", attempt)
 		}
 
+		entry := c.pickEntry()
+		entry.acquire()
+
 		timeoutCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 		callCtx := metadata.NewOutgoingContext(timeoutCtx, c.getMethodCallMetadata(false))
 
 		var err error
-		resp, err = c.casClient.FindMissingBlobs(callCtx, req)
+		resp, err = entry.casClient.FindMissingBlobs(callCtx, req)
 
 		cancel()
+		entry.release()
 
 		if err != nil {
 			c.logger.Errorf("Error in FindMissingBlobs attempt %d: %s", attempt, err)
@@ -325,12 +371,16 @@ func (c *Client) getMethodCallMetadata(logMD bool) metadata.MD {
 }
 
 func (c *Client) QueryWriteStatus(ctx context.Context, name string) (WriteStatus, error) {
+	entry := c.pickEntry()
+	entry.acquire()
+	defer entry.release()
+
 	resourceName := fmt.Sprintf("kv/%s", name)
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	callCtx := metadata.NewOutgoingContext(timeoutCtx, c.getMethodCallMetadata(false))
-	resp, err := c.bitriseKVClient.WriteStatus(callCtx, &bytestream.QueryWriteStatusRequest{
+	resp, err := entry.bitriseKVClient.WriteStatus(callCtx, &bytestream.QueryWriteStatusRequest{
 		ResourceName: resourceName,
 	})
 	if err != nil {

--- a/internal/build_cache/kv/methods.go
+++ b/internal/build_cache/kv/methods.go
@@ -37,15 +37,15 @@ type FileDigest struct {
 }
 
 func (c *Client) GetCapabilities(ctx context.Context) error {
-	entry := c.pickEntry()
-	entry.acquire()
-	defer entry.release()
+	ch := c.pickChannel()
+	ch.acquire()
+	defer ch.release()
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	callCtx := metadata.NewOutgoingContext(timeoutCtx, c.getMethodCallMetadata(true))
 
-	_, err := entry.capabilitiesClient.GetCapabilities(callCtx, &remoteexecution.GetCapabilitiesRequest{})
+	_, err := ch.capabilitiesClient.GetCapabilities(callCtx, &remoteexecution.GetCapabilitiesRequest{})
 	if err != nil {
 		st, ok := status.FromError(err)
 		if ok && st.Code() == codes.Unauthenticated {
@@ -90,12 +90,12 @@ func (c *Client) initiatePut(ctx context.Context, params PutParams) (*writer, er
 	// Timeout is the responsibility of the caller
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	entry := c.pickEntry()
-	entry.acquire()
+	ch := c.pickChannel()
+	ch.acquire()
 
-	stream, err := entry.bitriseKVClient.Put(ctx)
+	stream, err := ch.bitriseKVClient.Put(ctx)
 	if err != nil {
-		entry.release()
+		ch.release()
 
 		st, ok := status.FromError(err)
 		if ok && st.Code() == codes.Unauthenticated {
@@ -112,7 +112,7 @@ func (c *Client) initiatePut(ctx context.Context, params PutParams) (*writer, er
 		resourceName: resourceName,
 		offset:       params.Offset,
 		fileSize:     params.FileSize,
-		release:      entry.release,
+		release:      ch.release,
 	}
 
 	return w, nil
@@ -130,12 +130,12 @@ func (c *Client) initiateGet(ctx context.Context, logger log.Logger, name string
 		ReadLimit:    0,
 	}
 
-	entry := c.pickEntry()
-	entry.acquire()
+	ch := c.pickChannel()
+	ch.acquire()
 
-	stream, err := entry.bitriseKVClient.Get(ctx, readReq)
+	stream, err := ch.bitriseKVClient.Get(ctx, readReq)
 	if err != nil {
-		entry.release()
+		ch.release()
 
 		st, ok := status.FromError(err)
 		if ok && st.Code() == codes.Unauthenticated {
@@ -149,7 +149,7 @@ func (c *Client) initiateGet(ctx context.Context, logger log.Logger, name string
 		logger:        logger,
 		stream:        stream,
 		metadataReady: make(chan struct{}),
-		release:       entry.release,
+		release:       ch.release,
 	}
 	go r.readStreamMetadata()
 
@@ -157,9 +157,9 @@ func (c *Client) initiateGet(ctx context.Context, logger log.Logger, name string
 }
 
 func (c *Client) Delete(ctx context.Context, name string) error {
-	entry := c.pickEntry()
-	entry.acquire()
-	defer entry.release()
+	ch := c.pickChannel()
+	ch.acquire()
+	defer ch.release()
 
 	resourceName := fmt.Sprintf("kv/%s", name)
 
@@ -172,7 +172,7 @@ func (c *Client) Delete(ctx context.Context, name string) error {
 		ReadOffset:   0,
 		ReadLimit:    0,
 	}
-	_, err := entry.bitriseKVClient.Delete(callCtx, readReq)
+	_, err := ch.bitriseKVClient.Delete(callCtx, readReq)
 	if err != nil {
 		return fmt.Errorf("initiate delete: %w", err)
 	}
@@ -189,17 +189,17 @@ func (c *Client) findMissing(ctx context.Context,
 			c.logger.Debugf("Retrying FindMissingBlobs... (attempt %d)", attempt)
 		}
 
-		entry := c.pickEntry()
-		entry.acquire()
+		ch := c.pickChannel()
+		ch.acquire()
 
 		timeoutCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 		callCtx := metadata.NewOutgoingContext(timeoutCtx, c.getMethodCallMetadata(false))
 
 		var err error
-		resp, err = entry.casClient.FindMissingBlobs(callCtx, req)
+		resp, err = ch.casClient.FindMissingBlobs(callCtx, req)
 
 		cancel()
-		entry.release()
+		ch.release()
 
 		if err != nil {
 			c.logger.Errorf("Error in FindMissingBlobs attempt %d: %s", attempt, err)
@@ -352,16 +352,16 @@ func (c *Client) getMethodCallMetadata(logMD bool) metadata.MD {
 }
 
 func (c *Client) QueryWriteStatus(ctx context.Context, name string) (WriteStatus, error) {
-	entry := c.pickEntry()
-	entry.acquire()
-	defer entry.release()
+	ch := c.pickChannel()
+	ch.acquire()
+	defer ch.release()
 
 	resourceName := fmt.Sprintf("kv/%s", name)
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	callCtx := metadata.NewOutgoingContext(timeoutCtx, c.getMethodCallMetadata(false))
-	resp, err := entry.bitriseKVClient.WriteStatus(callCtx, &bytestream.QueryWriteStatusRequest{
+	resp, err := ch.bitriseKVClient.WriteStatus(callCtx, &bytestream.QueryWriteStatusRequest{
 		ResourceName: resourceName,
 	})
 	if err != nil {

--- a/internal/build_cache/kv/pool_internal_test.go
+++ b/internal/build_cache/kv/pool_internal_test.go
@@ -1,0 +1,137 @@
+//go:build unit
+
+package kv
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	remoteexecution "github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/build/bazel/remote/execution/v2"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/kv_storage"
+)
+
+// buildPool with no injected stubs dials one entry per channel using
+// max(2, NumCPU/6). Each entry gets a throttling semaphore sized to NumCPU.
+func TestBuildPool_DefaultSizing(t *testing.T) {
+	pool, err := buildPool(NewClientParams{
+		UseInsecure: true,
+		Host:        "localhost:0",
+		AuthConfig:  common.CacheAuthConfig{AuthToken: "tok"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, e := range pool {
+			if e.conn != nil {
+				_ = e.conn.Close()
+			}
+		}
+	})
+
+	wantChannels := max(2, runtime.NumCPU()/6)
+	assert.Len(t, pool, wantChannels)
+	for _, e := range pool {
+		require.NotNil(t, e.conn)
+		require.NotNil(t, e.sem)
+		assert.Equal(t, runtime.NumCPU(), cap(e.sem))
+		assert.NotNil(t, e.bitriseKVClient)
+		assert.NotNil(t, e.capabilitiesClient)
+		assert.NotNil(t, e.casClient)
+	}
+}
+
+// pickEntry hands entries out round-robin across concurrent callers.
+// Over 1000 evenly-distributed picks on 4 goroutines with a 4-entry pool
+// each entry should see ~250 hits.
+func TestClient_PickEntry_RoundRobinConcurrent(t *testing.T) {
+	const (
+		poolSize   = 4
+		callsTotal = 1000
+		goroutines = 4
+	)
+	pool := make([]*poolEntry, poolSize)
+	for i := range pool {
+		pool[i] = &poolEntry{}
+	}
+	c := &Client{pool: pool}
+
+	counts := make([]atomic.Int64, poolSize)
+	callsPerG := callsTotal / goroutines
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range callsPerG {
+				e := c.pickEntry()
+				for i := range pool {
+					if pool[i] == e {
+						counts[i].Add(1)
+
+						break
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	for i := range counts {
+		got := counts[i].Load()
+		assert.GreaterOrEqualf(t, got, int64(200), "entry %d saw %d calls, want >= 200", i, got)
+		assert.LessOrEqualf(t, got, int64(300), "entry %d saw %d calls, want <= 300", i, got)
+	}
+}
+
+// Injecting BitriseKVClient (or CapabilitiesClient) collapses the pool to one
+// entry with no semaphore, so pickEntry never blocks — even under load that
+// would otherwise exhaust perChannelLimit.
+func TestBuildPool_InjectedStubIsUnthrottled(t *testing.T) {
+	pool, err := buildPool(NewClientParams{
+		BitriseKVClient: &kvStubClient{},
+	})
+	require.NoError(t, err)
+	require.Len(t, pool, 1)
+	assert.Nil(t, pool[0].sem)
+	assert.Nil(t, pool[0].conn)
+
+	c := &Client{pool: pool}
+
+	// Many concurrent picks + acquires — the nil sem short-circuits, none block.
+	var wg sync.WaitGroup
+	for range 500 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			e := c.pickEntry()
+			e.acquire()
+			e.release()
+		}()
+	}
+	wg.Wait()
+}
+
+// Minimal stub to satisfy the non-nil check in buildPool without pulling in moq.
+type kvStubClient struct {
+	kv_storage.KVStorageClient
+}
+
+// Ensure the capabilities-only injection path also collapses the pool.
+func TestBuildPool_InjectedCapabilitiesStubOnly(t *testing.T) {
+	pool, err := buildPool(NewClientParams{
+		CapabilitiesClient: capStubClient{},
+	})
+	require.NoError(t, err)
+	require.Len(t, pool, 1)
+	assert.Nil(t, pool[0].sem)
+}
+
+type capStubClient struct {
+	remoteexecution.CapabilitiesClient
+}

--- a/internal/build_cache/kv/pool_internal_test.go
+++ b/internal/build_cache/kv/pool_internal_test.go
@@ -16,17 +16,17 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/proto/kv_storage"
 )
 
-// buildPool with no injected stubs dials one entry per channel using
+// buildChannels with no injected stubs dials one entry per channel using
 // max(2, NumCPU/6). Each entry gets a throttling semaphore sized to NumCPU.
 func TestBuildPool_DefaultSizing(t *testing.T) {
-	pool, err := buildPool(NewClientParams{
+	channels, err := buildChannels(NewClientParams{
 		UseInsecure: true,
 		Host:        "localhost:0",
 		AuthConfig:  common.CacheAuthConfig{AuthToken: "tok"},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		for _, e := range pool {
+		for _, e := range channels {
 			if e.conn != nil {
 				_ = e.conn.Close()
 			}
@@ -34,8 +34,8 @@ func TestBuildPool_DefaultSizing(t *testing.T) {
 	})
 
 	wantChannels := max(2, runtime.NumCPU()/6)
-	assert.Len(t, pool, wantChannels)
-	for _, e := range pool {
+	assert.Len(t, channels, wantChannels)
+	for _, e := range channels {
 		require.NotNil(t, e.conn)
 		require.NotNil(t, e.sem)
 		assert.Equal(t, runtime.NumCPU(), cap(e.sem))
@@ -45,8 +45,8 @@ func TestBuildPool_DefaultSizing(t *testing.T) {
 	}
 }
 
-// pickEntry hands entries out round-robin across concurrent callers.
-// Over 1000 evenly-distributed picks on 4 goroutines with a 4-entry pool
+// pickChannel hands entries out round-robin across concurrent callers.
+// Over 1000 evenly-distributed picks on 4 goroutines with a 4-entry channels
 // each entry should see ~250 hits.
 func TestClient_PickEntry_RoundRobinConcurrent(t *testing.T) {
 	const (
@@ -54,11 +54,11 @@ func TestClient_PickEntry_RoundRobinConcurrent(t *testing.T) {
 		callsTotal = 1000
 		goroutines = 4
 	)
-	pool := make([]*poolEntry, poolSize)
-	for i := range pool {
-		pool[i] = &poolEntry{}
+	channels := make([]*channel, poolSize)
+	for i := range channels {
+		channels[i] = &channel{}
 	}
-	c := &Client{pool: pool}
+	c := &Client{channels: channels}
 
 	counts := make([]atomic.Int64, poolSize)
 	callsPerG := callsTotal / goroutines
@@ -69,9 +69,9 @@ func TestClient_PickEntry_RoundRobinConcurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range callsPerG {
-				e := c.pickEntry()
-				for i := range pool {
-					if pool[i] == e {
+				e := c.pickChannel()
+				for i := range channels {
+					if channels[i] == e {
 						counts[i].Add(1)
 
 						break
@@ -89,19 +89,19 @@ func TestClient_PickEntry_RoundRobinConcurrent(t *testing.T) {
 	}
 }
 
-// Injecting BitriseKVClient (or CapabilitiesClient) collapses the pool to one
-// entry with no semaphore, so pickEntry never blocks — even under load that
+// Injecting BitriseKVClient (or CapabilitiesClient) collapses the channels to one
+// entry with no semaphore, so pickChannel never blocks — even under load that
 // would otherwise exhaust perChannelLimit.
 func TestBuildPool_InjectedStubIsUnthrottled(t *testing.T) {
-	pool, err := buildPool(NewClientParams{
+	channels, err := buildChannels(NewClientParams{
 		BitriseKVClient: &kvStubClient{},
 	})
 	require.NoError(t, err)
-	require.Len(t, pool, 1)
-	assert.Nil(t, pool[0].sem)
-	assert.Nil(t, pool[0].conn)
+	require.Len(t, channels, 1)
+	assert.Nil(t, channels[0].sem)
+	assert.Nil(t, channels[0].conn)
 
-	c := &Client{pool: pool}
+	c := &Client{channels: channels}
 
 	// Many concurrent picks + acquires — the nil sem short-circuits, none block.
 	var wg sync.WaitGroup
@@ -109,7 +109,7 @@ func TestBuildPool_InjectedStubIsUnthrottled(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			e := c.pickEntry()
+			e := c.pickChannel()
 			e.acquire()
 			e.release()
 		}()
@@ -117,19 +117,19 @@ func TestBuildPool_InjectedStubIsUnthrottled(t *testing.T) {
 	wg.Wait()
 }
 
-// Minimal stub to satisfy the non-nil check in buildPool without pulling in moq.
+// Minimal stub to satisfy the non-nil check in buildChannels without pulling in moq.
 type kvStubClient struct {
 	kv_storage.KVStorageClient
 }
 
-// Ensure the capabilities-only injection path also collapses the pool.
+// Ensure the capabilities-only injection path also collapses the channels.
 func TestBuildPool_InjectedCapabilitiesStubOnly(t *testing.T) {
-	pool, err := buildPool(NewClientParams{
+	channels, err := buildChannels(NewClientParams{
 		CapabilitiesClient: capStubClient{},
 	})
 	require.NoError(t, err)
-	require.Len(t, pool, 1)
-	assert.Nil(t, pool[0].sem)
+	require.Len(t, channels, 1)
+	assert.Nil(t, channels[0].sem)
 }
 
 type capStubClient struct {

--- a/internal/build_cache/kv/upload.go
+++ b/internal/build_cache/kv/upload.go
@@ -143,6 +143,7 @@ func (c *Client) uploadStream(ctx context.Context, source io.ReadSeeker, key, ch
 
 			return fmt.Errorf("create kv put client (with key %s): %w", key, err), false
 		}
+		defer kvWriter.Close()
 
 		bytesSent := int64(0)
 		if size > 0 {

--- a/internal/xcelerate/proxy/proxy.go
+++ b/internal/xcelerate/proxy/proxy.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -51,7 +50,6 @@ type Proxy struct {
 	kvClient                Client
 	pushEnabled             bool
 	sessionMutex            sync.Mutex
-	ccSemaphore             chan struct{}
 	capabilitiesCalled      bool
 	sessionState            *sessionState
 	skipGetCapabilitiesCall []grpc.ServiceDesc
@@ -72,12 +70,6 @@ type Proxy struct {
 const defaultInactivityTimeout = 5 * time.Minute
 
 func NewProxy(kvClient Client, pushEnabled bool, logger log.Logger, loggerFactory LoggerFactory, emitter InvocationEmitter) *Proxy {
-	// Note: Gradle plugin uses a client balancer, with multiple channels (min 2), each with multiple connections.
-	// For a simple implementation, we only have one channel with multiple connections.
-	numChan := max(2, runtime.NumCPU()/6)
-	ccLimit := numChan * runtime.NumCPU()
-	logger.Infof("Setting up proxy with concurrency limit: %d", ccLimit)
-
 	//nolint:exhaustruct
 	proxy := &Proxy{
 		kvClient:      kvClient,
@@ -86,7 +78,6 @@ func NewProxy(kvClient Client, pushEnabled bool, logger log.Logger, loggerFactor
 		logger:        logger,
 		loggerFactory: loggerFactory,
 		emitter:       emitter,
-		ccSemaphore:   make(chan struct{}, ccLimit),
 		skipGetCapabilitiesCall: []grpc.ServiceDesc{
 			session.Session_ServiceDesc, // skip GetCapabilities call for session service methods
 		},
@@ -308,9 +299,6 @@ func (p *Proxy) GetSessionStats(_ context.Context, _ *emptypb.Empty) (*session.G
 }
 
 func (p *Proxy) Get(ctx context.Context, request *llvmcas.CASGetRequest) (*llvmcas.CASGetResponse, error) {
-	p.ccSemaphore <- struct{}{}
-	defer func() { <-p.ccSemaphore }()
-
 	key := createLLVMCasKey(request.GetCasId())
 
 	p.logger.TDebugf("Get called with request: %s", key)
@@ -385,9 +373,6 @@ func (p *Proxy) Get(ctx context.Context, request *llvmcas.CASGetRequest) (*llvmc
 }
 
 func (p *Proxy) Put(ctx context.Context, request *llvmcas.CASPutRequest) (*llvmcas.CASPutResponse, error) {
-	p.ccSemaphore <- struct{}{}
-	defer func() { <-p.ccSemaphore }()
-
 	p.logger.TDebugf("Put called with references: %s", request.GetData().GetReferences())
 
 	var key string
@@ -484,9 +469,6 @@ func (p *Proxy) Put(ctx context.Context, request *llvmcas.CASPutRequest) (*llvmc
 }
 
 func (p *Proxy) Load(ctx context.Context, request *llvmcas.CASLoadRequest) (*llvmcas.CASLoadResponse, error) {
-	p.ccSemaphore <- struct{}{}
-	defer func() { <-p.ccSemaphore }()
-
 	key := createLLVMCasKey(request.GetCasId())
 
 	p.logger.TDebugf("Load called with request: %s", key)
@@ -554,9 +536,6 @@ func (p *Proxy) Load(ctx context.Context, request *llvmcas.CASLoadRequest) (*llv
 }
 
 func (p *Proxy) Save(ctx context.Context, request *llvmcas.CASSaveRequest) (*llvmcas.CASSaveResponse, error) {
-	p.ccSemaphore <- struct{}{}
-	defer func() { <-p.ccSemaphore }()
-
 	var key string
 
 	errorHandler := func(err error) *llvmcas.CASSaveResponse {
@@ -662,9 +641,6 @@ func (p *Proxy) Save(ctx context.Context, request *llvmcas.CASSaveRequest) (*llv
 }
 
 func (p *Proxy) GetValue(ctx context.Context, request *llvmkv.GetValueRequest) (*llvmkv.GetValueResponse, error) {
-	p.ccSemaphore <- struct{}{}
-	defer func() { <-p.ccSemaphore }()
-
 	key := createLLVMKVKey(request.GetKey())
 
 	var hit bool
@@ -729,9 +705,6 @@ func (p *Proxy) GetValue(ctx context.Context, request *llvmkv.GetValueRequest) (
 }
 
 func (p *Proxy) PutValue(ctx context.Context, request *llvmkv.PutValueRequest) (*llvmkv.PutValueResponse, error) {
-	p.ccSemaphore <- struct{}{}
-	defer func() { <-p.ccSemaphore }()
-
 	key := createLLVMKVKey(request.GetKey())
 
 	p.logger.TDebugf("PutValue called with key: %s", key)


### PR DESCRIPTION
[ACI-5290](https://bitrise.atlassian.net/browse/ACI-5290)

## TLDR

- KV client dials a pool of `max(2, NumCPU/6)` gRPC conns; round-robin picks one per RPC.
- Per-channel `chan struct{}` semaphore (size `NumCPU`) throttles inside the KV client; proxy `ccSemaphore` deleted (was double-throttle).
- `keepalive.ClientParameters{Time: 30s, Timeout: 10s, PermitWithoutStream: true}` on every conn.

## Why the 30s CAS waiter starved

Apple's `libToolchainCASPlugin.dylib` bakes in a 30s pool-waiter (`GRPCChannelPool.Configuration.ConnectionPool.maxWaitTime` at `0x1e630` = `30_000_000_000` ns) — not tunable via any exposed plugin option. Any queue > 30s between the plugin issuing an RPC and an HTTP/2 stream becoming available surfaces as `CAS operation failed: deadlineExceeded(connectionError: nil)`. Two chokepoints in the CLI created that queue: the xcelerate proxy's `ccSemaphore` capped concurrent RPC handlers at `max(2, NumCPU/6) * NumCPU` (20 on a 10-core Mac), and the KV client dialed a single `grpc.ClientConn` for all three sub-clients — every downstream RPC multiplexed over one HTTP/2 conn to BE. Fix mirrors the gradle plugin's `ClientBalancer`: one pool of connections, per-channel throttling inside the KV client, and the outer proxy semaphore removed so gRPC's own stream backpressure is the only limit.

## Testing

`xcodebuild build` on IceCubesApp, remote CAS fully populated (10 833 blobs / ~1 GB), identical workload each run:

| | Before | After |
|---|---|---|
| Wall time | 24m 10s | 1m 18.7s |
| Proxy blob hits | 10 757/10 757 (100%) | 10 833/10 833 (100%) |
| Xcode task hits | 1 820/1 896 (96%) | 1 896/1 896 (100%) |
| Cache-reported errors | 76 | 0 |
| Failed-upload lines in proxy log | 380+ | 0 |
| Per-session proxy log | 111 KB (retry noise) | 136 B |
| Post-run retries poisoning next session | yes | no |

`make lint` clean; `go test -tags unit -race ./internal/build_cache/kv/...` green (16 tests including 4 new for pool sizing, round-robin distribution, and stub-injection collapse).


[ACI-5290]: https://bitrise.atlassian.net/browse/ACI-5290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ