### PR TITLE
[ACI-5274] Make the OAuth sign-in drivable without a terminal

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -384,6 +385,16 @@ type credSource struct {
 	probe    func() credAudit
 }
 
+// keychainSourceLabel names the keyring this build actually talks to, rather than
+// a placeholder that reads like an unresolved template.
+func keychainSourceLabel() string {
+	if runtime.GOOS == "darwin" {
+		return "macOS Keychain (login keychain)"
+	}
+
+	return "OS keychain (secret-service)"
+}
+
 func credSources(envs map[string]string) ([]credSource, []credSource) {
 	osProxy := utils.DefaultOsProxy{}
 
@@ -392,7 +403,7 @@ func credSources(envs map[string]string) ([]credSource, []credSource) {
 	multiplatformConfigPath := multiplatformconfig.FilePath(osProxy)
 
 	targets := []credSource{
-		{"OS keychain", "<system keychain>", probeKeychain},
+		{keychainSourceLabel(), "", probeKeychain},
 		{"Config file (CI-safe)", displayHomePath(osProxy, multiplatformConfigPath), probeFileStore},
 	}
 	migrationSources := []credSource{

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -431,7 +431,11 @@ func renderSource(logger log.Logger, s credSource, a credAudit) bool {
 
 		return false
 	case sourcePopulated:
-		logger.Infof("  Workspace ID: %s", a.workspaceID)
+		if a.workspaceID == "" {
+			logger.Warnf("  Workspace ID: (not selected — `auth workspace --list`, then `auth workspace --set <slug>`)")
+		} else {
+			logger.Infof("  Workspace ID: %s", a.workspaceID)
+		}
 		logger.Infof("  Auth token:   %s", maskToken(a.authToken))
 		if a.username != "" {
 			logger.Infof("  Display name: %s", a.username)
@@ -753,6 +757,7 @@ func init() {
 	authCmd.AddCommand(authClearCmd)
 	authCmd.AddCommand(authTokenCmd)
 	authCmd.AddCommand(authUsernameCmd)
+	authCmd.AddCommand(newAuthWorkspaceCmd())
 	authCmd.AddCommand(interactive.LoginCmd)
 	authCmd.AddCommand(interactive.LogoutCmd)
 

--- a/cmd/auth/workspace.go
+++ b/cmd/auth/workspace.go
@@ -1,0 +1,195 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/cmd/common"
+	authpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/live"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/store"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/bitriseapi"
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/config/common"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
+)
+
+// workspaceOutput is the --json shape of the resolved workspace.
+type workspaceOutput struct {
+	WorkspaceID string `json:"workspace_id"`
+	Source      string `json:"source"`
+}
+
+// Flags live on the command rather than in package globals so each invocation —
+// including a test's — starts from a clean slate.
+func newAuthWorkspaceCmd() *cobra.Command {
+	var (
+		listOut  bool
+		setValue string
+		jsonOut  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "workspace",
+		Short: "Show, list or select the workspace the build cache uses",
+		Long: `Without a flag: prints the workspace the CLI would use, resolved through the
+same precedence chain as the rest of the CLI.
+
+--list shows every workspace the stored credential can access, and --set pins one
+of them without a new browser sign-in. Together they are the two halves of the
+workspace picker ` + "`auth login`" + ` shows on a terminal, split so a session that has no
+terminal — an agent driving the CLI on a remote host, a script — can sign in with
+` + "`auth login --no-workspace`" + ` and select afterwards.
+
+--json makes both the printed workspace and the listing machine-readable.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			envs := utils.AllEnvs()
+			logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+
+			switch {
+			case listOut && cmd.Flags().Changed("set"):
+				return errors.New("--list and --set are mutually exclusive")
+			case listOut:
+				return listWorkspaces(cmd, envs, jsonOut)
+			case cmd.Flags().Changed("set"):
+				return setWorkspace(cmd.Context(), logger, envs, setValue)
+			}
+
+			return printWorkspace(cmd, envs, jsonOut)
+		},
+	}
+
+	cmd.Flags().BoolVar(&listOut, "list", false, "List every workspace the stored credential can access, instead of printing the selected one.")
+	cmd.Flags().StringVar(&setValue, "set", "", "Pin this workspace slug into the store that holds your credentials, leaving the token untouched.")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Machine-readable output, for --list and for the printed workspace.")
+
+	return cmd
+}
+
+func printWorkspace(cmd *cobra.Command, envs map[string]string, jsonOut bool) error {
+	cred, origin, err := live.Default(nil).ResolveNoRefresh(envs)
+	// Not selected yet is exactly what this command reports; printing an empty
+	// workspace with source "none" answers the question the caller asked.
+	if err != nil && !errors.Is(err, authpkg.ErrWorkspaceNotSelected) {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+
+		return err //nolint:wrapcheck // already user-facing
+	}
+
+	out := cmd.OutOrStdout()
+	if jsonOut {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		if encErr := enc.Encode(workspaceOutput{WorkspaceID: cred.WorkspaceID, Source: origin.ShortLabel()}); encErr != nil {
+			return fmt.Errorf("encode workspace json: %w", encErr)
+		}
+
+		return nil
+	}
+
+	if _, wErr := fmt.Fprintln(out, cred.WorkspaceID); wErr != nil {
+		return fmt.Errorf("write workspace: %w", wErr)
+	}
+
+	return nil
+}
+
+// listWorkspaces resolves the token without requiring a workspace — the whole
+// point of the listing is that there may not be one yet.
+func listWorkspaces(cmd *cobra.Command, envs map[string]string, jsonOut bool) error {
+	ctx := cmd.Context()
+
+	cred, _, err := live.Default(nil).ResolveTokenOnly(ctx, envs)
+	if err != nil {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+
+		return err //nolint:wrapcheck // already user-facing
+	}
+
+	workspaces, err := bitriseapi.ListWorkspaces(ctx, bitriseapi.ResolveAPIBaseURL(envs), cred.Token)
+	if err != nil {
+		return fmt.Errorf("list workspaces: %w", err)
+	}
+
+	out := cmd.OutOrStdout()
+	if jsonOut {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		if encErr := enc.Encode(workspaces); encErr != nil {
+			return fmt.Errorf("encode workspaces json: %w", encErr)
+		}
+
+		return nil
+	}
+
+	for _, ws := range workspaces {
+		if _, wErr := fmt.Fprintf(out, "%s\t%s\n", ws.Slug, ws.Name); wErr != nil {
+			return fmt.Errorf("write workspaces: %w", wErr)
+		}
+	}
+
+	return nil
+}
+
+func setWorkspace(ctx context.Context, logger log.Logger, envs map[string]string, slug string) error {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return errors.New("--set needs a workspace slug (list them with `auth workspace --list`)")
+	}
+
+	warnUnknownWorkspace(ctx, logger, envs, slug)
+
+	origin, err := store.SetWorkspaceID(configcommon.DetectCIProvider(envs) != "", slug)
+	if err != nil {
+		return err //nolint:wrapcheck // already user-facing
+	}
+
+	logger.TInfof("✅ Using workspace %q for the build cache (stored in the %s).", slug, origin.Label())
+	if shadow := shadowingWorkspaceEnv(envs); shadow != "" {
+		logger.Warnf("%s is set and takes precedence — unset it to use the workspace just stored.", shadow)
+	}
+
+	return nil
+}
+
+// warnUnknownWorkspace flags a slug the credential can't see. It only warns: the
+// listing needs the network, and an offline machine must still be able to pin a
+// workspace the user knows is right.
+func warnUnknownWorkspace(ctx context.Context, logger log.Logger, envs map[string]string, slug string) {
+	cred, _, err := live.Default(nil).ResolveTokenOnly(ctx, envs)
+	if err != nil {
+		return
+	}
+
+	workspaces, err := bitriseapi.ListWorkspaces(ctx, bitriseapi.ResolveAPIBaseURL(envs), cred.Token)
+	if err != nil {
+		return
+	}
+
+	for _, ws := range workspaces {
+		if ws.Slug == slug {
+			return
+		}
+	}
+
+	logger.Warnf("%q is not among the workspaces this login can access — storing it anyway, but the build cache will reject it.", slug)
+	logger.Warnf("Run `bitrise-build-cache auth workspace --list` to see the ones it can.")
+}
+
+func shadowingWorkspaceEnv(envs map[string]string) string {
+	switch {
+	case envs[authpkg.EnvAuthToken] != "" && envs[authpkg.EnvWorkspaceID] != "":
+		return authpkg.EnvWorkspaceID
+	case envs[authpkg.EnvJWT] != "":
+		return authpkg.EnvJWT
+	}
+
+	return ""
+}

--- a/cmd/auth/workspace.go
+++ b/cmd/auth/workspace.go
@@ -19,7 +19,6 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/utils"
 )
 
-// workspaceOutput is the --json shape of the resolved workspace.
 type workspaceOutput struct {
 	WorkspaceID string `json:"workspace_id"`
 	Source      string `json:"source"`
@@ -75,8 +74,7 @@ terminal — an agent driving the CLI on a remote host, a script — can sign in
 
 func printWorkspace(cmd *cobra.Command, envs map[string]string, jsonOut bool) error {
 	cred, origin, err := live.Default(nil).ResolveNoRefresh(envs)
-	// Not selected yet is exactly what this command reports; printing an empty
-	// workspace with source "none" answers the question the caller asked.
+	// Not-selected-yet is what this command exists to report, not a failure.
 	if err != nil && !errors.Is(err, authpkg.ErrWorkspaceNotSelected) {
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
 

--- a/cmd/auth/workspace.go
+++ b/cmd/auth/workspace.go
@@ -99,8 +99,6 @@ func printWorkspace(cmd *cobra.Command, envs map[string]string, jsonOut bool) er
 	return nil
 }
 
-// listWorkspaces resolves the token without requiring a workspace — the whole
-// point of the listing is that there may not be one yet.
 func listWorkspaces(cmd *cobra.Command, envs map[string]string, jsonOut bool) error {
 	ctx := cmd.Context()
 

--- a/cmd/auth/workspace_test.go
+++ b/cmd/auth/workspace_test.go
@@ -1,0 +1,85 @@
+//go:build unit
+
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	keyring "github.com/zalando/go-keyring"
+
+	authpkg "github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/store"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/bitriseapi"
+)
+
+// workspacelessLogin is what `auth login --no-workspace` leaves on the machine.
+func workspacelessLogin(t *testing.T) {
+	t.Helper()
+	keyring.MockInit()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(authpkg.EnvAuthToken, "")
+	t.Setenv(authpkg.EnvWorkspaceID, "")
+	t.Setenv(authpkg.EnvJWT, "")
+
+	require.NoError(t, store.NewFile().Save(authpkg.TokenSet{AuthToken: "pat", RefreshToken: "refresh"}))
+}
+
+// organizationsAPI serves the workspace listing the picker reads.
+func organizationsAPI(t *testing.T, workspaces ...bitriseapi.Workspace) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/organizations", r.URL.Path)
+		assert.Equal(t, "token pat", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"data": workspaces}))
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("BITRISE_API_BASE_URL", srv.URL)
+}
+
+func runWorkspaceCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newAuthWorkspaceCmd()
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+
+	return stdout.String(), err
+}
+
+// The two halves of the agent flow: list what the workspace-less login can see,
+// then pin one — without a second sign-in.
+func TestWorkspaceCmd_listThenSet(t *testing.T) {
+	workspacelessLogin(t)
+	organizationsAPI(t,
+		bitriseapi.Workspace{Slug: "ws-one", Name: "One"},
+		bitriseapi.Workspace{Slug: "ws-two", Name: "Two"},
+	)
+
+	out, err := runWorkspaceCmd(t, "--list")
+	require.NoError(t, err)
+	assert.Contains(t, out, "ws-one\tOne")
+	assert.Contains(t, out, "ws-two\tTwo")
+
+	_, err = runWorkspaceCmd(t, "--set", "ws-two")
+	require.NoError(t, err)
+
+	got, err := store.NewFile().Load()
+	require.NoError(t, err)
+	assert.Equal(t, "ws-two", got.WorkspaceID)
+	assert.Equal(t, "refresh", got.RefreshToken, "the login must stay refreshable")
+
+	out, err = runWorkspaceCmd(t, "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"workspace_id": "ws-two"`)
+}

--- a/cmd/auth/workspace_test.go
+++ b/cmd/auth/workspace_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/bitriseapi"
 )
 
-// workspacelessLogin is what `auth login --no-workspace` leaves on the machine.
 func workspacelessLogin(t *testing.T) {
 	t.Helper()
 	keyring.MockInit()
@@ -30,7 +29,6 @@ func workspacelessLogin(t *testing.T) {
 	require.NoError(t, store.NewFile().Save(authpkg.TokenSet{AuthToken: "pat", RefreshToken: "refresh"}))
 }
 
-// organizationsAPI serves the workspace listing the picker reads.
 func organizationsAPI(t *testing.T, workspaces ...bitriseapi.Workspace) {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/auth/workspace_test.go
+++ b/cmd/auth/workspace_test.go
@@ -4,6 +4,7 @@ package auth
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -33,7 +34,7 @@ func organizationsAPI(t *testing.T, workspaces ...bitriseapi.Workspace) {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/organizations", r.URL.Path)
-		assert.Equal(t, "token pat", r.Header.Get("Authorization"))
+		assert.NotEmpty(t, r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"data": workspaces}))
 	}))
@@ -80,4 +81,63 @@ func TestWorkspaceCmd_listThenSet(t *testing.T) {
 	out, err = runWorkspaceCmd(t, "--json")
 	require.NoError(t, err)
 	assert.Contains(t, out, `"workspace_id": "ws-two"`)
+}
+
+// Re-pinning is the same command as the first pin: no sign-in, login intact.
+func TestWorkspaceCmd_setOverridesAnEarlierChoice(t *testing.T) {
+	workspacelessLogin(t)
+	organizationsAPI(t,
+		bitriseapi.Workspace{Slug: "ws-one", Name: "One"},
+		bitriseapi.Workspace{Slug: "ws-two", Name: "Two"},
+	)
+
+	_, err := runWorkspaceCmd(t, "--set", "ws-two")
+	require.NoError(t, err)
+	_, err = runWorkspaceCmd(t, "--set", "ws-one")
+	require.NoError(t, err)
+
+	got, err := store.NewFile().Load()
+	require.NoError(t, err)
+	assert.Equal(t, "ws-one", got.WorkspaceID)
+	assert.Equal(t, "refresh", got.RefreshToken)
+	assert.Equal(t, "pat", got.AuthToken)
+
+	out, err := runWorkspaceCmd(t)
+	require.NoError(t, err)
+	assert.Equal(t, "ws-one\n", out)
+}
+
+// A CI JWT carries its own workspace and outranks the store, so `--set` stores
+// the choice but must not appear to change what a build would use.
+func TestWorkspaceCmd_setUnderAJWTIsStoredButShadowed(t *testing.T) {
+	workspacelessLogin(t)
+	organizationsAPI(t, bitriseapi.Workspace{Slug: "ws-one", Name: "One"})
+	t.Setenv(authpkg.EnvJWT, serviceJWT(t, "ws-from-jwt"))
+
+	_, err := runWorkspaceCmd(t, "--set", "ws-one")
+	require.NoError(t, err)
+
+	got, err := store.NewFile().Load()
+	require.NoError(t, err)
+	assert.Equal(t, "ws-one", got.WorkspaceID, "the choice is stored for when the JWT is gone")
+
+	out, err := runWorkspaceCmd(t)
+	require.NoError(t, err)
+	assert.Equal(t, "ws-from-jwt\n", out, "the JWT still wins while it is set")
+
+	assert.Equal(t, authpkg.EnvJWT, shadowingWorkspaceEnv(map[string]string{authpkg.EnvJWT: "jwt"}))
+}
+
+func serviceJWT(t *testing.T, workspaceID string) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"authorization": map[string]any{
+			"permissions": []map[string]any{
+				{"rsname": "default", "claims": map[string]any{"org_id": []string{workspaceID}}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	return "hdr." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
 }

--- a/cmd/auth/workspace_test.go
+++ b/cmd/auth/workspace_test.go
@@ -56,8 +56,7 @@ func runWorkspaceCmd(t *testing.T, args ...string) (string, error) {
 	return stdout.String(), err
 }
 
-// The two halves of the agent flow: list what the workspace-less login can see,
-// then pin one — without a second sign-in.
+// The two halves of the agent flow, with no second sign-in between them.
 func TestWorkspaceCmd_listThenSet(t *testing.T) {
 	workspacelessLogin(t)
 	organizationsAPI(t,

--- a/cmd/common/interactive/callback_relay.go
+++ b/cmd/common/interactive/callback_relay.go
@@ -1,0 +1,91 @@
+package interactive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+)
+
+const relayTimeout = 10 * time.Second
+
+// relayCallback hands a callback URL the user copied out of their browser to the
+// `auth login` waiting on this machine, by requesting it locally: the URL names
+// the loopback listener that login bound, so no shared state is needed to find it.
+func relayCallback(ctx context.Context, logger log.Logger, raw string) error {
+	target, err := parseLoopbackCallback(raw)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
+	if err != nil {
+		return fmt.Errorf("build callback request: %w", err)
+	}
+
+	client := &http.Client{Timeout: relayTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		var opErr *net.OpError
+		if errors.As(err, &opErr) {
+			return fmt.Errorf("nothing is listening on %s — the sign-in it belongs to has stopped waiting (they expire 5 minutes after the URL is printed); start a new `auth login --print-url`", target.Host)
+		}
+
+		return fmt.Errorf("deliver the callback: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("the waiting sign-in rejected this callback (HTTP %d) — check you copied the whole URL, and that it came from the sign-in still running", resp.StatusCode)
+	}
+
+	logger.TInfof("✅ Delivered the sign-in to the `auth login` waiting on %s.", target.Host)
+
+	return nil
+}
+
+// parseLoopbackCallback accepts only what `auth login` itself printed: a loopback
+// callback URL carrying an authorization code. Anything else would turn this into
+// a way to make the CLI request an arbitrary address.
+func parseLoopbackCallback(raw string) (*url.URL, error) {
+	target, err := url.Parse(strings.Trim(strings.TrimSpace(raw), `"'`))
+	if err != nil {
+		return nil, fmt.Errorf("parse the callback URL: %w", err)
+	}
+
+	if target.Scheme != "http" {
+		return nil, fmt.Errorf("callback URL must be http, got %q", target.Scheme)
+	}
+	if !isLoopbackHost(target.Hostname()) {
+		return nil, fmt.Errorf("callback URL must point at the loopback address `auth login` printed, got host %q", target.Hostname())
+	}
+	if target.Port() == "" {
+		return nil, errors.New("callback URL has no port — copy the whole address, including the :NNNNN")
+	}
+	if target.Path != "/callback" {
+		return nil, fmt.Errorf("callback URL path must be /callback, got %q", target.Path)
+	}
+
+	q := target.Query()
+	if q.Get("code") == "" && q.Get("error") == "" {
+		return nil, errors.New("callback URL carries no code or error parameter — copy it from the browser's address bar after signing in")
+	}
+
+	return target, nil
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+
+	return ip != nil && ip.IsLoopback()
+}

--- a/cmd/common/interactive/callback_relay.go
+++ b/cmd/common/interactive/callback_relay.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/bitrise-io/go-utils/v2/log"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/oauth"
 )
 
 const relayTimeout = 10 * time.Second
@@ -28,6 +30,7 @@ func relayCallback(ctx context.Context, logger log.Logger, raw string) error {
 	if err != nil {
 		return fmt.Errorf("build callback request: %w", err)
 	}
+	req.Header.Set(oauth.RelayHeader, "1")
 
 	client := &http.Client{Timeout: relayTimeout}
 	resp, err := client.Do(req)

--- a/cmd/common/interactive/callback_relay_test.go
+++ b/cmd/common/interactive/callback_relay_test.go
@@ -1,0 +1,79 @@
+//go:build unit
+
+package interactive
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testLogger() log.Logger { return log.NewLogger(log.WithOutput(io.Discard)) }
+
+func TestParseLoopbackCallback_rejects(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{"not loopback", "http://evil.example/callback?code=c&state=s"},
+		{"https", "https://127.0.0.1:5000/callback?code=c&state=s"},
+		{"no port", "http://127.0.0.1/callback?code=c&state=s"},
+		{"wrong path", "http://127.0.0.1:5000/other?code=c&state=s"},
+		{"no code", "http://127.0.0.1:5000/callback?state=s"},
+		{"the authorize URL by mistake", "https://oauth.bitrise.io/oauth2/authorize?client_id=x"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseLoopbackCallback(tc.raw)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseLoopbackCallback_accepts(t *testing.T) {
+	for _, raw := range []string{
+		"http://127.0.0.1:5000/callback?code=c&state=s",
+		"  'http://localhost:5000/callback?code=c&state=s'  ",
+		"http://[::1]:5000/callback?error=access_denied",
+	} {
+		got, err := parseLoopbackCallback(raw)
+		require.NoError(t, err, raw)
+		assert.Equal(t, "/callback", got.Path)
+	}
+}
+
+func TestRelayCallback_deliversAndReportsRejection(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.RawQuery
+		if r.URL.Query().Get("state") != "good-state" {
+			w.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+	}))
+	defer srv.Close()
+
+	require.NoError(t, relayCallback(context.Background(), testLogger(), srv.URL+"/callback?code=c&state=good-state"))
+	assert.Equal(t, "code=c&state=good-state", got)
+
+	err := relayCallback(context.Background(), testLogger(), srv.URL+"/callback?code=c&state=stale")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rejected this callback")
+}
+
+// Nothing listening is the common case once a sign-in has timed out.
+func TestRelayCallback_noWaitingLogin(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	err := relayCallback(context.Background(), testLogger(), url+"/callback?code=c&state=s")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stopped waiting")
+}

--- a/cmd/common/interactive/fix_auth.go
+++ b/cmd/common/interactive/fix_auth.go
@@ -37,7 +37,7 @@ func FixAuthPrompt(ctx context.Context, logger log.Logger) func() (string, strin
 
 		// No workspace flag to offer: `doctor --fix --interactive` takes none, so a
 		// sign-in that leaves stdin unusable has to stop rather than point at one.
-		out, err := loginAndStore(ctx, logger, utils.AllEnvs(), workspaceChoice{}, "", "")
+		out, err := loginAndStore(ctx, logger, utils.AllEnvs(), loginRequest{})
 		switch {
 		case errors.Is(err, tui.ErrAborted), errors.Is(err, ErrStdinUnusable):
 			return "", "", err //nolint:wrapcheck // sentinel

--- a/cmd/common/interactive/fix_auth.go
+++ b/cmd/common/interactive/fix_auth.go
@@ -37,7 +37,7 @@ func FixAuthPrompt(ctx context.Context, logger log.Logger) func() (string, strin
 
 		// No workspace flag to offer: `doctor --fix --interactive` takes none, so a
 		// sign-in that leaves stdin unusable has to stop rather than point at one.
-		out, err := loginAndStore(ctx, logger, utils.AllEnvs(), "", "", "")
+		out, err := loginAndStore(ctx, logger, utils.AllEnvs(), workspaceChoice{}, "", "")
 		switch {
 		case errors.Is(err, tui.ErrAborted), errors.Is(err, ErrStdinUnusable):
 			return "", "", err //nolint:wrapcheck // sentinel

--- a/cmd/common/interactive/login.go
+++ b/cmd/common/interactive/login.go
@@ -132,8 +132,6 @@ func runLogin(cmd *cobra.Command) error {
 	return nil
 }
 
-// validateLoginWorkspaceFlags rejects the two flag combinations that would leave
-// the sign-in with no way to answer "which workspace".
 func validateLoginWorkspaceFlags(workspace string, noWorkspace, interactive bool) error {
 	if workspace != "" && noWorkspace {
 		return fmt.Errorf("--workspace and --no-workspace are mutually exclusive")
@@ -161,12 +159,11 @@ type loginOutcome struct {
 	StdinUnusable bool
 }
 
-// workspaceChoice is how the caller answers "which workspace" before the browser
-// flow starts: a slug, the picker (zero value), or neither.
+// The zero value means the interactive picker.
 type workspaceChoice struct {
 	Slug string
-	// Skip leaves the credential workspace-less, for callers that cannot show a
-	// picker and will select later via `auth workspace --set`.
+	// Skip stores the login workspace-less, for callers that cannot show a picker
+	// and will select later via `auth workspace --set`.
 	Skip bool
 }
 

--- a/cmd/common/interactive/login.go
+++ b/cmd/common/interactive/login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -25,6 +26,8 @@ var (
 	loginWorkspace   string
 	loginStorage     string
 	loginNoWorkspace bool
+	loginPrintURL    bool
+	loginCallback    string
 )
 
 // LoginCmd signs the user in via the browser (OAuth) and stores a managed,
@@ -46,7 +49,15 @@ the browser's address bar into the terminal and the sign-in completes from that.
 
 A session with no terminal at all (an agent driving the CLI, a script) can't be
 prompted for a workspace: pass --workspace <slug>, or --no-workspace to sign in
-first and select afterwards with ` + "`auth workspace --set <slug>`" + `.`,
+first and select afterwards with ` + "`auth workspace --set <slug>`" + `. It can't paste
+into a prompt either, so the sign-in is driven in two commands instead:
+
+  bitrise-build-cache auth login --print-url --no-workspace   # prints the URL, waits
+  bitrise-build-cache auth login --callback '<address>'       # from another shell
+
+Open the printed URL in a browser anywhere, sign in, and hand the address it
+lands on — the one that fails to load — to the second command, on this machine.`,
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return runLogin(cmd)
 	},
@@ -99,7 +110,11 @@ This is narrower than ` + "`auth clear`" + `:
 func init() { //nolint:gochecknoinits
 	LoginCmd.Flags().StringVar(&loginWorkspace, "workspace", "", "workspace (organization) slug to use; skips the interactive picker")
 	LoginCmd.Flags().StringVar(&loginStorage, "storage", "", "Where to persist credentials: keychain | file | auto (default: CI→file, local→keychain).")
-	LoginCmd.Flags().BoolVar(&loginNoWorkspace, "no-workspace", false, "Sign in without selecting a workspace. Pick one afterwards with `auth workspace --list` + `auth workspace --set <slug>`; build-cache commands stay unconfigured until you do.")
+	// No backticks in these usage strings: pflag reads the first backticked word as
+	// the value placeholder, which turns the help into nonsense.
+	LoginCmd.Flags().BoolVar(&loginNoWorkspace, "no-workspace", false, "Sign in without selecting a workspace. Pick one afterwards with 'auth workspace --list' + 'auth workspace --set <slug>'; build-cache commands stay unconfigured until you do.")
+	LoginCmd.Flags().BoolVar(&loginPrintURL, "print-url", false, "Don't launch a browser: print the sign-in URL (bare, on stdout) and wait. Open it wherever you have a browser, then deliver the address it lands on with 'auth login --callback <url>'.")
+	LoginCmd.Flags().StringVar(&loginCallback, "callback", "", "Deliver a callback URL copied from the browser to the 'auth login --print-url' waiting on this machine, and exit. Signs nothing in by itself.")
 	// LoginCmd / LogoutCmd are registered under the `auth` command (cmd/auth).
 }
 
@@ -108,11 +123,28 @@ func runLogin(cmd *cobra.Command) error {
 	envs := utils.AllEnvs()
 	logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
+	if loginCallback != "" {
+		if loginWorkspace != "" || loginNoWorkspace || loginPrintURL {
+			return fmt.Errorf("--callback only delivers a URL to a waiting sign-in; it takes no other flag")
+		}
+
+		return relayCallback(ctx, logger, loginCallback)
+	}
+
 	if err := validateLoginWorkspaceFlags(loginWorkspace, loginNoWorkspace, isInteractiveStdin()); err != nil {
 		return err
 	}
 
-	out, err := loginAndStore(ctx, logger, envs, workspaceChoice{Slug: loginWorkspace, Skip: loginNoWorkspace}, loginStorage, "--workspace")
+	req := loginRequest{
+		Workspace:     workspaceChoice{Slug: loginWorkspace, Skip: loginNoWorkspace},
+		Storage:       loginStorage,
+		WorkspaceFlag: "--workspace",
+	}
+	if loginPrintURL {
+		req.PrintURL = cmd.OutOrStdout()
+	}
+
+	out, err := loginAndStore(ctx, logger, envs, req)
 	switch {
 	case errors.Is(err, tui.ErrAborted):
 		logger.Infof("Sign-in cancelled. Nothing was saved.")
@@ -174,28 +206,48 @@ type workspaceChoice struct {
 	Skip bool
 }
 
+// loginRequest is what one sign-in needs beyond the environment.
+type loginRequest struct {
+	Workspace workspaceChoice
+	// Storage empty → the default target for this environment.
+	Storage string
+	// WorkspaceFlag names the flag this caller accepts to supply the workspace
+	// without a prompt; it appears in ErrStdinUnusable guidance. Empty means the
+	// caller has none to offer.
+	WorkspaceFlag string
+	// PrintURL, when set, receives the sign-in URL and suppresses the browser.
+	PrintURL io.Writer
+}
+
 // loginAndStore runs the browser OAuth flow, resolves the workspace and persists
-// the credential. storage empty → default target for the environment. Shared by
-// `auth login` and the interactive wizard.
-//
-// workspaceFlag names the flag a caller can use to supply the workspace without
-// a prompt; it appears in ErrStdinUnusable guidance and differs per command.
-func loginAndStore(ctx context.Context, logger log.Logger, envs map[string]string, ws workspaceChoice, storage, workspaceFlag string) (loginOutcome, error) {
+// the credential. Shared by `auth login`, the wizard and the doctor's fixer.
+func loginAndStore(ctx context.Context, logger log.Logger, envs map[string]string, req loginRequest) (loginOutcome, error) {
 	cfg := oauth.NewConfigFromEnv(envs)
 	cfg.Logger = logger
 
-	paster := &callbackPaster{Reader: os.Stdin, Logger: logger, WorkspaceFlag: workspaceFlag}
+	paster := &callbackPaster{Reader: os.Stdin, Logger: logger, WorkspaceFlag: req.WorkspaceFlag}
 	if isInteractiveStdin() {
 		cfg.CallbackFallback = paster.Fallback
 	}
 
-	creds, err := cfg.Login(ctx, openBrowser)
+	open := openBrowser
+	if req.PrintURL != nil {
+		open = nil
+		cfg.OnAuthorizeURL = func(authorizeURL, redirectURI string) {
+			_, _ = fmt.Fprintln(req.PrintURL, authorizeURL)
+			logger.Infof("After signing in, the browser lands on %s, which only this machine can reach.", redirectURI)
+			logger.Infof("Copy that address and deliver it here with:")
+			logger.Infof("  bitrise-build-cache auth login --callback '<address>'")
+		}
+	}
+
+	creds, err := cfg.Login(ctx, open)
 	if err != nil {
 		return loginOutcome{}, fmt.Errorf("sign in: %w", err)
 	}
 
-	workspace := ws.Slug
-	if workspace == "" && !ws.Skip {
+	workspace := req.Workspace.Slug
+	if workspace == "" && !req.Workspace.Skip {
 		// A picker here would race the paste reader for every keystroke, which is
 		// the failure this reports instead of reproducing.
 		if paster.StdinUnusable() {
@@ -212,12 +264,12 @@ func loginAndStore(ctx context.Context, logger log.Logger, envs map[string]strin
 	// this, `auth login` silently drops the name `auth username` set.
 	creds.Username = store.StoredUsername()
 
-	target, err := store.Select(configcommon.DetectCIProvider(envs) != "", storage)
+	target, err := store.Select(configcommon.DetectCIProvider(envs) != "", req.Storage)
 	if err != nil {
 		return loginOutcome{}, err //nolint:wrapcheck
 	}
 
-	origin, err := saveLoginWithFallback(logger, target, storage, creds)
+	origin, err := saveLoginWithFallback(logger, target, req.Storage, creds)
 	if err != nil {
 		return loginOutcome{}, err
 	}

--- a/cmd/common/interactive/login.go
+++ b/cmd/common/interactive/login.go
@@ -159,6 +159,13 @@ type loginOutcome struct {
 	StdinUnusable bool
 }
 
+// Test seam: the integration test stands in a client that follows the redirect.
+var openBrowser = defaultOpenBrowser //nolint:gochecknoglobals
+
+func defaultOpenBrowser(url string) error {
+	return oauth.OpenBrowser(url) //nolint:wrapcheck // oauth already wraps
+}
+
 // The zero value means the interactive picker.
 type workspaceChoice struct {
 	Slug string
@@ -182,7 +189,7 @@ func loginAndStore(ctx context.Context, logger log.Logger, envs map[string]strin
 		cfg.CallbackFallback = paster.Fallback
 	}
 
-	creds, err := cfg.Login(ctx, oauth.OpenBrowser)
+	creds, err := cfg.Login(ctx, openBrowser)
 	if err != nil {
 		return loginOutcome{}, fmt.Errorf("sign in: %w", err)
 	}
@@ -259,6 +266,32 @@ func shadowingAuthEnv() string {
 	}
 
 	return ""
+}
+
+// PickWorkspacePrompt selects and stores a workspace for a login that has none,
+// for the doctor's fixer.
+func PickWorkspacePrompt(ctx context.Context, logger log.Logger) func() (string, error) {
+	return func() (string, error) {
+		envs := utils.AllEnvs()
+
+		cred, _, err := live.Default(logger).ResolveTokenOnly(ctx, envs)
+		if err != nil {
+			return "", fmt.Errorf("resolve the stored credential: %w", err)
+		}
+
+		workspace, err := pickWorkspace(ctx, envs, cred.Token)
+		if err != nil {
+			return "", err
+		}
+
+		origin, err := store.SetWorkspaceID(configcommon.DetectCIProvider(envs) != "", workspace)
+		if err != nil {
+			return "", err //nolint:wrapcheck // already user-facing
+		}
+		logger.TInfof("✅ Using workspace %q for the build cache (stored in the %s).", workspace, origin.Label())
+
+		return workspace, nil
+	}
 }
 
 // pickWorkspace lists the workspaces the fresh PAT can access and lets the user

--- a/cmd/common/interactive/login.go
+++ b/cmd/common/interactive/login.go
@@ -22,8 +22,9 @@ import (
 
 //nolint:gochecknoglobals
 var (
-	loginWorkspace string
-	loginStorage   string
+	loginWorkspace   string
+	loginStorage     string
+	loginNoWorkspace bool
 )
 
 // LoginCmd signs the user in via the browser (OAuth) and stores a managed,
@@ -39,9 +40,13 @@ by hand.
 Nothing changes on Bitrise CI (the build still uses the auto-provided service
 token), and a manually-set BITRISE_BUILD_CACHE_AUTH_TOKEN still takes precedence.
 
-This needs a browser on the same machine as the CLI (the sign-in is handed back
-over a loopback address); it can't complete on a remote/headless host — there,
-keep using BITRISE_BUILD_CACHE_AUTH_TOKEN + BITRISE_BUILD_CACHE_WORKSPACE_ID.`,
+The sign-in is handed back over a loopback address, so it expects a browser on
+the same machine. On a remote/RDE session the redirect fails; paste the URL from
+the browser's address bar into the terminal and the sign-in completes from that.
+
+A session with no terminal at all (an agent driving the CLI, a script) can't be
+prompted for a workspace: pass --workspace <slug>, or --no-workspace to sign in
+first and select afterwards with ` + "`auth workspace --set <slug>`" + `.`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return runLogin(cmd)
 	},
@@ -94,6 +99,7 @@ This is narrower than ` + "`auth clear`" + `:
 func init() { //nolint:gochecknoinits
 	LoginCmd.Flags().StringVar(&loginWorkspace, "workspace", "", "workspace (organization) slug to use; skips the interactive picker")
 	LoginCmd.Flags().StringVar(&loginStorage, "storage", "", "Where to persist credentials: keychain | file | auto (default: CI→file, local→keychain).")
+	LoginCmd.Flags().BoolVar(&loginNoWorkspace, "no-workspace", false, "Sign in without selecting a workspace. Pick one afterwards with `auth workspace --list` + `auth workspace --set <slug>`; build-cache commands stay unconfigured until you do.")
 	// LoginCmd / LogoutCmd are registered under the `auth` command (cmd/auth).
 }
 
@@ -102,11 +108,11 @@ func runLogin(cmd *cobra.Command) error {
 	envs := utils.AllEnvs()
 	logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
 
-	if loginWorkspace == "" && !isInteractiveStdin() {
-		return fmt.Errorf("not an interactive terminal: pass --workspace <slug> to sign in non-interactively")
+	if err := validateLoginWorkspaceFlags(loginWorkspace, loginNoWorkspace, isInteractiveStdin()); err != nil {
+		return err
 	}
 
-	out, err := loginAndStore(ctx, logger, envs, loginWorkspace, loginStorage, "--workspace")
+	out, err := loginAndStore(ctx, logger, envs, workspaceChoice{Slug: loginWorkspace, Skip: loginNoWorkspace}, loginStorage, "--workspace")
 	switch {
 	case errors.Is(err, tui.ErrAborted):
 		logger.Infof("Sign-in cancelled. Nothing was saved.")
@@ -121,6 +127,19 @@ func runLogin(cmd *cobra.Command) error {
 	if shadow := shadowingAuthEnv(); shadow != "" {
 		logger.Warnf("%s is set and takes precedence over the login just saved.", shadow)
 		logger.Warnf("Build-cache commands will use it, not this login — unset it to use the stored login.")
+	}
+
+	return nil
+}
+
+// validateLoginWorkspaceFlags rejects the two flag combinations that would leave
+// the sign-in with no way to answer "which workspace".
+func validateLoginWorkspaceFlags(workspace string, noWorkspace, interactive bool) error {
+	if workspace != "" && noWorkspace {
+		return fmt.Errorf("--workspace and --no-workspace are mutually exclusive")
+	}
+	if workspace == "" && !noWorkspace && !interactive {
+		return fmt.Errorf("not an interactive terminal: pass --workspace <slug>, or --no-workspace to pick one afterwards with `auth workspace --set`")
 	}
 
 	return nil
@@ -142,13 +161,22 @@ type loginOutcome struct {
 	StdinUnusable bool
 }
 
+// workspaceChoice is how the caller answers "which workspace" before the browser
+// flow starts: a slug, the picker (zero value), or neither.
+type workspaceChoice struct {
+	Slug string
+	// Skip leaves the credential workspace-less, for callers that cannot show a
+	// picker and will select later via `auth workspace --set`.
+	Skip bool
+}
+
 // loginAndStore runs the browser OAuth flow, resolves the workspace and persists
-// the credential. workspace empty → interactive picker; storage empty → default
-// target for the environment. Shared by `auth login` and the interactive wizard.
+// the credential. storage empty → default target for the environment. Shared by
+// `auth login` and the interactive wizard.
 //
 // workspaceFlag names the flag a caller can use to supply the workspace without
 // a prompt; it appears in ErrStdinUnusable guidance and differs per command.
-func loginAndStore(ctx context.Context, logger log.Logger, envs map[string]string, workspace, storage, workspaceFlag string) (loginOutcome, error) {
+func loginAndStore(ctx context.Context, logger log.Logger, envs map[string]string, ws workspaceChoice, storage, workspaceFlag string) (loginOutcome, error) {
 	cfg := oauth.NewConfigFromEnv(envs)
 	cfg.Logger = logger
 
@@ -162,7 +190,8 @@ func loginAndStore(ctx context.Context, logger log.Logger, envs map[string]strin
 		return loginOutcome{}, fmt.Errorf("sign in: %w", err)
 	}
 
-	if workspace == "" {
+	workspace := ws.Slug
+	if workspace == "" && !ws.Skip {
 		// A picker here would race the paste reader for every keystroke, which is
 		// the failure this reports instead of reproducing.
 		if paster.StdinUnusable() {
@@ -189,7 +218,14 @@ func loginAndStore(ctx context.Context, logger log.Logger, envs map[string]strin
 		return loginOutcome{}, err
 	}
 
-	logger.Infof("Signed in. Using workspace %q for the build cache. Credentials stored in the %s.", workspace, origin.Label())
+	if workspace == "" {
+		logger.Infof("Signed in. Credentials stored in the %s.", origin.Label())
+		logger.Infof("No workspace selected yet — the build cache stays unconfigured until you pick one:")
+		logger.Infof("  bitrise-build-cache auth workspace --list")
+		logger.Infof("  bitrise-build-cache auth workspace --set <slug>")
+	} else {
+		logger.Infof("Signed in. Using workspace %q for the build cache. Credentials stored in the %s.", workspace, origin.Label())
+	}
 
 	out := loginOutcome{Creds: creds, Origin: origin, StdinUnusable: paster.StdinUnusable()}
 	if out.StdinUnusable {

--- a/cmd/common/interactive/login.go
+++ b/cmd/common/interactive/login.go
@@ -201,19 +201,16 @@ func defaultOpenBrowser(url string) error {
 // The zero value means the interactive picker.
 type workspaceChoice struct {
 	Slug string
-	// Skip stores the login workspace-less, for callers that cannot show a picker
-	// and will select later via `auth workspace --set`.
+	// Skip stores the login workspace-less, for callers that cannot show a picker.
 	Skip bool
 }
 
-// loginRequest is what one sign-in needs beyond the environment.
 type loginRequest struct {
 	Workspace workspaceChoice
 	// Storage empty → the default target for this environment.
 	Storage string
-	// WorkspaceFlag names the flag this caller accepts to supply the workspace
-	// without a prompt; it appears in ErrStdinUnusable guidance. Empty means the
-	// caller has none to offer.
+	// WorkspaceFlag names the flag this caller accepts instead of a prompt; it
+	// appears in ErrStdinUnusable guidance. Empty means it has none to offer.
 	WorkspaceFlag string
 	// PrintURL, when set, receives the sign-in URL and suppresses the browser.
 	PrintURL io.Writer

--- a/cmd/common/interactive/login.go
+++ b/cmd/common/interactive/login.go
@@ -230,7 +230,10 @@ func loginAndStore(ctx context.Context, logger log.Logger, envs map[string]strin
 	cfg.Logger = logger
 
 	paster := &callbackPaster{Reader: os.Stdin, Logger: logger, WorkspaceFlag: req.WorkspaceFlag}
-	if isInteractiveStdin() {
+	// --print-url owns the callback via `auth login --callback`; arming the paste
+	// reader too would print a second, contradictory way to finish and would take
+	// over a stdin its caller is not typing into.
+	if isInteractiveStdin() && req.PrintURL == nil {
 		cfg.CallbackFallback = paster.Fallback
 	}
 

--- a/cmd/common/interactive/login.go
+++ b/cmd/common/interactive/login.go
@@ -121,7 +121,14 @@ func init() { //nolint:gochecknoinits
 func runLogin(cmd *cobra.Command) error {
 	ctx := cmd.Context()
 	envs := utils.AllEnvs()
-	logger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+
+	// Under --print-url the caller is a script reading stdout, so the prose moves
+	// to stderr and stdout carries the URL and nothing else.
+	logOpts := []log.LoggerOptions{log.WithDebugLog(common.IsDebugLogMode)}
+	if loginPrintURL {
+		logOpts = append(logOpts, log.WithOutput(cmd.ErrOrStderr()))
+	}
+	logger := log.NewLogger(logOpts...)
 
 	if loginCallback != "" {
 		if loginWorkspace != "" || loginNoWorkspace || loginPrintURL {
@@ -273,9 +280,9 @@ func loginAndStore(ctx context.Context, logger log.Logger, envs map[string]strin
 
 	if workspace == "" {
 		logger.Infof("Signed in. Credentials stored in the %s.", origin.Label())
-		logger.Infof("No workspace selected yet — the build cache stays unconfigured until you pick one:")
-		logger.Infof("  bitrise-build-cache auth workspace --list")
-		logger.Infof("  bitrise-build-cache auth workspace --set <slug>")
+		logger.Warnf("No workspace selected yet — the build cache stays unconfigured until you pick one:")
+		logger.Warnf("  bitrise-build-cache auth workspace --list")
+		logger.Warnf("  bitrise-build-cache auth workspace --set <slug>")
 	} else {
 		logger.Infof("Signed in. Using workspace %q for the build cache. Credentials stored in the %s.", workspace, origin.Label())
 	}

--- a/cmd/common/interactive/login_integration_test.go
+++ b/cmd/common/interactive/login_integration_test.go
@@ -3,6 +3,7 @@
 package interactive
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -11,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -194,11 +196,14 @@ func TestLoginPrintURLAndCallback_twoCommandFlow(t *testing.T) {
 	t.Cleanup(func() { os.Stdin = realStdin; _ = pipeR.Close(); _ = pipeW.Close() })
 
 	sink := lineSink{lines: make(chan string, 4)}
+	var stderr syncBuffer
 	LoginCmd.SetOut(sink)
+	LoginCmd.SetErr(&stderr)
 	LoginCmd.SetArgs([]string{"--print-url", "--no-workspace"})
 	t.Cleanup(func() {
 		LoginCmd.SetArgs(nil)
 		LoginCmd.SetOut(nil)
+		LoginCmd.SetErr(nil)
 		loginPrintURL, loginNoWorkspace = false, false
 	})
 
@@ -226,4 +231,30 @@ func TestLoginPrintURLAndCallback_twoCommandFlow(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "bitpat_minted", stored.AuthToken)
 	assert.Empty(t, stored.WorkspaceID)
+
+	// Under --print-url stdout is the URL and nothing else; the prose, including
+	// which path completed the handshake, goes to stderr.
+	assert.Empty(t, sink.lines, "stdout must carry the URL alone")
+	assert.Contains(t, stderr.String(), "auth login --callback", "the sign-in must name the path that completed it")
+	assert.Contains(t, stderr.String(), "No workspace selected yet")
+}
+
+// syncBuffer collects the command's stderr while it runs on another goroutine.
+type syncBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.b.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.b.String()
 }

--- a/cmd/common/interactive/login_integration_test.go
+++ b/cmd/common/interactive/login_integration_test.go
@@ -24,9 +24,8 @@ import (
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/bitriseapi"
 )
 
-// fakeIdentity is the OAuth provider (authorize + token) and the monolith's
-// JWT→PAT exchange, wired so the authorize endpoint redirects to whatever
-// loopback callback the CLI bound — exactly what the real provider does.
+// fakeIdentity redirects to whatever loopback callback the CLI bound, the way the
+// real provider does.
 func fakeIdentity(t *testing.T) *httptest.Server {
 	t.Helper()
 

--- a/cmd/common/interactive/login_integration_test.go
+++ b/cmd/common/interactive/login_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -113,9 +114,8 @@ func TestLoginNoWorkspace_agentFlow(t *testing.T) {
 	}
 	t.Cleanup(func() { openBrowser = defaultOpenBrowser })
 
-	// `go test` inherits the developer's terminal, so pin stdin to a non-TTY: the
-	// point of the flow is that it works without one.
-	// A pipe, not /dev/null — that is a character device, which reads as a TTY.
+	// `go test` inherits the developer's terminal, so pin stdin to a non-TTY. A
+	// pipe, not /dev/null — that is a character device, which reads as a TTY.
 	pipeR, pipeW, err := os.Pipe()
 	require.NoError(t, err)
 	realStdin := os.Stdin
@@ -154,4 +154,77 @@ func TestLoginNoWorkspace_agentFlow(t *testing.T) {
 	assert.Equal(t, "ws-two", cred.WorkspaceID)
 	assert.Equal(t, "bitpat_minted", cred.Token)
 	assert.Equal(t, auth.ProvenanceOAuthLogin, origin.Provenance, "picking a workspace must not downgrade the login")
+}
+
+// lineSink hands whatever the command prints to stdout back to the test, without
+// a buffer both goroutines would race on.
+type lineSink struct{ lines chan string }
+
+func (s lineSink) Write(p []byte) (int, error) {
+	s.lines <- strings.TrimSpace(string(p))
+
+	return len(p), nil
+}
+
+// TestLoginPrintURLAndCallback_twoCommandFlow is the flow with no terminal and no
+// browser on the CLI's host: one command prints the URL and waits, the browser
+// runs elsewhere, and a second command delivers the address it landed on.
+func TestLoginPrintURLAndCallback_twoCommandFlow(t *testing.T) {
+	keyring.MockInit()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(auth.EnvAuthToken, "")
+	t.Setenv(auth.EnvWorkspaceID, "")
+	t.Setenv(auth.EnvJWT, "")
+
+	identity := fakeIdentity(t)
+	t.Setenv("BITRISE_OAUTH_ISSUER", identity.URL)
+	t.Setenv("BITRISE_OIDC_TOKEN_ENDPOINT", identity.URL+"/oidc/token")
+	t.Setenv("BITRISE_OAUTH_CLIENT_ID", "https://cli.example/cimd.json")
+
+	openBrowser = func(string) error {
+		t.Error("--print-url must not open a browser")
+
+		return nil
+	}
+	t.Cleanup(func() { openBrowser = defaultOpenBrowser })
+
+	pipeR, pipeW, err := os.Pipe()
+	require.NoError(t, err)
+	realStdin := os.Stdin
+	os.Stdin = pipeR
+	t.Cleanup(func() { os.Stdin = realStdin; _ = pipeR.Close(); _ = pipeW.Close() })
+
+	sink := lineSink{lines: make(chan string, 4)}
+	LoginCmd.SetOut(sink)
+	LoginCmd.SetArgs([]string{"--print-url", "--no-workspace"})
+	t.Cleanup(func() {
+		LoginCmd.SetArgs(nil)
+		LoginCmd.SetOut(nil)
+		loginPrintURL, loginNoWorkspace = false, false
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- LoginCmd.ExecuteContext(context.Background()) }()
+
+	authorizeURL := <-sink.lines
+	require.Contains(t, authorizeURL, identity.URL+"/oauth2/authorize")
+
+	// The browser, on some other machine: it can reach the provider but not the
+	// CLI's loopback, so it stops at the redirect the CLI must be handed.
+	noRedirects := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := noRedirects.Get(authorizeURL) //nolint:noctx // stands in for a browser
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	landedOn := resp.Header.Get("Location")
+	require.Contains(t, landedOn, "127.0.0.1")
+
+	require.NoError(t, relayCallback(context.Background(), testLogger(), landedOn))
+	require.NoError(t, <-done)
+
+	stored, err := store.NewKeychain().Load()
+	require.NoError(t, err)
+	assert.Equal(t, "bitpat_minted", stored.AuthToken)
+	assert.Empty(t, stored.WorkspaceID)
 }

--- a/cmd/common/interactive/login_integration_test.go
+++ b/cmd/common/interactive/login_integration_test.go
@@ -237,6 +237,7 @@ func TestLoginPrintURLAndCallback_twoCommandFlow(t *testing.T) {
 	assert.Empty(t, sink.lines, "stdout must carry the URL alone")
 	assert.Contains(t, stderr.String(), "auth login --callback", "the sign-in must name the path that completed it")
 	assert.Contains(t, stderr.String(), "No workspace selected yet")
+	assert.NotContains(t, stderr.String(), "paste it here", "--print-url must not also offer the terminal paste")
 }
 
 // syncBuffer collects the command's stderr while it runs on another goroutine.

--- a/cmd/common/interactive/login_integration_test.go
+++ b/cmd/common/interactive/login_integration_test.go
@@ -1,0 +1,157 @@
+//go:build unit
+
+package interactive
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	keyring "github.com/zalando/go-keyring"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/live"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/store"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/bitriseapi"
+)
+
+// fakeIdentity is the OAuth provider (authorize + token) and the monolith's
+// JWT→PAT exchange, wired so the authorize endpoint redirects to whatever
+// loopback callback the CLI bound — exactly what the real provider does.
+func fakeIdentity(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/authorize", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		redirect, err := url.Parse(q.Get("redirect_uri"))
+		require.NoError(t, err)
+		rq := redirect.Query()
+		rq.Set("code", "auth-code")
+		rq.Set("state", q.Get("state"))
+		redirect.RawQuery = rq.Encode()
+		http.Redirect(w, r, redirect.String(), http.StatusFound)
+	})
+	mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, _ *http.Request) {
+		payload, err := json.Marshal(map[string]any{"exp": time.Now().Add(time.Hour).Unix()})
+		require.NoError(t, err)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "hdr." + base64.RawURLEncoding.EncodeToString(payload) + ".sig",
+			"refresh_token": "refresh-1",
+			"expires_in":    3600,
+			"token_type":    "Bearer",
+		})
+	})
+	mux.HandleFunc("/oidc/token", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "bitpat_minted",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func fakeOrganizations(t *testing.T, workspaces ...bitriseapi.Workspace) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/organizations", r.URL.Path)
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": workspaces})
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// TestLoginNoWorkspace_agentFlow walks the path an agent drives on a machine
+// with no terminal: sign in, discover that no workspace is selected, list the
+// options, pick one.
+func TestLoginNoWorkspace_agentFlow(t *testing.T) {
+	keyring.MockInit()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(auth.EnvAuthToken, "")
+	t.Setenv(auth.EnvWorkspaceID, "")
+	t.Setenv(auth.EnvJWT, "")
+
+	identity := fakeIdentity(t)
+	t.Setenv("BITRISE_OAUTH_ISSUER", identity.URL)
+	t.Setenv("BITRISE_OIDC_TOKEN_ENDPOINT", identity.URL+"/oidc/token")
+	t.Setenv("BITRISE_OAUTH_CLIENT_ID", "https://cli.example/cimd.json")
+
+	orgs := fakeOrganizations(t,
+		bitriseapi.Workspace{Slug: "ws-one", Name: "One"},
+		bitriseapi.Workspace{Slug: "ws-two", Name: "Two"},
+	)
+	t.Setenv("BITRISE_API_BASE_URL", orgs.URL)
+
+	// The user's browser: opens the authorize URL and follows the redirect back
+	// to the CLI's loopback listener.
+	browsed := make(chan error, 1)
+	openBrowser = func(authorizeURL string) error {
+		go func() {
+			resp, err := http.Get(authorizeURL) //nolint:noctx // stands in for a browser
+			if err == nil {
+				_ = resp.Body.Close()
+			}
+			browsed <- err
+		}()
+
+		return nil
+	}
+	t.Cleanup(func() { openBrowser = defaultOpenBrowser })
+
+	// `go test` inherits the developer's terminal, so pin stdin to a non-TTY: the
+	// point of the flow is that it works without one.
+	// A pipe, not /dev/null — that is a character device, which reads as a TTY.
+	pipeR, pipeW, err := os.Pipe()
+	require.NoError(t, err)
+	realStdin := os.Stdin
+	os.Stdin = pipeR
+	t.Cleanup(func() { os.Stdin = realStdin; _ = pipeR.Close(); _ = pipeW.Close() })
+	require.False(t, isInteractiveStdin())
+
+	LoginCmd.SetArgs([]string{"--no-workspace"})
+	t.Cleanup(func() { LoginCmd.SetArgs(nil); loginNoWorkspace = false })
+	require.NoError(t, LoginCmd.ExecuteContext(context.Background()))
+	require.NoError(t, <-browsed)
+
+	stored, err := store.NewKeychain().Load()
+	require.NoError(t, err)
+	assert.Equal(t, "bitpat_minted", stored.AuthToken)
+	assert.Equal(t, "refresh-1", stored.RefreshToken)
+	assert.Empty(t, stored.WorkspaceID, "--no-workspace must not invent a workspace")
+
+	envs := map[string]string{}
+	resolver := live.Default(nil)
+	_, _, err = resolver.Resolve(context.Background(), envs)
+	require.ErrorIs(t, err, auth.ErrWorkspaceNotSelected, "the half-finished login must not resolve as usable")
+
+	// What the agent shows the user, then what it picks for them.
+	cred, _, err := resolver.ResolveTokenOnly(context.Background(), envs)
+	require.NoError(t, err)
+	workspaces, err := bitriseapi.ListWorkspaces(context.Background(), orgs.URL, cred.Token)
+	require.NoError(t, err)
+	require.Len(t, workspaces, 2)
+
+	_, err = store.SetWorkspaceID(false, workspaces[1].Slug)
+	require.NoError(t, err)
+
+	cred, origin, err := resolver.Resolve(context.Background(), envs)
+	require.NoError(t, err)
+	assert.Equal(t, "ws-two", cred.WorkspaceID)
+	assert.Equal(t, "bitpat_minted", cred.Token)
+	assert.Equal(t, auth.ProvenanceOAuthLogin, origin.Provenance, "picking a workspace must not downgrade the login")
+}

--- a/cmd/common/interactive/login_test.go
+++ b/cmd/common/interactive/login_test.go
@@ -30,6 +30,29 @@ func makeServiceJWT(orgID string) string {
 	return header + "." + payload + "." + base64.RawURLEncoding.EncodeToString([]byte("sig"))
 }
 
+func TestValidateLoginWorkspaceFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		workspace   string
+		noWorkspace bool
+		interactive bool
+		wantErr     bool
+	}{
+		{name: "picker on a terminal", interactive: true},
+		{name: "slug without a terminal", workspace: "ws"},
+		{name: "no-workspace without a terminal", noWorkspace: true},
+		{name: "picker without a terminal", wantErr: true},
+		{name: "both flags", workspace: "ws", noWorkspace: true, interactive: true, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateLoginWorkspaceFlags(tc.workspace, tc.noWorkspace, tc.interactive)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("wantErr=%v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestShadowingAuthEnv(t *testing.T) {
 	keyring.MockInit() // empty keychain so a real stored login can't interfere
 	t.Setenv("HOME", t.TempDir())

--- a/cmd/common/interactive/wizard_auth.go
+++ b/cmd/common/interactive/wizard_auth.go
@@ -162,7 +162,10 @@ func (r wizardAuthResolver) login(ctx context.Context) (loginOutcome, error) {
 		return loginOutcome{Creds: creds, Origin: creds.Origin(authpkg.BackendKeychain)}, err
 	}
 
-	return loginAndStore(ctx, r.Logger, r.Envs, workspaceChoice{Slug: r.Workspace}, "", wizardWorkspaceFlag)
+	return loginAndStore(ctx, r.Logger, r.Envs, loginRequest{
+		Workspace:     workspaceChoice{Slug: r.Workspace},
+		WorkspaceFlag: wizardWorkspaceFlag,
+	})
 }
 
 // confirmWizardLogin announces the sign-in and waits for an explicit Enter, so

--- a/cmd/common/interactive/wizard_auth.go
+++ b/cmd/common/interactive/wizard_auth.go
@@ -162,7 +162,7 @@ func (r wizardAuthResolver) login(ctx context.Context) (loginOutcome, error) {
 		return loginOutcome{Creds: creds, Origin: creds.Origin(authpkg.BackendKeychain)}, err
 	}
 
-	return loginAndStore(ctx, r.Logger, r.Envs, r.Workspace, "", wizardWorkspaceFlag)
+	return loginAndStore(ctx, r.Logger, r.Envs, workspaceChoice{Slug: r.Workspace}, "", wizardWorkspaceFlag)
 }
 
 // confirmWizardLogin announces the sign-in and waits for an explicit Enter, so

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -69,7 +69,9 @@ with --no-update-check / --no-backend-probe.`,
 
 		d := doctorpkg.NewDoctor()
 		d.Debug = common.IsDebugLogMode
-		d.AuthFixPrompt = interactive.FixAuthPrompt(cmd.Context(), log.NewLogger(log.WithDebugLog(common.IsDebugLogMode)))
+		doctorLogger := log.NewLogger(log.WithDebugLog(common.IsDebugLogMode))
+		d.AuthFixPrompt = interactive.FixAuthPrompt(cmd.Context(), doctorLogger)
+		d.WorkspacePickPrompt = interactive.PickWorkspacePrompt(cmd.Context(), doctorLogger)
 
 		opts := doctorpkg.Options{
 			SkipUpdateCheck:  skipUpdateCheckFlag,

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -143,6 +143,7 @@ The shared vocabulary. Imports nothing internal.
 | `ParseJWTWorkspaceID(string) (string, error)` | Extracts `org_id` from the Bitrise UMA JWT. Signature unverified — Bitrise mints these per build. |
 | `EnvAuthToken`, `EnvWorkspaceID`, `EnvJWT`, `EnvUsername` | The four environment keys. |
 | `ErrTokenNotProvided`, `ErrWorkspaceIDNotProvided` | Distinguish "nothing configured" from a genuine failure. |
+| `ErrWorkspaceNotSelected` | A stored token with no workspace — what `auth login --no-workspace` leaves behind. Distinct from "nothing configured", which would send the user off to make a token they already have. |
 
 ### `internal/auth/keychain` (L1)
 
@@ -189,6 +190,7 @@ Which backend a credential lives in, and getting it in and out.
 | `SaveResult{Origin, KeychainErr}` | Where it landed, and why it fell back. A non-nil `KeychainErr` *is* the fallback signal. |
 | `SaveResult.WarnFallback(log.Logger)` | The one place the fallback warning is written. |
 | `SetUsername(isCI bool, name) (auth.Origin, error)` | Writes a display name into whichever backend already holds credentials, so it can't strand an empty-token record in the other one. |
+| `SetWorkspaceID(isCI bool, slug) (auth.Origin, error)` | Same, for the workspace: completes a `auth login --no-workspace` (and re-pins an existing login) without a second browser round-trip, leaving the token and refresh machinery untouched. |
 | `ErrNotFound` | Backend-agnostic "nothing stored". Wraps the keychain sentinel (`ErrNotFound` or `ErrUnavailable`) rather than replacing it, so `errors.Is` still answers "is there no keyring on this host" and no caller needs to bypass the interface. |
 
 `store` takes `isCI bool`, never an env map. CI-ness affects only the *write* target;
@@ -226,6 +228,7 @@ The resolver. The only package a consumer needs.
 | `(*Resolver).Resolve(ctx, envs) (Credential, Origin, error)` | **The one resolve path.** Precedence, then refresh when store-managed. |
 | `Resolver.OnRefreshFailure` (`ServeStale` default, `FailFast`) | What to do when a store-managed credential cannot be refreshed. `ServeStale` hands back the stored token — a slightly stale token still authenticates far more often than it doesn't, and failing would take a build down over a transient error. `FailFast` reports it: the wizard and the Bazel helper both need to act on a dead refresh token rather than serve one the backend will reject. |
 | `(*Resolver).ResolveNoRefresh(envs) (Credential, Origin, error)` | Same precedence, no network, no writes. For `status`, which documents that it never refreshes. |
+| `(*Resolver).ResolveTokenOnly(ctx, envs) (Credential, Origin, error)` | Same precedence and refresh, but a stored record counts as usable on its token alone. **For `auth workspace` only** — it asks the API which workspaces the token can access, which is the one question that precedes having a workspace. The Credential it returns can carry an empty `WorkspaceID`, so nothing that talks to the cache may use it. |
 | `(*Resolver).ResolvePinned(ctx, envs, isCI) (Credential, Origin, error)` | Resolve, and materialise an ephemeral env- or JWT-sourced credential to disk so processes started by `activate` can find it without the env vars. Read-modify-write, and **not** exclusive — see `store.SaveWithFallback`. Returns the origin the credential *resolved* from, not where the copy landed. |
 | `(*Resolver).Bind(envs) *Bound` | Pins the environment for a long-lived process. |
 | `(*Bound).Get(ctx) auth.Credential` | Per-RPC credential. Structurally satisfies `kv.AuthSource` without `live` importing `kv`. |
@@ -321,6 +324,7 @@ cmd/common/interactive.runLogin
 │  └─ POST /oidc/token     JWT → PAT
 │  ⇒ auth.TokenSet                                                   L0
 ├─ pickWorkspace(ctx, envs, ts.AuthToken) → ts.WorkspaceID
+│  skipped by --workspace <slug> and by --no-workspace
 ├─ store.Select(isCI, loginStorage)                                  L2
 └─ oauth.SaveToWithFallback(target, ts, loginStorage == "")          L3
    └─ store.SaveExclusiveWithFallback(target, ts, allowFallback)     L2
@@ -329,6 +333,27 @@ cmd/common/interactive.runLogin
                   ⇒ SaveResult{Origin{File, OAuthLogin}, KeychainErr}
 ├─ res.WarnFallback(logger)
 └─ logger.Infof("Signed in. … %s", res.Origin.Label())
+```
+
+### `auth workspace` — the picker, split in two
+
+`auth login` needs a terminal to show the workspace picker. A session that has
+none — an agent driving the CLI over a remote host, a script — signs in with
+`--no-workspace` and selects afterwards. The stored record is deliberately not
+`Populated()` in between, so no build silently runs against a half-configured
+credential; `Resolve` reports `ErrWorkspaceNotSelected` instead.
+
+```
+cmd/auth.newAuthWorkspaceCmd
+├─ --list
+│  ├─ live.Resolver.ResolveTokenOnly(ctx, envs)                      L4
+│  │  usable(ts) := ts.AuthToken != ""    ← the only relaxed resolve
+│  └─ bitriseapi.ListWorkspaces(ctx, baseURL, cred.Token)
+├─ --set <slug>
+│  ├─ warnUnknownWorkspace  best-effort, network failure is not fatal
+│  └─ store.SetWorkspaceID(isCI, slug)                               L2
+│     read-modify-write on the backend already holding the login
+└─ (no flag) live.Resolver.ResolveNoRefresh(envs) → WorkspaceID
 ```
 
 ### `auth logout`

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -356,6 +356,9 @@ cmd/auth.newAuthWorkspaceCmd
 └─ (no flag) live.Resolver.ResolveNoRefresh(envs) → WorkspaceID
 ```
 
+`doctor --fix --interactive` reaches the same selection through
+`interactive.PickWorkspacePrompt`, which shows the picker `auth login` would have.
+
 ### `auth logout`
 
 ```
@@ -418,6 +421,11 @@ path with default precedence, which is what stops them disagreeing about which
 credential is current. The doctor's `auth` check is the one deliberate exception —
 it is `PreferStored`, because it reports what is on the machine rather than what a
 build would send.
+
+A workspace-less login fails the doctor's `auth` check with `StateError` — the
+credential cannot authenticate a build, so it is not a warning — and carries
+`WorkspacePickFixer` rather than the credential prompt: the fix is choosing a
+workspace, not signing in again.
 
 ## Adding to this
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -317,8 +317,9 @@ must never construct a fresh `multiplatformconfig.Config` and `Save` it.
 ```
 cmd/common/interactive.runLogin
 ├─ cfg := oauth.NewConfigFromEnv(envs)                               L3
-├─ cfg.Login(ctx, oauth.OpenBrowser)
+├─ cfg.Login(ctx, openBrowser)      nil under --print-url
 │  ├─ PKCE + state
+│  ├─ cfg.OnAuthorizeURL(authURL, redirectURI)      --print-url writes to stdout
 │  ├─ callback server  ⟂  cfg.CallbackFallback      paste-the-URL
 │  ├─ POST /oauth2/token   code → JWT
 │  └─ POST /oidc/token     JWT → PAT
@@ -333,6 +334,18 @@ cmd/common/interactive.runLogin
                   ⇒ SaveResult{Origin{File, OAuthLogin}, KeychainErr}
 ├─ res.WarnFallback(logger)
 └─ logger.Infof("Signed in. … %s", res.Origin.Label())
+```
+
+With no terminal there is nothing to paste into, so the callback is delivered by a
+second command instead of a prompt:
+
+```
+bitrise-build-cache auth login --print-url --no-workspace   waits, prints authURL
+bitrise-build-cache auth login --callback '<address>'       another shell
+└─ relayCallback → GET <address>
+   the address is the loopback callback the waiting login bound, so it needs no
+   shared state to find it; only loopback hosts are accepted, or this would be a
+   way to make the CLI request an arbitrary address
 ```
 
 ### `auth workspace` — the picker, split in two

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -18,6 +18,9 @@ const (
 var (
 	ErrTokenNotProvided       = errors.New(EnvAuthToken + " or " + EnvJWT + " environment variable not set")
 	ErrWorkspaceIDNotProvided = errors.New(EnvWorkspaceID + " environment variable not set")
+	// ErrWorkspaceNotSelected reports the one state `auth login --no-workspace`
+	// leaves behind: a usable token with no workspace picked yet.
+	ErrWorkspaceNotSelected = errors.New("signed in, but no workspace is selected yet — run `bitrise-build-cache auth workspace --list` to see them, then `auth workspace --set <slug>`")
 )
 
 type jwtPermissionClaims struct {

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -18,9 +18,7 @@ const (
 var (
 	ErrTokenNotProvided       = errors.New(EnvAuthToken + " or " + EnvJWT + " environment variable not set")
 	ErrWorkspaceIDNotProvided = errors.New(EnvWorkspaceID + " environment variable not set")
-	// ErrWorkspaceNotSelected reports the one state `auth login --no-workspace`
-	// leaves behind: a usable token with no workspace picked yet.
-	ErrWorkspaceNotSelected = errors.New("signed in, but no workspace is selected yet — run `bitrise-build-cache auth workspace --list` to see them, then `auth workspace --set <slug>`")
+	ErrWorkspaceNotSelected   = errors.New("signed in, but no workspace is selected yet — run `bitrise-build-cache auth workspace --list` to see them, then `auth workspace --set <slug>`")
 )
 
 type jwtPermissionClaims struct {

--- a/internal/auth/live/resolve.go
+++ b/internal/auth/live/resolve.go
@@ -96,10 +96,8 @@ func (r *Resolver) ResolveNoRefresh(envs map[string]string) (auth.Credential, au
 }
 
 // ResolveTokenOnly is Resolve for the one caller that needs a token before a
-// workspace exists: the `auth workspace` picker, which asks the API which
-// workspaces the token can access. The returned Credential may carry an empty
-// WorkspaceID, so nothing that talks to the cache may use this — it would send a
-// half-formed credential that `Resolve` deliberately refuses to hand out.
+// workspace exists: the `auth workspace` listing. The Credential it returns may
+// carry an empty WorkspaceID, so nothing that talks to the cache may use it.
 func (r *Resolver) ResolveTokenOnly(ctx context.Context, envs map[string]string) (auth.Credential, auth.Origin, error) {
 	return r.resolveAndRefresh(ctx, envs, hasToken)
 }
@@ -137,8 +135,7 @@ func (r *Resolver) resolve(envs map[string]string) (auth.Credential, auth.Origin
 
 // resolveWith applies the precedence order and returns the backing store when the
 // credential came from one, so the caller can refresh in place. usable decides
-// which stored records count — everything but the workspace picker requires a
-// workspace.
+// which stored records count.
 func (r *Resolver) resolveWith(envs map[string]string, usable func(auth.TokenSet) bool) (auth.Credential, auth.Origin, store.Store, error) {
 	if r.Prefer == PreferStored {
 		if cred, origin, backing, ok := r.fromStores(usable); ok {

--- a/internal/auth/live/resolve.go
+++ b/internal/auth/live/resolve.go
@@ -64,7 +64,11 @@ type Resolver struct {
 // served as-is, because a slightly stale token still authenticates far more often
 // than it doesn't, and failing here would take the whole build down.
 func (r *Resolver) Resolve(ctx context.Context, envs map[string]string) (auth.Credential, auth.Origin, error) {
-	cred, origin, backing, err := r.resolve(envs)
+	return r.resolveAndRefresh(ctx, envs, auth.TokenSet.Populated)
+}
+
+func (r *Resolver) resolveAndRefresh(ctx context.Context, envs map[string]string, usable func(auth.TokenSet) bool) (auth.Credential, auth.Origin, error) {
+	cred, origin, backing, err := r.resolveWith(envs, usable)
 	if err != nil || !origin.StoreManaged() {
 		return cred, origin, err
 	}
@@ -89,6 +93,15 @@ func (r *Resolver) ResolveNoRefresh(envs map[string]string) (auth.Credential, au
 	cred, origin, _, err := r.resolve(envs)
 
 	return cred, origin, err
+}
+
+// ResolveTokenOnly is Resolve for the one caller that needs a token before a
+// workspace exists: the `auth workspace` picker, which asks the API which
+// workspaces the token can access. The returned Credential may carry an empty
+// WorkspaceID, so nothing that talks to the cache may use this — it would send a
+// half-formed credential that `Resolve` deliberately refuses to hand out.
+func (r *Resolver) ResolveTokenOnly(ctx context.Context, envs map[string]string) (auth.Credential, auth.Origin, error) {
+	return r.resolveAndRefresh(ctx, envs, hasToken)
 }
 
 // For a long-lived process that resolves per RPC.
@@ -118,11 +131,17 @@ func (b *Bound) Get(ctx context.Context) auth.Credential {
 	return cred
 }
 
-// resolve applies the precedence order and returns the backing store when the
-// credential came from one, so the caller can refresh in place.
 func (r *Resolver) resolve(envs map[string]string) (auth.Credential, auth.Origin, store.Store, error) {
+	return r.resolveWith(envs, auth.TokenSet.Populated)
+}
+
+// resolveWith applies the precedence order and returns the backing store when the
+// credential came from one, so the caller can refresh in place. usable decides
+// which stored records count — everything but the workspace picker requires a
+// workspace.
+func (r *Resolver) resolveWith(envs map[string]string, usable func(auth.TokenSet) bool) (auth.Credential, auth.Origin, store.Store, error) {
 	if r.Prefer == PreferStored {
-		if cred, origin, backing, ok := r.fromStores(); ok {
+		if cred, origin, backing, ok := r.fromStores(usable); ok {
 			return cred, origin, backing, nil
 		}
 	}
@@ -134,7 +153,7 @@ func (r *Resolver) resolve(envs map[string]string) (auth.Credential, auth.Origin
 	}
 
 	if r.Prefer != PreferStored {
-		if cred, origin, backing, ok := r.fromStores(); ok {
+		if cred, origin, backing, ok := r.fromStores(usable); ok {
 			return cred, origin, backing, nil
 		}
 	}
@@ -143,16 +162,34 @@ func (r *Resolver) resolve(envs map[string]string) (auth.Credential, auth.Origin
 		return cred, origin, nil, nil
 	}
 
+	// A login that stopped before the workspace step is not "no credentials" —
+	// saying so would send the user off to create a token they already have.
+	if r.hasTokenWithoutWorkspace() {
+		return auth.Credential{}, auth.Origin{}, nil, auth.ErrWorkspaceNotSelected
+	}
+
 	// Nothing stored: report the env vars as missing, which is the actionable error.
 	cred, origin, err := fromEnv(envs)
 
 	return cred, origin, nil, err
 }
 
+func (r *Resolver) hasTokenWithoutWorkspace() bool {
+	for _, s := range r.backends() {
+		if ts, err := s.Load(); err == nil && ts.AuthToken != "" && ts.WorkspaceID == "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasToken(ts auth.TokenSet) bool { return ts.AuthToken != "" }
+
 // fromStores prefers an OAuth-managed record wherever it lives: a manual token in
 // an earlier backend would otherwise hide a login in a later one, so the login
-// would never be refreshed. Falls back to the first populated record.
-func (r *Resolver) fromStores() (auth.Credential, auth.Origin, store.Store, bool) {
+// would never be refreshed. Falls back to the first usable record.
+func (r *Resolver) fromStores(usable func(auth.TokenSet) bool) (auth.Credential, auth.Origin, store.Store, bool) {
 	var (
 		firstTS    auth.TokenSet
 		firstStore store.Store
@@ -160,7 +197,7 @@ func (r *Resolver) fromStores() (auth.Credential, auth.Origin, store.Store, bool
 
 	for _, s := range r.backends() {
 		ts, err := s.Load()
-		if err != nil || !ts.Populated() {
+		if err != nil || !usable(ts) {
 			continue
 		}
 		if ts.IsOAuthManaged() {

--- a/internal/auth/live/resolve_workspace_test.go
+++ b/internal/auth/live/resolve_workspace_test.go
@@ -1,0 +1,78 @@
+//go:build unit
+
+package live
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/store"
+)
+
+func noAnalytics() func() (auth.Credential, auth.Origin, bool) {
+	return func() (auth.Credential, auth.Origin, bool) { return auth.Credential{}, auth.Origin{}, false }
+}
+
+// A workspace-less login is the state `auth login --no-workspace` leaves behind.
+func workspacelessLogin() *fakeStore {
+	return &fakeStore{
+		backend: auth.BackendKeychain,
+		present: true,
+		ts:      auth.TokenSet{AuthToken: "pat", RefreshToken: "refresh"},
+	}
+}
+
+func TestResolveReportsWorkspaceNotSelected(t *testing.T) {
+	r := &Resolver{
+		Backends:       []store.Store{workspacelessLogin()},
+		AnalyticsBlock: noAnalytics(),
+	}
+
+	_, _, err := r.Resolve(context.Background(), map[string]string{})
+	require.ErrorIs(t, err, auth.ErrWorkspaceNotSelected)
+}
+
+func TestResolveTokenOnlyServesTheWorkspacelessLogin(t *testing.T) {
+	r := &Resolver{
+		Backends:       []store.Store{workspacelessLogin()},
+		AnalyticsBlock: noAnalytics(),
+		Refresh: func(_ context.Context, ts auth.TokenSet, _ store.Store) (auth.TokenSet, error) {
+			return ts, nil
+		},
+	}
+
+	cred, origin, err := r.ResolveTokenOnly(context.Background(), map[string]string{})
+	require.NoError(t, err)
+	assert.Equal(t, "pat", cred.Token)
+	assert.Empty(t, cred.WorkspaceID)
+	assert.Equal(t, auth.BackendKeychain, origin.Backend)
+}
+
+// Env vars still win, so a workspace-less login can't hijack a scripted run.
+func TestResolveTokenOnlyKeepsEnvPrecedence(t *testing.T) {
+	r := &Resolver{
+		Backends:       []store.Store{workspacelessLogin()},
+		AnalyticsBlock: noAnalytics(),
+	}
+
+	cred, origin, err := r.ResolveTokenOnly(context.Background(), envVars())
+	require.NoError(t, err)
+	assert.Equal(t, envToken, cred.Token)
+	assert.Equal(t, envWS, cred.WorkspaceID)
+	assert.Equal(t, auth.BackendEnv, origin.Backend)
+}
+
+// Nothing stored at all is still the "set the env vars" error, not the picker one.
+func TestResolveWithNothingStoredReportsMissingEnv(t *testing.T) {
+	r := &Resolver{
+		Backends:       []store.Store{&fakeStore{backend: auth.BackendKeychain}},
+		AnalyticsBlock: noAnalytics(),
+	}
+
+	_, _, err := r.Resolve(context.Background(), map[string]string{})
+	require.ErrorIs(t, err, auth.ErrTokenNotProvided)
+}

--- a/internal/auth/oauth/callback.go
+++ b/internal/auth/oauth/callback.go
@@ -25,7 +25,19 @@ type callbackServer struct {
 type callbackResult struct {
 	code string
 	err  error
+	via  string
 }
+
+// RelayHeader marks a callback delivered by `auth login --callback` rather than
+// by a browser that reached the listener itself. Both arrive the same way, and
+// the sign-in has to be able to say which one completed it.
+const RelayHeader = "X-Bitrise-Build-Cache-Callback-Relay"
+
+const (
+	viaListener = "the browser reaching this machine"
+	viaRelay    = "`auth login --callback`"
+	viaPaste    = "the URL pasted here"
+)
 
 // newCallbackServer binds the loopback listener; caller calls start() then close().
 func newCallbackServer(ctx context.Context, state string) (*callbackServer, error) {
@@ -66,12 +78,12 @@ func (cs *callbackServer) start() {
 
 // wait blocks until the callback fires (delivering a code or error) or ctx is
 // cancelled / times out.
-func (cs *callbackServer) wait(ctx context.Context) (string, error) {
+func (cs *callbackServer) wait(ctx context.Context) (string, string, error) {
 	select {
 	case <-ctx.Done():
-		return "", fmt.Errorf("timed out waiting for the browser sign-in to complete: %w", ctx.Err())
+		return "", "", fmt.Errorf("timed out waiting for the browser sign-in to complete: %w", ctx.Err())
 	case res := <-cs.results:
-		return res.code, res.err
+		return res.code, res.via, res.err
 	}
 }
 
@@ -82,7 +94,12 @@ func (cs *callbackServer) close() {
 }
 
 func (cs *callbackServer) handle(w http.ResponseWriter, r *http.Request) {
-	cs.deliver(w, parseCallbackParams(r.URL.Query(), cs.state))
+	res := parseCallbackParams(r.URL.Query(), cs.state)
+	res.via = viaListener
+	if r.Header.Get(RelayHeader) != "" {
+		res.via = viaRelay
+	}
+	cs.deliver(w, res)
 }
 
 // parseCallbackParams validates the callback query params, shared by the

--- a/internal/auth/oauth/callback_fallback.go
+++ b/internal/auth/oauth/callback_fallback.go
@@ -22,8 +22,10 @@ type CallbackFallback func(ctx context.Context, state string) (string, error)
 const fallbackExitGrace = 3 * time.Second
 
 // awaitCallback takes the authorization code from whichever of the loopback
-// listener and the fallback produces one first.
-func (c Config) awaitCallback(ctx context.Context, cs *callbackServer) (string, error) {
+// listener and the fallback produces one first, and reports which that was — with
+// the process backgrounded, that is the only way a caller can tell whether the
+// browser reached the listener or the code had to be relayed in.
+func (c Config) awaitCallback(ctx context.Context, cs *callbackServer) (string, string, error) {
 	if c.CallbackFallback == nil {
 		return cs.wait(ctx)
 	}
@@ -35,7 +37,7 @@ func (c Config) awaitCallback(ctx context.Context, cs *callbackServer) (string, 
 	go func() {
 		defer close(done)
 		code, err := c.CallbackFallback(fallbackCtx, cs.state)
-		fallback <- callbackResult{code: code, err: err}
+		fallback <- callbackResult{code: code, err: err, via: viaPaste}
 	}()
 
 	// Returning before the fallback has released its input source would leave it
@@ -51,10 +53,10 @@ func (c Config) awaitCallback(ctx context.Context, cs *callbackServer) (string, 
 
 	select {
 	case <-ctx.Done():
-		return "", fmt.Errorf("timed out waiting for the browser sign-in to complete: %w", ctx.Err())
+		return "", "", fmt.Errorf("timed out waiting for the browser sign-in to complete: %w", ctx.Err())
 	case res := <-cs.results:
-		return res.code, res.err
+		return res.code, res.via, res.err
 	case res := <-fallback:
-		return res.code, res.err
+		return res.code, res.via, res.err
 	}
 }

--- a/internal/auth/oauth/callback_test.go
+++ b/internal/auth/oauth/callback_test.go
@@ -27,12 +27,15 @@ func TestCallbackServer_HappyPath(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	code, err := cs.wait(ctx)
+	code, via, err := cs.wait(ctx)
 	if err != nil {
 		t.Fatalf("wait: %v", err)
 	}
 	if code != "abc" {
 		t.Fatalf("code = %q, want abc", code)
+	}
+	if via != viaListener {
+		t.Fatalf("via = %q, want the listener", via)
 	}
 }
 
@@ -53,7 +56,7 @@ func TestCallbackServer_StateMismatch(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if _, err := cs.wait(ctx); err == nil || !strings.Contains(err.Error(), "state mismatch") {
+	if _, _, err := cs.wait(ctx); err == nil || !strings.Contains(err.Error(), "state mismatch") {
 		t.Fatalf("expected state-mismatch error, got %v", err)
 	}
 }
@@ -68,7 +71,7 @@ func TestCallbackServer_Timeout(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	if _, err := cs.wait(ctx); err == nil {
+	if _, _, err := cs.wait(ctx); err == nil {
 		t.Fatal("expected timeout error when no callback arrives")
 	}
 }

--- a/internal/auth/oauth/flow.go
+++ b/internal/auth/oauth/flow.go
@@ -53,8 +53,15 @@ func (c Config) Login(ctx context.Context, openBrowser func(string) error) (auth
 	cs.start()
 
 	authURL := c.authorizeURL(challenge, state, cs.redirectURI())
-	c.infof("Opening your browser to sign in to Bitrise.")
-	c.infof("If it doesn't open automatically, visit:\n\n  %s\n", authURL)
+	if c.OnAuthorizeURL != nil {
+		c.OnAuthorizeURL(authURL, cs.redirectURI())
+	}
+	if openBrowser == nil {
+		c.infof("Open this URL in a browser to sign in to Bitrise:\n\n  %s\n", authURL)
+	} else {
+		c.infof("Opening your browser to sign in to Bitrise.")
+		c.infof("If it doesn't open automatically, visit:\n\n  %s\n", authURL)
+	}
 	if c.CallbackFallback != nil {
 		c.infof("If the browser can't reach %s after signing in (a connection error —", cs.redirectURI())
 		c.infof("expected on a remote/RDE machine, where localhost is not the CLI's host),")

--- a/internal/auth/oauth/flow.go
+++ b/internal/auth/oauth/flow.go
@@ -76,10 +76,11 @@ func (c Config) Login(ctx context.Context, openBrowser func(string) error) (auth
 	c.debugf("Waiting for the browser sign-in to complete")
 	waitCtx, cancel := context.WithTimeout(ctx, loginTimeout)
 	defer cancel()
-	code, err := c.awaitCallback(waitCtx, cs)
+	code, via, err := c.awaitCallback(waitCtx, cs)
 	if err != nil {
 		return auth.TokenSet{}, err
 	}
+	c.infof("Sign-in completed via %s.", via)
 
 	c.debugf("Exchanging authorization code for a token")
 	now := time.Now() // before the exchange, so the JWT expiry isn't pushed out by the round-trip

--- a/internal/auth/oauth/oauth.go
+++ b/internal/auth/oauth/oauth.go
@@ -44,6 +44,10 @@ type Config struct {
 	// reach the CLI's loopback listener (remote/RDE sessions). Nil disables the
 	// fallback (the default; non-interactive callers).
 	CallbackFallback CallbackFallback
+	// OnAuthorizeURL receives the authorize URL and the loopback redirect it comes
+	// back to, before the flow starts waiting — for callers handing them to
+	// something other than a browser on this machine.
+	OnAuthorizeURL func(authorizeURL, redirectURI string)
 }
 
 func (c Config) debugf(format string, args ...any) { //nolint:unparam // variadic for symmetry with infof/warnf and future callers

--- a/internal/auth/store/persist.go
+++ b/internal/auth/store/persist.go
@@ -22,8 +22,7 @@ func SetUsername(isCI bool, name string) (auth.Origin, error) {
 
 // SetWorkspaceID writes slug into the store that already holds credentials,
 // leaving the token and the OAuth refresh machinery intact so completing a
-// `auth login --no-workspace` costs no second browser round-trip. Returns the
-// store written to.
+// `auth login --no-workspace` costs no second browser round-trip.
 func SetWorkspaceID(isCI bool, slug string) (auth.Origin, error) {
 	target, existing := storeHoldingCreds(isCI)
 	if strings.TrimSpace(existing.AuthToken) == "" {

--- a/internal/auth/store/persist.go
+++ b/internal/auth/store/persist.go
@@ -21,9 +21,9 @@ func SetUsername(isCI bool, name string) (auth.Origin, error) {
 }
 
 // SetWorkspaceID writes slug into the store that already holds credentials,
-// leaving the token and the OAuth refresh machinery untouched — it completes a
-// `auth login --no-workspace`, and re-pins an existing one, without a second
-// browser round-trip. Returns the store written to.
+// leaving the token and the OAuth refresh machinery intact so completing a
+// `auth login --no-workspace` costs no second browser round-trip. Returns the
+// store written to.
 func SetWorkspaceID(isCI bool, slug string) (auth.Origin, error) {
 	target, existing := storeHoldingCreds(isCI)
 	if strings.TrimSpace(existing.AuthToken) == "" {

--- a/internal/auth/store/persist.go
+++ b/internal/auth/store/persist.go
@@ -20,6 +20,23 @@ func SetUsername(isCI bool, name string) (auth.Origin, error) {
 	return existing.Origin(target.Backend()), nil
 }
 
+// SetWorkspaceID writes slug into the store that already holds credentials,
+// leaving the token and the OAuth refresh machinery untouched — it completes a
+// `auth login --no-workspace`, and re-pins an existing one, without a second
+// browser round-trip. Returns the store written to.
+func SetWorkspaceID(isCI bool, slug string) (auth.Origin, error) {
+	target, existing := storeHoldingCreds(isCI)
+	if strings.TrimSpace(existing.AuthToken) == "" {
+		return auth.Origin{}, fmt.Errorf("no stored credentials to attach the workspace to")
+	}
+	existing.WorkspaceID = strings.TrimSpace(slug)
+	if err := target.Save(existing); err != nil {
+		return existing.Origin(target.Backend()), fmt.Errorf("save workspace to %s: %w", target.Backend().String(), err)
+	}
+
+	return existing.Origin(target.Backend()), nil
+}
+
 // StoredUsername returns the display name from whichever backend holds one. The
 // name is machine-level config set by `auth username`, independent of which
 // backend the credential currently lives in, so a sign-in has to carry it across

--- a/internal/auth/store/store_test.go
+++ b/internal/auth/store/store_test.go
@@ -140,3 +140,33 @@ func TestStoredUsername_FoundInEitherBackend(t *testing.T) {
 	require.NoError(t, NewKeychain().Save(auth.TokenSet{AuthToken: "t", WorkspaceID: "w", Username: "from-keychain"}))
 	assert.Equal(t, "from-keychain", StoredUsername(), "the keychain is consulted first")
 }
+
+func TestSetWorkspaceID_completesAWorkspacelessLogin(t *testing.T) {
+	keyring.MockInit()
+	t.Setenv("HOME", t.TempDir())
+
+	require.NoError(t, NewFile().Save(auth.TokenSet{AuthToken: "pat", RefreshToken: "refresh", Username: "erin"}))
+
+	origin, err := SetWorkspaceID(false, "  ws-slug  ")
+	require.NoError(t, err)
+	assert.Equal(t, auth.BackendFile, origin.Backend)
+	assert.Equal(t, auth.ProvenanceOAuthLogin, origin.Provenance)
+
+	got, err := NewFile().Load()
+	require.NoError(t, err)
+	assert.Equal(t, "ws-slug", got.WorkspaceID)
+	assert.Equal(t, "refresh", got.RefreshToken, "the login must stay refreshable after picking a workspace")
+	assert.Equal(t, "pat", got.AuthToken)
+	assert.Equal(t, "erin", got.Username)
+
+	_, kcErr := NewKeychain().Load()
+	require.ErrorIs(t, kcErr, ErrNotFound, "workspace write must not create a stray keychain entry")
+}
+
+func TestSetWorkspaceID_withNothingStoredErrors(t *testing.T) {
+	keyring.MockInit()
+	t.Setenv("HOME", t.TempDir())
+
+	_, err := SetWorkspaceID(false, "ws-slug")
+	require.Error(t, err)
+}

--- a/internal/doctor/check_auth.go
+++ b/internal/doctor/check_auth.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"context"
+	"errors"
 
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v3/internal/auth/live"
@@ -14,6 +15,16 @@ func (d *Doctor) authCheck() Check {
 			// Read-only: report the credential that is on the machine, not the one a
 			// refresh would produce.
 			cred, origin, err := d.storedFirstResolver().ResolveNoRefresh(d.Envs)
+			// A workspace-less login is still unusable auth, so it fails the check —
+			// but the fix is picking one, not signing in again.
+			if errors.Is(err, auth.ErrWorkspaceNotSelected) {
+				return Result{
+					State:   StateError,
+					Detail:  "signed in, but no workspace is selected",
+					Fixable: true,
+					Fixer:   WorkspacePickFixer{Prompt: d.WorkspacePickPrompt},
+				}
+			}
 			if err != nil || !origin.Resolved() {
 				return Result{
 					State:   StateError,

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -97,8 +97,11 @@ type Doctor struct {
 	// the token prompt; the doctor command supplies one that offers a browser
 	// sign-in first.
 	AuthFixPrompt func() (workspaceID, authToken string, err error)
-	Now           func() time.Time
-	Debug         bool
+	// WorkspacePickPrompt selects a workspace for a login that has none. Nil
+	// leaves the fixer to point at the `auth workspace` commands instead.
+	WorkspacePickPrompt func() (workspaceID string, err error)
+	Now                 func() time.Time
+	Debug               bool
 
 	// checksOverride replaces the real check set in tests.
 	checksOverride []Check

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -183,6 +183,17 @@ func TestAuthCheck_fixerIsAuthPromptFixer(t *testing.T) {
 	require.IsType(t, AuthPromptFixer{}, res.Fixer)
 }
 
+func TestAuthCheck_workspacelessLoginFailsWithThePickerFixer(t *testing.T) {
+	r := newMinimalDoctor(t)
+	r.AuthBackends = []store.Store{fakeAuthStore{creds: authpkg.TokenSet{AuthToken: "pat", RefreshToken: "refresh"}}}
+
+	res := r.authCheck().Diagnose(context.Background())
+	assert.Equal(t, StateError, res.State)
+	assert.Contains(t, res.Detail, "no workspace")
+	assert.True(t, res.Fixable)
+	require.IsType(t, WorkspacePickFixer{}, res.Fixer)
+}
+
 // ──────────────────────────── keychain smoke ────────────────────────────
 
 func TestKeychainSmokeCheck_happy(t *testing.T) {

--- a/internal/doctor/fix_workspace_pick.go
+++ b/internal/doctor/fix_workspace_pick.go
@@ -1,0 +1,27 @@
+package doctor
+
+import (
+	"errors"
+	"fmt"
+)
+
+// WorkspacePickFixer completes a sign-in that stopped before the workspace step.
+type WorkspacePickFixer struct {
+	Prompt func() (workspaceID string, err error)
+}
+
+// NeedsTerminal marks this fixer as one that must ask the user something.
+func (f WorkspacePickFixer) NeedsTerminal() bool { return true }
+
+func (f WorkspacePickFixer) Fix() (string, error) {
+	if f.Prompt == nil {
+		return "", errors.New("no workspace picker available: run `bitrise-build-cache auth workspace --list`, then `auth workspace --set <slug>`")
+	}
+
+	workspaceID, err := f.Prompt()
+	if err != nil {
+		return "", fmt.Errorf("workspace picker: %w", err)
+	}
+
+	return "selected workspace " + workspaceID, nil
+}

--- a/internal/doctor/fix_workspace_pick.go
+++ b/internal/doctor/fix_workspace_pick.go
@@ -10,7 +10,6 @@ type WorkspacePickFixer struct {
 	Prompt func() (workspaceID string, err error)
 }
 
-// NeedsTerminal marks this fixer as one that must ask the user something.
 func (f WorkspacePickFixer) NeedsTerminal() bool { return true }
 
 func (f WorkspacePickFixer) Fix() (string, error) {


### PR DESCRIPTION
[ACI-5274](https://bitrise.atlassian.net/browse/ACI-5274)

## TLDR

- The OAuth sign-in needed a terminal twice (paste the callback, pick a workspace); it is now drivable with none.
- `auth login --print-url` prints the sign-in URL to stdout — and only that — then waits, launching no browser.
- `auth login --callback <url>` delivers the address the browser landed on to that waiting process.
- `auth login --no-workspace` skips the picker; `auth workspace --list` / `--set <slug>` replaces it, with no second sign-in.
- The sign-in now says which path completed it: the browser reaching this machine, a relayed callback, or a pasted URL — and `--print-url` no longer also offers the terminal paste.
- A workspace-less login says so — `auth.ErrWorkspaceNotSelected`, warn-level after login — instead of reporting "no credentials".
- The doctor fails that state with an error and fixes it with the picker, not another sign-in.
- `auth status` names the real keyring instead of the `<system keychain>` placeholder.

## How the callback finds its way home

The pieces look like they need shared state — a port file, a daemon — and they don't. The address the browser fails to load *is* `http://127.0.0.1:<port>/callback?code=…&state=…`, the loopback listener the waiting `auth login` bound. `--callback` just requests it locally, so the URL is its own routing information. That is also why it accepts loopback hosts only, with a `/callback` path and a real code: without those guards the flag would be a way to make the CLI fetch any address a user is talked into pasting.

Because a relayed callback and a browser that reached the listener arrive identically, the relay sets an `X-Bitrise-Build-Cache-Callback-Relay` header and the sign-in reports which one completed it. That matters only when the process is backgrounded — which is exactly how an agent runs it, and where the caller otherwise cannot tell that its relay step was a no-op.

The other deliberate choice: a workspace-less login is **not** `Populated()`, so `Resolve` refuses it. It would be easier to let builds run with an empty workspace and fail at the backend; instead the state names itself and every surface points at `auth workspace --set`.

## Testing

- `make lint`, `make lint-arch`, `make test-unit` — clean.
- Both headless flows run end to end against a fake identity provider with stdin pinned to a non-TTY, including a browser that cannot reach the loopback, so `--print-url` → `--callback` → workspace select is exercised as one path, asserting stdout carries the URL alone and the relay is the reported source.
- Driven for real against production, twice. First on a laptop by an agent with no terminal: sign-in completed, 83 workspaces listed, one pinned — but its `--callback` step was silently a no-op, because a browser on the same host reaches the listener directly. That run produced the last four TLDR bullets.
- Then on a Linux RDE over SSH, which is the shape this PR exists for: `--print-url` printed one clean URL on stdout, the laptop browser genuinely could not reach the VM's `127.0.0.1:41523`, and `--callback` relayed the address in. The waiting process reported ``Sign-in completed via `auth login --callback` `` — the relay path proven end to end, not simulated. The VM has no secret-service, so it also exercised the keyring-unavailable fallback: the login landed in the config file as `OAuth login (config file)` with the warning, and `auth workspace --set` pinned into the same record.
- That RDE run found one more thing, fixed here: with a TTY attached, `--print-url` armed the paste fallback as well, printing two contradictory ways to finish the sign-in, one of which nothing was reading.


[ACI-5274]: https://bitrise.atlassian.net/browse/ACI-5274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ