### PR TITLE
[ACI-5274] Assert the activation write leaves the other backend alone

### DIFF
--- a/internal/auth/live/pin_test.go
+++ b/internal/auth/live/pin_test.go
@@ -102,3 +102,38 @@ func TestResolvePinned_FallbackMergesAgainstTheFileNotTheDeadKeychain(t *testing
 	assert.Equal(t, "refresh-me", after.RefreshToken, "the file's refresh token must survive a keychain outage")
 	assert.Equal(t, "dev", after.Username)
 }
+
+// Guards what the fallback test cannot: on the happy path the file store must be
+// untouched. Switching to store.SaveExclusiveWithFallback would clear it, taking a
+// login stored there with it, and every other test here would still pass.
+func TestResolvePinned_HealthyKeychainLeavesTheFileUntouched(t *testing.T) {
+	keyring.MockInit()
+	t.Setenv("HOME", t.TempDir())
+
+	fileLogin := auth.TokenSet{
+		AuthToken:    "file-pat",
+		WorkspaceID:  "file-ws",
+		RefreshToken: "file-refresh",
+		Username:     "dev",
+	}
+	require.NoError(t, store.NewFile().Save(fileLogin))
+
+	// Backends[0] is the pin target; the env credential outranks the file, so the
+	// pin actually runs.
+	r := &Resolver{
+		Backends:       []store.Store{store.NewKeychain(), store.NewFile()},
+		AnalyticsBlock: func() (auth.Credential, auth.Origin, bool) { return auth.Credential{}, auth.Origin{}, false },
+	}
+
+	_, origin, err := r.ResolvePinned(t.Context(), envVars(), false)
+	require.NoError(t, err)
+	require.Equal(t, auth.BackendEnv, origin.Backend, "the env credential must be the one being pinned")
+
+	kc, err := store.NewKeychain().Load()
+	require.NoError(t, err, "the keychain is the target and must have been written")
+	assert.Equal(t, envToken, kc.AuthToken)
+
+	onDisk, ok := multiplatformconfig.ReadCredentials(utils.DefaultOsProxy{}, utils.DefaultDecoderFactory{})
+	require.True(t, ok, "the file store must still hold its record — an incidental write must not clear it")
+	assert.Equal(t, fileLogin, onDisk, "the file store must be byte-for-byte untouched")
+}

--- a/scripts/lint_arch.sh
+++ b/scripts/lint_arch.sh
@@ -38,16 +38,17 @@ report() {
 # ─────────────────────────────────────────────────────────────────────────────
 
 tokenset_allowed=(
-	# path regex                          # why it may name TokenSet
-	'^\./internal/auth/'                  # L0-L4: the type's own tree
-	'^\./internal/config/multiplatform/'  # L1: the file backend serialises it
-	'^\./cmd/auth/'                       # auth login/set/clear write whole records; auth status audits them
-	'^\./cmd/common/interactive/'         # the wizard completes a sign-in and stores the result
-	'^\./internal/authprompt/'            # the doctor's auth fixer writes the credential the user typed
-	'_test\.go$'                          # tests construct records to drive the layers below
+	'^internal/auth/'                   # L0-L4: the type's own tree
+	'^internal/config/multiplatform/'   # L1: the file backend serialises it
+	'^cmd/auth/'                        # auth login/set/clear write whole records; auth status audits them
+	'^cmd/common/interactive/'          # the wizard completes a sign-in and stores the result
+	'^internal/authprompt/'             # the doctor's auth fixer writes the credential the user typed
+	'_test\.go$'                        # tests construct records to drive the layers below
 )
 
-hits=$(grep -rln 'auth\.TokenSet\|authpkg\.TokenSet' --include='*.go' . 2>/dev/null || true)
+# git ls-files, not `grep -r .`, which also descends into nested git worktrees and
+# vendored copies where these prefixes do not match.
+hits=$(git ls-files '*.go' | xargs grep -ln 'auth\.TokenSet\|authpkg\.TokenSet' 2>/dev/null || true)
 for allow in "${tokenset_allowed[@]}"; do
 	hits=$(printf '%s\n' "$hits" | grep -v "$allow" || true)
 done


### PR DESCRIPTION
[ACI-5274](https://bitrise.atlassian.net/browse/ACI-5274)

Follow-up to #459.

## TLDR

- Assert the invariant `ResolvePinned`'s happy path relied on but never checked: when the keychain write succeeds, the file store is left untouched.
- Fix `lint-arch` walking into nested git worktrees, where its path-prefixed allow-list produced 13 false positives.

## Why the missing case mattered

`ResolvePinned` materialises an injected credential during activation. That is *incidental* to what the user asked for, so it uses `store.SaveWithFallback` — which writes one backend and leaves the others alone — rather than `SaveExclusiveWithFallback`, which clears them.

Nothing asserted the difference. The existing fallback test only covers the path where the keychain is **dead**, so it says nothing about the healthy case. Swapping in the exclusive save passed every test in the file while silently clearing a login the user had deliberately stored with `auth login --storage=file`.

The new case primes the file store, resolves an env credential with a healthy keychain, and asserts the keychain got the write and the file record is byte-for-byte unchanged. Confirmed by making the regression: with `SaveExclusiveWithFallback` swapped in, it fails on the file's credentials block being gone.

## Testing

- `make lint` (golangci-lint + `lint_arch.sh`) and `go test -race ./...` clean.
- New test verified to fail against the flip it guards, not just to pass as written.
- `lint-arch` re-verified after the `git ls-files` change: both rules still fire on a planted `auth.TokenSet` reference and a planted `store.NewKeychain()` call in `pkg/browse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ACI-5274]: https://bitrise.atlassian.net/browse/ACI-5274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ